### PR TITLE
test(publication): add bounded Poppler semantic sentinels

### DIFF
--- a/.github/issue-milestones.json
+++ b/.github/issue-milestones.json
@@ -9,6 +9,7 @@
     { "issue": 11, "milestone": "M0" },
     { "issue": 12, "milestone": "M1" },
     { "issue": 13, "milestone": "M0" },
-    { "issue": 14, "milestone": "M0" }
+    { "issue": 14, "milestone": "M0" },
+    { "issue": 17, "milestone": "M0" }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ the exact diff; this file records why the project changed.
 
 ### Added
 
+- A versioned PDF semantic sentinel now binds the current source, book, A4 and
+  tag metadata, Poppler tool identity, separate structure and text streams,
+  exact diagnostics, and six nonlinear content anchors. Atomic evidence keeps
+  both validated reports and failure envelopes. Recognized structure and
+  reading-order defects remain explicit `known-debt` failures; the sentinel
+  makes no PDF/UA or WCAG conformance claim.
 - A project-local publication-design skill now treats the continuous web book
   and generated PDF as one source-bound publication. It requires bounded
   page-class sampling, rendered PNG inspection, extracted reading-order checks,
@@ -121,8 +127,9 @@ the exact diff; this file records why the project changed.
   through Git's linked-worktree common directory. Its normal checkout and
   Git-free frozen-capsule verification paths retain their existing authority.
 - Browser verification now waits through a bounded termination grace and
-  forced-exit interval before deleting its temporary profile, removing a race
-  with a still-running Chromium process.
+  forced-exit interval, then retries temporary-profile removal through a
+  bounded filesystem backoff. This covers both a still-running Chromium
+  process and late child-process writes after the main process exits.
 
 ## [0.3.0] - 2026-08-30
 

--- a/docs/publication-workflow.md
+++ b/docs/publication-workflow.md
@@ -136,6 +136,20 @@ dependency tree. Their byte comparison therefore tests deterministic rendering
 conditional on one clean `npm ci` realization; it does not independently
 reinstall or byte-bind two realized `node_modules` trees.
 
+`node scripts/audit-book-pdf-semantics.mjs --evidence-dir
+.workingdir2/evidence/design/<new-directory-name>` captures plain `pdfinfo`,
+`pdfinfo -struct`, `pdfinfo -struct-text`, default text extraction and raw text
+extraction as separate bounded streams. Evidence is published atomically under
+that declared root; a semantic mismatch retains the streams with an explicit
+failure envelope. The checked baseline binds the current source digest, PDF,
+manifest, A4 page format, tag state, Poppler 26.08.0 identity, exact diagnostics
+and six content anchors. Its current expected outcome is `known-debt`, so a
+matching audit exits non-zero; it is a regression sentinel, not a PDF/UA or WCAG
+conformance check. DOM and accessibility-tree order are outside this Poppler
+snapshot and require the pinned-Chrome renderer-aware follow-up. Required CI
+enforcement waits for the separately locked PDF-tools container so an ambient
+host Poppler cannot silently redefine the baseline.
+
 Container publication has a separate two-phase boundary. The build pushes a
 candidate under its canonical digest without a release tag. The workflow then
 validates and executes that exact digest. Only a digest produced by a build

--- a/scripts/audit-book-pdf-semantics.mjs
+++ b/scripts/audit-book-pdf-semantics.mjs
@@ -1,0 +1,146 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { bookSourceDigest } from "./book-source.mjs";
+import {
+  auditBookPdfSemanticCaptures,
+  assertBookPdfSemanticArtifactIdentity,
+  BOOK_PDF_SEMANTIC_CLAIM_BOUNDARY,
+  captureBookPdfSemanticOutputs,
+  parseBookPdfSemanticBaseline,
+  summarizeBookPdfSemanticCapture,
+  writeBookPdfSemanticEvidence,
+} from "./lib/book-pdf-semantic-audit.mjs";
+import { readStableOpenedFile } from "./lib/opened-file.mjs";
+
+const scriptPath = fileURLToPath(import.meta.url);
+const repositoryRoot = path.resolve(path.dirname(scriptPath), "..");
+const baselinePath = path.join(repositoryRoot, "scripts", "book-pdf-semantic-baseline.json");
+const evidenceRoot = path.join(repositoryRoot, ".workingdir2", "evidence", "design");
+const maximumBaselineBytes = 1024 * 1024;
+const maximumManifestBytes = 1024 * 1024;
+const maximumPdfBytes = 256 * 1024 * 1024;
+
+function readRepositoryFile(file, label, maximumBytes) {
+  return readStableOpenedFile(file, {
+    containedBy: repositoryRoot,
+    label,
+    maximumBytes,
+  });
+}
+
+function semanticFailureEnvelope(error, observed) {
+  return Object.freeze({
+    claim_boundary: BOOK_PDF_SEMANTIC_CLAIM_BOUNDARY,
+    error: Object.freeze({ message: error.message }),
+    outputs: Object.freeze(Object.fromEntries(
+      Object.entries(observed.captures).map(([name, capture]) => [
+        name,
+        summarizeBookPdfSemanticCapture(capture),
+      ]),
+    )),
+    passed: false,
+    schema_version: 1,
+    status: "invalid",
+    tools: observed.toolIdentities,
+  });
+}
+
+function parseArguments(arguments_) {
+  let evidenceDirectory;
+  for (let index = 0; index < arguments_.length; index += 1) {
+    const argument = arguments_[index];
+    if (argument !== "--evidence-dir") throw new Error(`Unknown argument: ${argument}`);
+    const value = arguments_[index + 1];
+    if (!value || value.startsWith("--")) throw new Error("--evidence-dir requires a path");
+    if (evidenceDirectory) throw new Error("--evidence-dir may be provided only once");
+    evidenceDirectory = path.resolve(value);
+    if (path.dirname(evidenceDirectory) !== evidenceRoot) {
+      throw new Error(
+        `--evidence-dir must name a new direct child of ${path.relative(repositoryRoot, evidenceRoot)}`,
+      );
+    }
+    index += 1;
+  }
+  return Object.freeze({ evidenceDirectory });
+}
+
+async function main() {
+  const options = parseArguments(process.argv.slice(2));
+  const baselineBytes = await readRepositoryFile(
+    baselinePath,
+    "book PDF semantic baseline",
+    maximumBaselineBytes,
+  );
+  const baseline = parseBookPdfSemanticBaseline(baselineBytes);
+  const pdfPath = path.join(repositoryRoot, baseline.artifact.pdf);
+  const manifestPath = path.join(repositoryRoot, baseline.artifact.manifest);
+  const [pdfBytes, manifestBytes] = await Promise.all([
+    readRepositoryFile(pdfPath, "book PDF semantic artifact", maximumPdfBytes),
+    readRepositoryFile(manifestPath, "book PDF semantic manifest", maximumManifestBytes),
+  ]);
+  assertBookPdfSemanticArtifactIdentity({ baseline, manifestBytes, pdfBytes });
+  const source = await bookSourceDigest(repositoryRoot);
+  if (source.digest !== baseline.artifact.source_digest) {
+    throw new Error(
+      `book source digest changed: expected ${baseline.artifact.source_digest}, received ${source.digest}`,
+    );
+  }
+  const observed = captureBookPdfSemanticOutputs({
+    expectedToolVersions: {
+      pdfinfo: baseline.tools.pdfinfo.version,
+      pdftotext: baseline.tools.pdftotext.version,
+    },
+    pdfBytes,
+  });
+  let auditError;
+  let report;
+  try {
+    const [finalBaselineBytes, finalPdfBytes, finalManifestBytes] = await Promise.all([
+      readRepositoryFile(baselinePath, "book PDF semantic baseline", maximumBaselineBytes),
+      readRepositoryFile(pdfPath, "book PDF semantic artifact", maximumPdfBytes),
+      readRepositoryFile(manifestPath, "book PDF semantic manifest", maximumManifestBytes),
+    ]);
+    const finalSource = await bookSourceDigest(repositoryRoot);
+    if (
+      !finalBaselineBytes.equals(baselineBytes)
+      || !finalPdfBytes.equals(pdfBytes)
+      || !finalManifestBytes.equals(manifestBytes)
+      || finalSource.digest !== source.digest
+    ) {
+      throw new Error("semantic baseline, PDF, manifest, or book source changed during capture");
+    }
+    report = auditBookPdfSemanticCaptures({
+      baseline,
+      captures: observed.captures,
+      manifestBytes,
+      pdfBytes,
+      toolIdentities: observed.toolIdentities,
+    });
+  } catch (error) {
+    auditError = error;
+  }
+  if (options.evidenceDirectory) {
+    await writeBookPdfSemanticEvidence({
+      captures: observed.captures,
+      directory: options.evidenceDirectory,
+      evidenceRoot,
+      failure: auditError ? semanticFailureEnvelope(auditError, observed) : undefined,
+      report,
+    });
+  }
+  if (auditError) throw auditError;
+  console.log(`${JSON.stringify(report, null, 2)}\n`);
+  if (!report.passed) {
+    throw new Error(
+      `recognized ${report.expected_outcome} remains in ${report.sentinels.length} nonlinear sentinel classes`,
+    );
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === scriptPath) {
+  main().catch((error) => {
+    console.error(`Book PDF semantic audit failed: ${error.message}`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/book-pdf-semantic-baseline.json
+++ b/scripts/book-pdf-semantic-baseline.json
@@ -1,0 +1,280 @@
+{
+  "schema_version": 1,
+  "authority": "engineering-regression-sentinel",
+  "claim_boundary": "Engineering regression sentinel only; this audit does not establish PDF/UA or WCAG conformance.",
+  "expected_outcome": "known-debt",
+  "artifact": {
+    "pdf": "public/downloads/20-watts-was-enough-full-concept-book.pdf",
+    "manifest": "public/downloads/book-manifest.json",
+    "pdf_sha256": "aaab0416b8d648394aa5edd7cba25c629768de46cf8b1a4498aff628cd3bc745",
+    "manifest_sha256": "77f271275a76add72a370727d05cd3655b95a504036830e0018238178fca1dfc",
+    "size_bytes": 12817261,
+    "pages": 413,
+    "page_size_name": "A4",
+    "page_size_points": {
+      "width": 594.96,
+      "height": 841.92
+    },
+    "pdf_version": "1.4",
+    "tagged": true,
+    "source_ref": "main",
+    "source_digest": "24dfe4226c8b3503a78c4034ea4c38dcd8204b40e0a84b04728c551df07c2710",
+    "version": "0.3.0"
+  },
+  "tools": {
+    "pdfinfo": {
+      "command": "pdfinfo",
+      "version": "26.08.0"
+    },
+    "pdftotext": {
+      "command": "pdftotext",
+      "version": "26.08.0"
+    }
+  },
+  "outputs": {
+    "metadata": {
+      "exit_status": 0,
+      "stdout": {
+        "bytes": 627,
+        "sha256": "54e5324efbca72b730cf015b99e92f7b540c37da566ab3f54d3c7b9f7f2e0d54"
+      },
+      "stderr": {
+        "bytes": 0,
+        "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      }
+    },
+    "structure": {
+      "exit_status": 0,
+      "stdout": {
+        "bytes": 1057763,
+        "sha256": "536758274b750f38e6590d53b718bd75d8e0418b38c580b6dc6382b373faeb3c"
+      },
+      "stderr": {
+        "bytes": 34429,
+        "sha256": "201819c4b6f29ad9af0f8dc72e1bbb8db5aae7c9345a5c1f343f428648f4e254"
+      }
+    },
+    "structure_text": {
+      "exit_status": 0,
+      "stdout": {
+        "bytes": 2393142,
+        "sha256": "d3de126e6fb074b828ca71f99442d19144de10a8f33cb05a54546e4bd5ff0fa5"
+      },
+      "stderr": {
+        "bytes": 34429,
+        "sha256": "201819c4b6f29ad9af0f8dc72e1bbb8db5aae7c9345a5c1f343f428648f4e254"
+      }
+    },
+    "default_text": {
+      "exit_status": 0,
+      "stdout": {
+        "bytes": 1119498,
+        "sha256": "a946aece2b90e4ca8111a777e4028c7402529acd546c0ee73d488bfff9c3f68d"
+      },
+      "stderr": {
+        "bytes": 0,
+        "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      }
+    },
+    "raw_text": {
+      "exit_status": 0,
+      "stdout": {
+        "bytes": 1110034,
+        "sha256": "40080242633f88c7fd2989a9981126a8e022b0722d1551cbcb215e278d154cb0"
+      },
+      "stderr": {
+        "bytes": 0,
+        "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      }
+    }
+  },
+  "diagnostics": {
+    "structure": [
+      {
+        "message": "Syntax Error: StructElem object is wrong type (Em)",
+        "count": 14
+      },
+      {
+        "message": "Syntax Error: StructElem object is wrong type (Strong)",
+        "count": 613
+      }
+    ],
+    "structure_text": [
+      {
+        "message": "Syntax Error: StructElem object is wrong type (Em)",
+        "count": 14
+      },
+      {
+        "message": "Syntax Error: StructElem object is wrong type (Strong)",
+        "count": 613
+      }
+    ]
+  },
+  "sentinels": [
+    {
+      "id": "readiness-dashboard-late-values",
+      "class": "dashboard-status",
+      "recorded_page": 4,
+      "default_anchor": "Scientific claims are not runnable tests",
+      "default_fragments": [
+        "Scientific claims are not runnable tests",
+        "1,475",
+        "Protocol-covered claims",
+        "Experiment implementation lane",
+        "Evidence status by highest test tier"
+      ],
+      "struct_text_fragments": [
+        "Scientific claims are not runnable tests",
+        "Written protocols versus executable evidence",
+        "Protocol-covered claims",
+        "Experiment implementation lane",
+        "Evidence status by highest test tier"
+      ],
+      "raw_fragments": [
+        "Evidencestatusbyhighesttesttier",
+        "project's experiment.",
+        "49",
+        "COMPLETE WRITTEN",
+        "11",
+        "VALIDATED SMOKE HARNESS",
+        "0",
+        "WORKSTATION-READY"
+      ],
+      "state": "known-debt",
+      "defect": "The three implementation-lane values paint after the readiness matrix instead of remaining with their labels."
+    },
+    {
+      "id": "candidate-frontier-equation-late",
+      "class": "table-displayed-equation",
+      "recorded_page": 22,
+      "default_anchor": "For a biological candidate",
+      "default_fragments": [
+        "For a biological candidate",
+        "the engineering experiment compares at least three systems",
+        "where Q is task quality",
+        "The decision geometry below is illustrative"
+      ],
+      "struct_text_fragments": [
+        "For a biological candidate",
+        "thecandidate is interesting only if",
+        "where ",
+        "The decision geometry below is illustrative"
+      ],
+      "raw_fragments": [
+        "For a biological candidate",
+        "where is task quality",
+        "The decision geometry below is illustrative",
+        "(Q,R,E,L)"
+      ],
+      "state": "known-debt",
+      "defect": "The displayed frontier equation moves behind its explanation in content-stream extraction and is absent from tagged structure text."
+    },
+    {
+      "id": "biomimetic-figure-caption-late",
+      "class": "diagram-figure",
+      "recorded_page": 27,
+      "default_anchor": "The public descriptions of biomimicry are useful for discovering biological strategies",
+      "default_fragments": [
+        "The public descriptions of biomimicry are useful for discovering biological strategies",
+        "Five solution families"
+      ],
+      "struct_text_fragments": [
+        "Biomimetic transfer is a search method, not an evidence grade",
+        "Wide diagram · scroll horizontally on narrow screens",
+        "Process diagram for Biomimetic transfer",
+        "The public descriptions of biomimicry are useful for discovering biological strategies",
+        "Five solution families"
+      ],
+      "raw_fragments": [
+        "The public descriptions of biomimicry are useful for discovering biological strategies",
+        "Five solution families",
+        "Wide diagram · scroll horizontally on narrow screens",
+        "FIGURE 6"
+      ],
+      "state": "known-debt",
+      "defect": "The printed layout cue and Figure 6 caption paint after the following prose."
+    },
+    {
+      "id": "lifecycle-equation-late",
+      "class": "table-displayed-equation",
+      "recorded_page": 36,
+      "default_anchor": "expected recovery are joules over the same observation",
+      "default_fragments": [
+        "expected recovery are joules over the same observation",
+        "A positive",
+        "Evidence status",
+        "Speculative extensions",
+        "Failure modes"
+      ],
+      "struct_text_fragments": [
+        "lifecycle acceptance uses the energy contract",
+        "where ",
+        "A positive ",
+        "Evidence status",
+        "Speculative extensions",
+        "Failure modes"
+      ],
+      "raw_fragments": [
+        "where is a dimensionless count",
+        "Evidence status",
+        "Failure modes",
+        "Positive-result bias",
+        "ΔE"
+      ],
+      "state": "known-debt",
+      "defect": "The lifecycle equation moves to the end of the page in content-stream extraction and is absent from tagged structure text."
+    },
+    {
+      "id": "adiabatic-equation-fragmented",
+      "class": "diagram-figure",
+      "recorded_page": 378,
+      "default_anchor": "Four normalized adiabatic energy curves form different U-shaped crossovers",
+      "default_fragments": [
+        "Four normalized adiabatic energy curves form different U-shaped crossovers",
+        "The normalized diagnostic model is",
+        "Slowing a transition",
+        "device-boundary model."
+      ],
+      "struct_text_fragments": [
+        "Finite-time adiabatic crossover",
+        "Four normalized adiabatic energy curves",
+        "The normalized diagnostic model is",
+        "Slowing a transition",
+        "Sparse/locality break-even plane"
+      ],
+      "raw_fragments": [
+        "The normalized diagnostic model is",
+        "Slowing a transition",
+        "device-boundary model.",
+        "CV 2"
+      ],
+      "state": "known-debt",
+      "defect": "The adiabatic equation fragments after its explanatory paragraph and is absent from tagged structure text."
+    },
+    {
+      "id": "field-coverage-heading-merged",
+      "class": "diagram-figure",
+      "recorded_page": 387,
+      "default_anchor": "This is the repository's breadth control",
+      "default_fragments": [
+        "This is the repository's breadth control",
+        "How global is the research search?",
+        "FIGURE 80"
+      ],
+      "struct_text_fragments": [
+        "Global field coverage",
+        "This is the repository's breadth control",
+        "Multi-resolution EU, OECD, DFG, and ANZSRC research-field coverage",
+        "Editable data:"
+      ],
+      "raw_fragments": [
+        "APPENDIX A1",
+        "Globalfieldcoverage",
+        "Census date: 2026-08-27",
+        "FIGURE 80"
+      ],
+      "state": "known-debt",
+      "defect": "Content-stream extraction merges the appendix heading into Globalfieldcoverage."
+    }
+  ]
+}

--- a/scripts/lib/book-pdf-semantic-audit.mjs
+++ b/scripts/lib/book-pdf-semantic-audit.mjs
@@ -1,0 +1,787 @@
+import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  realpath,
+  rename,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { assertBookPdfBytesIntegrity } from "./book-pdf-integrity.mjs";
+import { parseStrictJson } from "./strict-json.mjs";
+
+export const BOOK_PDF_SEMANTIC_BASELINE_SCHEMA_VERSION = 1;
+export const BOOK_PDF_SEMANTIC_CLAIM_BOUNDARY =
+  "Engineering regression sentinel only; this audit does not establish PDF/UA or WCAG conformance.";
+
+const SHA256_PATTERN = /^[0-9a-f]{64}$/u;
+const SEMANTIC_AUTHORITY = "engineering-regression-sentinel";
+const OUTCOMES = new Set(["clean", "known-debt"]);
+const SENTINEL_CLASSES = new Set([
+  "dashboard-status",
+  "diagram-figure",
+  "table-displayed-equation",
+]);
+const CAPTURE_NAMES = Object.freeze([
+  "metadata",
+  "structure",
+  "structure_text",
+  "default_text",
+  "raw_text",
+]);
+const MAXIMUM_CAPTURE_BYTES = 16 * 1024 * 1024;
+const MAXIMUM_PDF_BYTES = 256 * 1024 * 1024;
+const CAPTURE_TIMEOUT_MS = 120_000;
+const EMPTY_SHA256 = createHash("sha256").digest("hex");
+
+const EVIDENCE_FILE_NAMES = Object.freeze({
+  metadata: Object.freeze({
+    stdout: "pdfinfo.stdout.txt",
+    stderr: "pdfinfo.stderr.txt",
+  }),
+  structure: Object.freeze({
+    stdout: "pdfinfo-struct.stdout.txt",
+    stderr: "pdfinfo-struct.stderr.txt",
+  }),
+  structure_text: Object.freeze({
+    stdout: "pdfinfo-struct-text.stdout.txt",
+    stderr: "pdfinfo-struct-text.stderr.txt",
+  }),
+  default_text: Object.freeze({
+    stdout: "pdftotext-default.stdout.txt",
+    stderr: "pdftotext-default.stderr.txt",
+  }),
+  raw_text: Object.freeze({
+    stdout: "pdftotext-raw.stdout.txt",
+    stderr: "pdftotext-raw.stderr.txt",
+  }),
+});
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function assertClosedObject(value, expectedFields, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    fail(`${label} must be an object`);
+  }
+  const actual = Object.keys(value).sort();
+  const expected = [...expectedFields].sort();
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    fail(`${label} fields are not closed: expected [${expected.join(", ")}], received [${actual.join(", ")}]`);
+  }
+}
+
+function assertString(value, label) {
+  if (typeof value !== "string" || value.length === 0) {
+    fail(`${label} must be a non-empty string`);
+  }
+}
+
+function assertPositiveInteger(value, label) {
+  if (!Number.isSafeInteger(value) || value < 1) {
+    fail(`${label} must be a positive integer`);
+  }
+}
+
+function assertPositiveNumber(value, label) {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    fail(`${label} must be a positive finite number`);
+  }
+}
+
+function assertSha256(value, label) {
+  if (!SHA256_PATTERN.test(value ?? "")) fail(`${label} must be a lowercase SHA-256 digest`);
+}
+
+function assertCanonicalRelativePath(value, label) {
+  assertString(value, label);
+  if (
+    value.includes("\0")
+    || value.includes("\\")
+    || value.startsWith("/")
+    || value === ".."
+    || value.startsWith("../")
+    || path.posix.normalize(value) !== value
+    || value === "."
+  ) fail(`${label} must be a canonical repository-relative path`);
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function validateStreamExpectation(value, label) {
+  assertClosedObject(value, ["bytes", "sha256"], label);
+  if (!Number.isSafeInteger(value.bytes) || value.bytes < 0) {
+    fail(`${label}.bytes must be a non-negative integer`);
+  }
+  assertSha256(value.sha256, `${label}.sha256`);
+}
+
+function validateCaptureExpectation(value, label) {
+  assertClosedObject(value, ["exit_status", "stderr", "stdout"], label);
+  if (value.exit_status !== 0) fail(`${label}.exit_status must be zero`);
+  validateStreamExpectation(value.stdout, `${label}.stdout`);
+  validateStreamExpectation(value.stderr, `${label}.stderr`);
+}
+
+function validateDiagnosticList(value, label) {
+  if (!Array.isArray(value)) fail(`${label} must be an array`);
+  const messages = [];
+  for (const [index, entry] of value.entries()) {
+    assertClosedObject(entry, ["count", "message"], `${label}[${index}]`);
+    assertString(entry.message, `${label}[${index}].message`);
+    assertPositiveInteger(entry.count, `${label}[${index}].count`);
+    messages.push(entry.message);
+  }
+  if (new Set(messages).size !== messages.length) fail(`${label} repeats a diagnostic message`);
+  if (JSON.stringify(messages) !== JSON.stringify([...messages].sort())) {
+    fail(`${label} must use canonical message order`);
+  }
+}
+
+function validateFragmentList(value, label) {
+  if (!Array.isArray(value) || value.length < 2) {
+    fail(`${label} must contain at least two ordered fragments`);
+  }
+  value.forEach((fragment, index) => assertString(fragment, `${label}[${index}]`));
+}
+
+function validateSentinel(value, index, artifact, identities) {
+  const label = `semantic baseline sentinels[${index}]`;
+  assertClosedObject(value, [
+    "class",
+    "default_anchor",
+    "default_fragments",
+    "defect",
+    "id",
+    "raw_fragments",
+    "recorded_page",
+    "state",
+    "struct_text_fragments",
+  ], label);
+  assertString(value.id, `${label}.id`);
+  if (identities.has(value.id)) fail(`semantic baseline repeats sentinel ${value.id}`);
+  identities.add(value.id);
+  if (!SENTINEL_CLASSES.has(value.class)) fail(`${label}.class is unknown`);
+  assertPositiveInteger(value.recorded_page, `${label}.recorded_page`);
+  if (value.recorded_page > artifact.pages) fail(`${label}.recorded_page exceeds the PDF page count`);
+  assertString(value.default_anchor, `${label}.default_anchor`);
+  validateFragmentList(value.default_fragments, `${label}.default_fragments`);
+  validateFragmentList(value.struct_text_fragments, `${label}.struct_text_fragments`);
+  validateFragmentList(value.raw_fragments, `${label}.raw_fragments`);
+  if (value.default_fragments[0] !== value.default_anchor) {
+    fail(`${label}.default_fragments must begin with default_anchor`);
+  }
+  if (!OUTCOMES.has(value.state)) fail(`${label}.state is unknown`);
+  assertString(value.defect, `${label}.defect`);
+}
+
+function validateArtifact(value) {
+  assertClosedObject(value, [
+    "manifest",
+    "manifest_sha256",
+    "pages",
+    "page_size_name",
+    "page_size_points",
+    "pdf",
+    "pdf_sha256",
+    "pdf_version",
+    "size_bytes",
+    "source_digest",
+    "source_ref",
+    "tagged",
+    "version",
+  ], "semantic baseline artifact");
+  assertCanonicalRelativePath(value.pdf, "semantic baseline artifact.pdf");
+  assertCanonicalRelativePath(value.manifest, "semantic baseline artifact.manifest");
+  assertSha256(value.pdf_sha256, "semantic baseline artifact.pdf_sha256");
+  assertSha256(value.manifest_sha256, "semantic baseline artifact.manifest_sha256");
+  assertSha256(value.source_digest, "semantic baseline artifact.source_digest");
+  assertPositiveInteger(value.size_bytes, "semantic baseline artifact.size_bytes");
+  assertPositiveInteger(value.pages, "semantic baseline artifact.pages");
+  assertClosedObject(
+    value.page_size_points,
+    ["height", "width"],
+    "semantic baseline artifact.page_size_points",
+  );
+  assertPositiveNumber(
+    value.page_size_points.width,
+    "semantic baseline artifact.page_size_points.width",
+  );
+  assertPositiveNumber(
+    value.page_size_points.height,
+    "semantic baseline artifact.page_size_points.height",
+  );
+  assertString(value.page_size_name, "semantic baseline artifact.page_size_name");
+  assertString(value.pdf_version, "semantic baseline artifact.pdf_version");
+  if (value.tagged !== true) fail("semantic baseline artifact.tagged must be true");
+  assertString(value.source_ref, "semantic baseline artifact.source_ref");
+  assertString(value.version, "semantic baseline artifact.version");
+}
+
+function validateTools(value) {
+  assertClosedObject(value, ["pdfinfo", "pdftotext"], "semantic baseline tools");
+  for (const name of ["pdfinfo", "pdftotext"]) {
+    assertClosedObject(value[name], ["command", "version"], `semantic baseline tools.${name}`);
+    if (value[name].command !== name) fail(`semantic baseline tools.${name}.command must be ${name}`);
+    assertString(value[name].version, `semantic baseline tools.${name}.version`);
+  }
+}
+
+export function validateBookPdfSemanticBaseline(value) {
+  assertClosedObject(value, [
+    "artifact",
+    "authority",
+    "claim_boundary",
+    "diagnostics",
+    "expected_outcome",
+    "outputs",
+    "schema_version",
+    "sentinels",
+    "tools",
+  ], "semantic baseline");
+  if (value.schema_version !== BOOK_PDF_SEMANTIC_BASELINE_SCHEMA_VERSION) {
+    fail(`unsupported semantic baseline schema version: ${value.schema_version}`);
+  }
+  if (value.authority !== SEMANTIC_AUTHORITY) fail("semantic baseline authority is invalid");
+  if (value.claim_boundary !== BOOK_PDF_SEMANTIC_CLAIM_BOUNDARY) {
+    fail("semantic baseline claim boundary is invalid");
+  }
+  if (!OUTCOMES.has(value.expected_outcome)) fail("semantic baseline expected_outcome is unknown");
+  validateArtifact(value.artifact);
+  validateTools(value.tools);
+  assertClosedObject(value.outputs, CAPTURE_NAMES, "semantic baseline outputs");
+  CAPTURE_NAMES.forEach((name) => validateCaptureExpectation(
+    value.outputs[name],
+    `semantic baseline outputs.${name}`,
+  ));
+  assertClosedObject(value.diagnostics, ["structure", "structure_text"], "semantic baseline diagnostics");
+  validateDiagnosticList(value.diagnostics.structure, "semantic baseline diagnostics.structure");
+  validateDiagnosticList(value.diagnostics.structure_text, "semantic baseline diagnostics.structure_text");
+  if (!Array.isArray(value.sentinels) || value.sentinels.length < 3) {
+    fail("semantic baseline requires at least three nonlinear sentinels");
+  }
+  const identities = new Set();
+  value.sentinels.forEach((entry, index) => validateSentinel(entry, index, value.artifact, identities));
+  const representedClasses = new Set(value.sentinels.map((entry) => entry.class));
+  const missingClasses = [...SENTINEL_CLASSES].filter((className) => !representedClasses.has(className));
+  if (missingClasses.length > 0) {
+    fail(`semantic baseline is missing sentinel classes: ${missingClasses.join(", ")}`);
+  }
+  const observedOutcome = value.sentinels.some((entry) => entry.state === "known-debt")
+    || value.diagnostics.structure.length > 0
+    || value.diagnostics.structure_text.length > 0
+    ? "known-debt"
+    : "clean";
+  if (observedOutcome !== value.expected_outcome) {
+    fail(`semantic baseline expected_outcome must be ${observedOutcome}`);
+  }
+  if (value.outputs.default_text.stderr.bytes !== 0 || value.outputs.raw_text.stderr.bytes !== 0) {
+    fail("pdftotext stderr cannot be accepted as semantic baseline debt");
+  }
+  if (
+    value.outputs.default_text.stderr.sha256 !== EMPTY_SHA256
+    || value.outputs.raw_text.stderr.sha256 !== EMPTY_SHA256
+  ) fail("empty pdftotext stderr must use the empty SHA-256 digest");
+  return value;
+}
+
+export function parseBookPdfSemanticBaseline(bytes) {
+  return validateBookPdfSemanticBaseline(parseStrictJson(bytes, {
+    label: "book PDF semantic baseline",
+    maximumDepth: 12,
+    maximumContainerEntries: 256,
+  }));
+}
+
+function commandResult(command, arguments_, options = {}) {
+  const maximumBytes = options.maxBuffer ?? MAXIMUM_CAPTURE_BYTES;
+  const result = spawnSync(command, arguments_, {
+    cwd: options.cwd,
+    encoding: null,
+    env: { LANG: "C", LC_ALL: "C", PATH: process.env.PATH ?? "", TZ: "UTC" },
+    killSignal: "SIGKILL",
+    maxBuffer: maximumBytes,
+    timeout: options.timeout ?? CAPTURE_TIMEOUT_MS,
+    windowsHide: true,
+  });
+  if (result.error) fail(`${command} failed before exit: ${result.error.message}`);
+  const stdout = Buffer.from(result.stdout ?? []);
+  const stderr = Buffer.from(result.stderr ?? []);
+  if (stdout.length > maximumBytes || stderr.length > maximumBytes) {
+    fail(`${command} exceeded the ${maximumBytes}-byte capture bound`);
+  }
+  return Object.freeze({
+    signal: result.signal ?? null,
+    status: result.status,
+    stderr,
+    stdout,
+  });
+}
+
+function toolVersion(command, name) {
+  const result = commandResult(command, ["-v"], { maxBuffer: 64 * 1024, timeout: 10_000 });
+  if (result.status !== 0 || result.signal !== null) fail(`${name} -v did not exit cleanly`);
+  const output = Buffer.concat([result.stdout, result.stderr]).toString("utf8");
+  const match = new RegExp(`^${name} version ([^\\s]+)$`, "mu").exec(output);
+  if (!match) fail(`${name} -v did not expose a parseable version`);
+  return match[1];
+}
+
+export function captureBookPdfSemanticOutputs({
+  captureLimits = {
+    maximum_bytes: MAXIMUM_CAPTURE_BYTES,
+    timeout_ms: CAPTURE_TIMEOUT_MS,
+  },
+  expectedToolVersions,
+  pdfBytes,
+  pdfinfoCommand = "pdfinfo",
+  pdftotextCommand = "pdftotext",
+  temporaryRoot = os.tmpdir(),
+} = {}) {
+  if (!Buffer.isBuffer(pdfBytes) || pdfBytes.length === 0) {
+    fail("semantic audit pdfBytes must be a non-empty Buffer");
+  }
+  if (pdfBytes.length > MAXIMUM_PDF_BYTES) {
+    fail(`semantic audit PDF exceeds the ${MAXIMUM_PDF_BYTES}-byte input bound`);
+  }
+  assertClosedObject(captureLimits, ["maximum_bytes", "timeout_ms"], "semantic capture limits");
+  const maximumBytes = captureLimits.maximum_bytes ?? MAXIMUM_CAPTURE_BYTES;
+  const timeout = captureLimits.timeout_ms ?? CAPTURE_TIMEOUT_MS;
+  if (!Number.isSafeInteger(maximumBytes) || maximumBytes < 1 || maximumBytes > MAXIMUM_CAPTURE_BYTES) {
+    fail(`semantic capture maximum_bytes must be between 1 and ${MAXIMUM_CAPTURE_BYTES}`);
+  }
+  if (!Number.isSafeInteger(timeout) || timeout < 1 || timeout > CAPTURE_TIMEOUT_MS) {
+    fail(`semantic capture timeout_ms must be between 1 and ${CAPTURE_TIMEOUT_MS}`);
+  }
+  assertString(temporaryRoot, "semantic capture temporaryRoot");
+  const toolIdentities = Object.freeze({
+    pdfinfo: toolVersion(pdfinfoCommand, "pdfinfo"),
+    pdftotext: toolVersion(pdftotextCommand, "pdftotext"),
+  });
+  if (expectedToolVersions) {
+    assertClosedObject(expectedToolVersions, ["pdfinfo", "pdftotext"], "expected semantic tool versions");
+    for (const name of ["pdfinfo", "pdftotext"]) {
+      if (toolIdentities[name] !== expectedToolVersions[name]) {
+        fail(`${name} version changed: expected ${expectedToolVersions[name]}, received ${toolIdentities[name]}`);
+      }
+    }
+  }
+  const snapshotDirectory = mkdtempSync(path.join(path.resolve(temporaryRoot), "20w-book-pdf-semantic-"));
+  const snapshotPath = path.join(snapshotDirectory, "book.pdf");
+  try {
+    chmodSync(snapshotDirectory, 0o700);
+    writeFileSync(snapshotPath, pdfBytes, { flag: "wx", mode: 0o600 });
+    const options = { cwd: snapshotDirectory, maxBuffer: maximumBytes, timeout };
+    const captures = Object.freeze({
+      metadata: commandResult(pdfinfoCommand, ["book.pdf"], options),
+      structure: commandResult(pdfinfoCommand, ["-struct", "book.pdf"], options),
+      structure_text: commandResult(pdfinfoCommand, ["-struct-text", "book.pdf"], options),
+      default_text: commandResult(pdftotextCommand, ["book.pdf", "-"], options),
+      raw_text: commandResult(pdftotextCommand, ["-raw", "book.pdf", "-"], options),
+    });
+    return Object.freeze({
+      captures,
+      toolIdentities,
+    });
+  } finally {
+    rmSync(snapshotDirectory, { recursive: true, force: true });
+  }
+}
+
+export function summarizeBookPdfSemanticCapture(capture) {
+  if (!capture || !Buffer.isBuffer(capture.stdout) || !Buffer.isBuffer(capture.stderr)) {
+    fail("semantic capture must contain Buffer stdout and stderr streams");
+  }
+  return Object.freeze({
+    exit_status: capture.status,
+    stderr: Object.freeze({ bytes: capture.stderr.length, sha256: sha256(capture.stderr) }),
+    stdout: Object.freeze({ bytes: capture.stdout.length, sha256: sha256(capture.stdout) }),
+  });
+}
+
+function diagnosticCounts(bytes) {
+  const counts = new Map();
+  const lines = bytes.toString("utf8").replaceAll("\r\n", "\n").split("\n");
+  for (const line of lines) {
+    if (line.length === 0) continue;
+    counts.set(line, (counts.get(line) ?? 0) + 1);
+  }
+  return counts;
+}
+
+function assertDiagnosticCounts(bytes, expected, label) {
+  const actual = diagnosticCounts(bytes);
+  const expectedByMessage = new Map(expected.map((entry) => [entry.message, entry.count]));
+  for (const [message, count] of actual) {
+    if (!expectedByMessage.has(message)) fail(`${label} emitted unknown diagnostic: ${message}`);
+    if (expectedByMessage.get(message) !== count) {
+      fail(`${label} diagnostic count changed for ${message}: expected ${expectedByMessage.get(message)}, received ${count}`);
+    }
+  }
+  for (const [message, count] of expectedByMessage) {
+    if (!actual.has(message)) fail(`${label} lost known diagnostic ${message} (expected ${count})`);
+  }
+}
+
+function normalizeText(value) {
+  return value.normalize("NFC").replace(/\s+/gu, " ").trim();
+}
+
+function parsePdfInfoMetadata(bytes) {
+  const text = bytes.toString("utf8").replaceAll("\r\n", "\n");
+  function exactMatch(pattern, label) {
+    const matches = [...text.matchAll(pattern)];
+    if (matches.length !== 1) fail(`pdfinfo metadata must contain exactly one ${label}`);
+    return matches[0];
+  }
+  const pages = Number(exactMatch(/^Pages:\s+(\d+)\s*$/gmu, "page count")[1]);
+  const pageSize = exactMatch(
+    /^Page size:\s+([0-9]+(?:\.[0-9]+)?) x ([0-9]+(?:\.[0-9]+)?) pts \(([^)]+)\)\s*$/gmu,
+    "page size",
+  );
+  const tagged = exactMatch(/^Tagged:\s+(yes|no)\s*$/gmu, "tag state")[1] === "yes";
+  const pdfVersion = exactMatch(/^PDF version:\s+(\S+)\s*$/gmu, "PDF version")[1];
+  return Object.freeze({
+    page_size_name: pageSize[3],
+    page_size_points: Object.freeze({
+      height: Number(pageSize[2]),
+      width: Number(pageSize[1]),
+    }),
+    pages,
+    pdf_version: pdfVersion,
+    tagged,
+  });
+}
+
+function splitExtractedPages(bytes, label) {
+  const text = bytes.toString("utf8");
+  if (!text.endsWith("\f")) fail(`${label} lost its final page delimiter`);
+  return text.slice(0, -1).split("\f").map((page) => (
+    page.normalize("NFC").replaceAll("\r\n", "\n")
+  ));
+}
+
+function locateAnchor(pages, anchor, label) {
+  const matches = [];
+  for (const [index, page] of pages.entries()) {
+    let cursor = 0;
+    for (;;) {
+      const match = page.indexOf(anchor, cursor);
+      if (match < 0) break;
+      matches.push(index + 1);
+      cursor = match + anchor.length;
+    }
+  }
+  if (matches.length !== 1) {
+    fail(`${label} anchor must locate exactly one page; received [${matches.join(", ")}]`);
+  }
+  return matches[0];
+}
+
+function assertOrderedFragments(text, fragments, label) {
+  let cursor = 0;
+  for (const fragment of fragments) {
+    const index = text.indexOf(fragment, cursor);
+    if (index < 0) fail(`${label} lost or reordered fragment: ${fragment}`);
+    cursor = index + fragment.length;
+  }
+}
+
+function evaluateSentinels(baseline, captures) {
+  const defaultPages = splitExtractedPages(captures.default_text.stdout, "pdftotext default output");
+  const rawPages = splitExtractedPages(captures.raw_text.stdout, "pdftotext raw output");
+  if (defaultPages.length !== baseline.artifact.pages || rawPages.length !== baseline.artifact.pages) {
+    fail(`semantic extraction page count changed: expected ${baseline.artifact.pages}, received default=${defaultPages.length}, raw=${rawPages.length}`);
+  }
+  const structureText = normalizeText(captures.structure_text.stdout.toString("utf8"));
+  return baseline.sentinels.map((sentinel) => {
+    const page = locateAnchor(defaultPages, sentinel.default_anchor, sentinel.id);
+    if (page !== sentinel.recorded_page) {
+      fail(`${sentinel.id} moved from recorded page ${sentinel.recorded_page} to ${page}`);
+    }
+    assertOrderedFragments(
+      normalizeText(defaultPages[page - 1]),
+      sentinel.default_fragments,
+      `${sentinel.id} default extraction`,
+    );
+    assertOrderedFragments(structureText, sentinel.struct_text_fragments, `${sentinel.id} structure-text extraction`);
+    assertOrderedFragments(rawPages[page - 1], sentinel.raw_fragments, `${sentinel.id} raw extraction`);
+    return Object.freeze({
+      class: sentinel.class,
+      defect: sentinel.defect,
+      id: sentinel.id,
+      page,
+      state: sentinel.state,
+    });
+  });
+}
+
+function assertArtifactIdentity(baseline, pdfBytes, manifestBytes) {
+  const manifest = parseStrictJson(manifestBytes, {
+    label: "book PDF manifest",
+    maximumDepth: 10,
+    maximumContainerEntries: 512,
+  });
+  const inspected = assertBookPdfBytesIntegrity(pdfBytes, manifest);
+  const expected = baseline.artifact;
+  const comparisons = [
+    [inspected.pdf_sha256, expected.pdf_sha256, "PDF SHA-256"],
+    [inspected.size_bytes, expected.size_bytes, "PDF byte size"],
+    [sha256(manifestBytes), expected.manifest_sha256, "manifest SHA-256"],
+    [manifest.pdf, expected.pdf, "manifest PDF path"],
+    [manifest.source_ref, expected.source_ref, "manifest source ref"],
+    [manifest.source_digest, expected.source_digest, "manifest source digest"],
+    [manifest.version, expected.version, "manifest version"],
+  ];
+  for (const [actual, wanted, label] of comparisons) {
+    if (actual !== wanted) fail(`${label} changed: expected ${wanted}, received ${actual}`);
+  }
+  return inspected;
+}
+
+export function assertBookPdfSemanticArtifactIdentity({
+  baseline,
+  manifestBytes,
+  pdfBytes,
+} = {}) {
+  validateBookPdfSemanticBaseline(baseline);
+  if (!Buffer.isBuffer(pdfBytes) || !Buffer.isBuffer(manifestBytes)) {
+    fail("semantic audit requires PDF and manifest Buffer inputs");
+  }
+  return assertArtifactIdentity(baseline, pdfBytes, manifestBytes);
+}
+
+function assertToolIdentities(baseline, toolIdentities) {
+  assertClosedObject(toolIdentities, ["pdfinfo", "pdftotext"], "semantic tool identities");
+  for (const name of ["pdfinfo", "pdftotext"]) {
+    if (toolIdentities[name] !== baseline.tools[name].version) {
+      fail(`${name} version changed: expected ${baseline.tools[name].version}, received ${toolIdentities[name]}`);
+    }
+  }
+}
+
+function assertCaptureStatusAndDiagnostics(baseline, captures) {
+  assertClosedObject(captures, CAPTURE_NAMES, "semantic captures");
+  for (const name of CAPTURE_NAMES) {
+    const capture = captures[name];
+    summarizeBookPdfSemanticCapture(capture);
+    if (capture.signal !== null) fail(`${name} ended with signal ${capture.signal}`);
+    if (capture.status !== baseline.outputs[name].exit_status) {
+      fail(`${name} exit status changed: expected ${baseline.outputs[name].exit_status}, received ${capture.status}`);
+    }
+  }
+  assertDiagnosticCounts(captures.structure.stderr, baseline.diagnostics.structure, "pdfinfo -struct");
+  assertDiagnosticCounts(
+    captures.structure_text.stderr,
+    baseline.diagnostics.structure_text,
+    "pdfinfo -struct-text",
+  );
+  if (captures.default_text.stderr.length > 0) fail("pdftotext default emitted an unexplained diagnostic");
+  if (captures.raw_text.stderr.length > 0) fail("pdftotext raw emitted an unexplained diagnostic");
+  if (captures.metadata.stderr.length > 0) fail("pdfinfo metadata emitted an unexplained diagnostic");
+}
+
+function assertExactCaptureIdentities(baseline, captures) {
+  for (const name of CAPTURE_NAMES) {
+    const actual = summarizeBookPdfSemanticCapture(captures[name]);
+    const expected = baseline.outputs[name];
+    for (const stream of ["stdout", "stderr"]) {
+      if (
+        actual[stream].bytes !== expected[stream].bytes
+        || actual[stream].sha256 !== expected[stream].sha256
+      ) fail(`${name} ${stream} identity changed`);
+    }
+  }
+}
+
+export function auditBookPdfSemanticCaptures({
+  baseline,
+  captures,
+  manifestBytes,
+  pdfBytes,
+  toolIdentities,
+} = {}) {
+  const artifact = assertBookPdfSemanticArtifactIdentity({ baseline, manifestBytes, pdfBytes });
+  assertToolIdentities(baseline, toolIdentities);
+  assertCaptureStatusAndDiagnostics(baseline, captures);
+  const metadata = parsePdfInfoMetadata(captures.metadata.stdout);
+  const metadataComparisons = [
+    [metadata.pages, baseline.artifact.pages, "pdfinfo page count"],
+    [metadata.page_size_name, baseline.artifact.page_size_name, "pdfinfo page size name"],
+    [metadata.page_size_points.width, baseline.artifact.page_size_points.width, "pdfinfo page width"],
+    [metadata.page_size_points.height, baseline.artifact.page_size_points.height, "pdfinfo page height"],
+    [metadata.pdf_version, baseline.artifact.pdf_version, "pdfinfo PDF version"],
+    [metadata.tagged, baseline.artifact.tagged, "pdfinfo tag state"],
+  ];
+  for (const [actual, wanted, label] of metadataComparisons) {
+    if (actual !== wanted) fail(`${label} changed: expected ${wanted}, received ${actual}`);
+  }
+  const sentinels = evaluateSentinels(baseline, captures);
+  assertExactCaptureIdentities(baseline, captures);
+  const outputIdentities = Object.fromEntries(CAPTURE_NAMES.map((name) => [
+    name,
+    summarizeBookPdfSemanticCapture(captures[name]),
+  ]));
+  const passed = baseline.expected_outcome === "clean";
+  return Object.freeze({
+    artifact: Object.freeze({
+      manifest_sha256: baseline.artifact.manifest_sha256,
+      page_size_name: metadata.page_size_name,
+      page_size_points: metadata.page_size_points,
+      pages: baseline.artifact.pages,
+      pdf_sha256: artifact.pdf_sha256,
+      pdf_version: metadata.pdf_version,
+      size_bytes: artifact.size_bytes,
+      source_digest: baseline.artifact.source_digest,
+      source_ref: baseline.artifact.source_ref,
+      tagged: metadata.tagged,
+    }),
+    claim_boundary: BOOK_PDF_SEMANTIC_CLAIM_BOUNDARY,
+    commands: Object.freeze({
+      default_text: Object.freeze(["pdftotext", baseline.artifact.pdf, "-"]),
+      metadata: Object.freeze(["pdfinfo", baseline.artifact.pdf]),
+      raw_text: Object.freeze(["pdftotext", "-raw", baseline.artifact.pdf, "-"]),
+      structure: Object.freeze(["pdfinfo", "-struct", baseline.artifact.pdf]),
+      structure_text: Object.freeze(["pdfinfo", "-struct-text", baseline.artifact.pdf]),
+    }),
+    diagnostics: Object.freeze({
+      structure: Object.freeze(baseline.diagnostics.structure.map((entry) => Object.freeze({ ...entry }))),
+      structure_text: Object.freeze(
+        baseline.diagnostics.structure_text.map((entry) => Object.freeze({ ...entry })),
+      ),
+    }),
+    expected_outcome: baseline.expected_outcome,
+    outputs: Object.freeze(outputIdentities),
+    passed,
+    sentinels: Object.freeze(sentinels),
+    tools: Object.freeze({ ...toolIdentities }),
+  });
+}
+
+function sameFileIdentity(left, right) {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+async function inspectEvidenceRoot(root) {
+  const absolute = path.resolve(root);
+  const missing = [];
+  let existing = absolute;
+  for (;;) {
+    try {
+      await lstat(existing);
+      break;
+    } catch (error) {
+      if (error?.code !== "ENOENT") throw error;
+      const parent = path.dirname(existing);
+      if (parent === existing) throw error;
+      missing.unshift(existing);
+      existing = parent;
+    }
+  }
+  let parentInformation = await lstat(existing, { bigint: true });
+  if (
+    parentInformation.isSymbolicLink()
+    || !parentInformation.isDirectory()
+    || path.resolve(await realpath(existing)) !== path.resolve(existing)
+  ) fail("semantic evidence root has a linked or non-canonical ancestor");
+  for (const directory of missing) {
+    const currentParent = await lstat(existing, { bigint: true });
+    if (!sameFileIdentity(parentInformation, currentParent)) {
+      fail("semantic evidence root ancestor changed identity during creation");
+    }
+    await mkdir(directory, { mode: 0o700 });
+    const information = await lstat(directory, { bigint: true });
+    if (
+      information.isSymbolicLink()
+      || !information.isDirectory()
+      || path.resolve(await realpath(directory)) !== path.resolve(directory)
+    ) fail("semantic evidence root creation produced a linked or non-canonical directory");
+    existing = directory;
+    parentInformation = information;
+  }
+  const information = await lstat(absolute, { bigint: true });
+  const resolved = await realpath(absolute);
+  if (
+    information.isSymbolicLink()
+    || !information.isDirectory()
+    || path.resolve(resolved) !== absolute
+  ) fail("semantic evidence root is linked or not canonical");
+  return Object.freeze({ absolute, information });
+}
+
+async function assertEvidenceRootUnchanged(root) {
+  const information = await lstat(root.absolute, { bigint: true });
+  const resolved = await realpath(root.absolute);
+  if (
+    information.isSymbolicLink()
+    || !information.isDirectory()
+    || !sameFileIdentity(root.information, information)
+    || path.resolve(resolved) !== root.absolute
+  ) fail("semantic evidence root changed identity during publication");
+}
+
+async function assertDestinationAbsent(directory) {
+  try {
+    await lstat(directory);
+  } catch (error) {
+    if (error?.code === "ENOENT") return;
+    throw error;
+  }
+  fail("semantic evidence directory already exists");
+}
+
+export async function writeBookPdfSemanticEvidence({
+  captures,
+  directory,
+  evidenceRoot,
+  failure,
+  report,
+} = {}) {
+  assertString(directory, "semantic evidence directory");
+  assertString(evidenceRoot, "semantic evidence root");
+  assertClosedObject(captures, CAPTURE_NAMES, "semantic captures");
+  CAPTURE_NAMES.forEach((name) => summarizeBookPdfSemanticCapture(captures[name]));
+  if ((report === undefined) === (failure === undefined)) {
+    fail("semantic evidence requires exactly one validated report or failure envelope");
+  }
+  const root = await inspectEvidenceRoot(evidenceRoot);
+  const destination = path.resolve(directory);
+  if (path.dirname(destination) !== root.absolute) {
+    fail("semantic evidence directory must be a direct child of its evidence root");
+  }
+  if (path.basename(destination).startsWith(".semantic-stage-")) {
+    fail("semantic evidence directory uses a reserved staging prefix");
+  }
+  await assertDestinationAbsent(destination);
+  const staging = await mkdtemp(path.join(root.absolute, ".semantic-stage-"));
+  try {
+    for (const name of CAPTURE_NAMES) {
+      const files = EVIDENCE_FILE_NAMES[name];
+      await writeFile(path.join(staging, files.stdout), captures[name].stdout, { flag: "wx" });
+      await writeFile(path.join(staging, files.stderr), captures[name].stderr, { flag: "wx" });
+    }
+    const document = report ?? failure;
+    const documentName = report === undefined
+      ? "semantic-audit-error.json"
+      : "semantic-audit-report.json";
+    await writeFile(
+      path.join(staging, documentName),
+      `${JSON.stringify(document, null, 2)}\n`,
+      { encoding: "utf8", flag: "wx" },
+    );
+    await assertEvidenceRootUnchanged(root);
+    await assertDestinationAbsent(destination);
+    await rename(staging, destination);
+  } finally {
+    await rm(staging, { recursive: true, force: true });
+  }
+}

--- a/scripts/lib/pdf-metadata.test.mjs
+++ b/scripts/lib/pdf-metadata.test.mjs
@@ -1,7 +1,149 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
+import { bookSourceDigest } from "../book-source.mjs";
+import {
+  auditBookPdfSemanticCaptures,
+  assertBookPdfSemanticArtifactIdentity,
+  BOOK_PDF_SEMANTIC_BASELINE_SCHEMA_VERSION,
+  BOOK_PDF_SEMANTIC_CLAIM_BOUNDARY,
+  captureBookPdfSemanticOutputs,
+  parseBookPdfSemanticBaseline,
+  summarizeBookPdfSemanticCapture,
+  validateBookPdfSemanticBaseline,
+  writeBookPdfSemanticEvidence,
+} from "./book-pdf-semantic-audit.mjs";
+import { readStableOpenedFile } from "./opened-file.mjs";
 import { normalizeChromiumPdfMetadata } from "./pdf-metadata.mjs";
+
+const knownDiagnostic = "Syntax Error: StructElem object is wrong type (Strong)";
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function semanticCapture(stdout, stderr = "") {
+  return {
+    signal: null,
+    status: 0,
+    stderr: Buffer.from(stderr),
+    stdout: Buffer.from(stdout),
+  };
+}
+
+function semanticCaptures(outcome) {
+  const diagnostic = outcome === "known-debt" ? `${knownDiagnostic}\n` : "";
+  return {
+    metadata: semanticCapture([
+      "Tagged:          yes",
+      "Pages:           1",
+      "Page size:       594.96 x 841.92 pts (A4)",
+      "PDF version:     1.4",
+      "",
+    ].join("\n")),
+    structure: semanticCapture("Document\n", diagnostic),
+    structure_text: semanticCapture(
+      "Dashboard tagged tail\nEquation tagged tail\nFigure tagged tail\n",
+      diagnostic,
+    ),
+    default_text: semanticCapture(
+      "Dashboard anchor default tail\nEquation anchor default tail\nFigure anchor default tail\f",
+    ),
+    raw_text: semanticCapture("Dashboard raw debt\nEquation raw debt\nFigure raw debt\f"),
+  };
+}
+
+function semanticSentinels(outcome) {
+  return [
+    ["dashboard", "dashboard-status", "Dashboard"],
+    ["equation", "table-displayed-equation", "Equation"],
+    ["figure", "diagram-figure", "Figure"],
+  ].map(([id, className, prefix]) => ({
+    id,
+    class: className,
+    recorded_page: 1,
+    default_anchor: `${prefix} anchor`,
+    default_fragments: [`${prefix} anchor`, "default tail"],
+    struct_text_fragments: [`${prefix} tagged`, "tail"],
+    raw_fragments: [`${prefix} raw`, "debt"],
+    state: outcome,
+    defect: outcome === "known-debt" ? `${prefix} debt remains.` : `${prefix} is clean.`,
+  }));
+}
+
+function semanticFixture(outcome = "known-debt") {
+  const pdfBytes = Buffer.alloc(100_000, 0x20);
+  pdfBytes.write("%PDF-1.4\n", 0, "ascii");
+  const pdfSha256 = sha256(pdfBytes);
+  const sourceDigest = "a".repeat(64);
+  const manifest = {
+    pdf: "public/downloads/test.pdf",
+    pdf_sha256: pdfSha256,
+    size_bytes: pdfBytes.length,
+    source_ref: "main",
+    source_digest: sourceDigest,
+    version: "0.0.0",
+  };
+  const manifestBytes = Buffer.from(JSON.stringify(manifest));
+  const captures = semanticCaptures(outcome);
+  const diagnostics = outcome === "known-debt"
+    ? [{ message: knownDiagnostic, count: 1 }]
+    : [];
+  const outputs = Object.fromEntries(Object.entries(captures).map(([name, capture]) => [
+    name,
+    summarizeBookPdfSemanticCapture(capture),
+  ]));
+  const baseline = {
+    schema_version: BOOK_PDF_SEMANTIC_BASELINE_SCHEMA_VERSION,
+    authority: "engineering-regression-sentinel",
+    claim_boundary: BOOK_PDF_SEMANTIC_CLAIM_BOUNDARY,
+    expected_outcome: outcome,
+    artifact: {
+      pdf: manifest.pdf,
+      manifest: "public/downloads/test-manifest.json",
+      pdf_sha256: pdfSha256,
+      manifest_sha256: sha256(manifestBytes),
+      size_bytes: pdfBytes.length,
+      pages: 1,
+      page_size_name: "A4",
+      page_size_points: { width: 594.96, height: 841.92 },
+      pdf_version: "1.4",
+      tagged: true,
+      source_ref: manifest.source_ref,
+      source_digest: sourceDigest,
+      version: manifest.version,
+    },
+    tools: {
+      pdfinfo: { command: "pdfinfo", version: "26.08.0" },
+      pdftotext: { command: "pdftotext", version: "26.08.0" },
+    },
+    outputs,
+    diagnostics: { structure: diagnostics, structure_text: diagnostics },
+    sentinels: semanticSentinels(outcome),
+  };
+  return {
+    baseline,
+    captures,
+    manifestBytes,
+    pdfBytes,
+    toolIdentities: { pdfinfo: "26.08.0", pdftotext: "26.08.0" },
+  };
+}
 
 function fixture(timestamp, firstNode = "node00000384", secondNode = "node00000392") {
   return Buffer.concat([
@@ -12,6 +154,56 @@ function fixture(timestamp, firstNode = "node00000384", secondNode = "node000003
     Buffer.from(`) /ID (${firstNode}) /Headers [(${secondNode}) (${firstNode})] >>\n`),
     Buffer.from([0x00, 0x7f, 0x80, 0xff]),
   ]);
+}
+
+function fakePopplerSource(logPath, behavior = "normal") {
+  return `#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { appendFileSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+
+const name = path.basename(process.argv[1]);
+const args = process.argv.slice(2);
+if (args[0] === "-v") {
+  process.stderr.write(name + " version " + ${JSON.stringify(
+    behavior === "wrong-version" ? "99.0.0" : "26.08.0",
+  )} + "\\n");
+  process.exit(0);
+}
+const bytes = readFileSync("book.pdf");
+appendFileSync(${JSON.stringify(logPath)}, JSON.stringify({
+  name,
+  args,
+  directory_mode: (statSync(".").mode & 0o777).toString(8),
+  file_mode: (statSync("book.pdf").mode & 0o777).toString(8),
+  sha256: createHash("sha256").update(bytes).digest("hex"),
+}) + "\\n");
+if (${JSON.stringify(behavior)} === "timeout" && args[0] === "-struct") {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 2_000);
+}
+if (${JSON.stringify(behavior)} === "nonzero" && args[0] === "-struct") process.exit(7);
+if (${JSON.stringify(behavior)} === "oversize") process.stdout.write("x".repeat(4096));
+else if (name === "pdfinfo" && args[0] === "book.pdf") {
+  process.stdout.write("Tagged: yes\\nPages: 1\\nPage size: 594.96 x 841.92 pts (A4)\\nPDF version: 1.4\\n");
+} else if (name === "pdfinfo") process.stdout.write("Document\\n");
+else process.stdout.write("Dashboard anchor default tail\\nEquation anchor default tail\\nFigure anchor default tail\\f");
+`;
+}
+
+async function fakePopplerTools(root, behavior = "normal") {
+  const bin = path.join(root, `bin-${behavior}`);
+  const log = path.join(root, `${behavior}.jsonl`);
+  await mkdir(bin);
+  for (const name of ["pdfinfo", "pdftotext"]) {
+    const command = path.join(bin, name);
+    await writeFile(command, fakePopplerSource(log, behavior), "utf8");
+    await chmod(command, 0o700);
+  }
+  return Object.freeze({
+    log,
+    pdfinfoCommand: path.join(bin, "pdfinfo"),
+    pdftotextCommand: path.join(bin, "pdftotext"),
+  });
 }
 
 test("Chromium PDF wall-clock metadata normalizes to the release date", () => {
@@ -41,4 +233,351 @@ test("PDF metadata normalization fails closed on invalid dates or renderer drift
     () => normalizeChromiumPdfMetadata(Buffer.from("%PDF-1.4\n"), "2026-08-28"),
     /exactly one CreationDate and one ModDate/u,
   );
+});
+
+test("the tracked semantic baseline is closed and records failing debt", async () => {
+  const baseline = parseBookPdfSemanticBaseline(await readFile(
+    new URL("../book-pdf-semantic-baseline.json", import.meta.url),
+  ));
+  assert.equal(baseline.expected_outcome, "known-debt");
+  assert.equal(baseline.sentinels.length, 6);
+  assert.deepEqual(
+    baseline.diagnostics.structure.map(({ count }) => count),
+    [14, 613],
+  );
+  const [pdfBytes, manifestBytes, source] = await Promise.all([
+    readStableOpenedFile(path.join(repositoryRoot, baseline.artifact.pdf), {
+      containedBy: repositoryRoot,
+      maximumBytes: 256 * 1024 * 1024,
+    }),
+    readStableOpenedFile(path.join(repositoryRoot, baseline.artifact.manifest), {
+      containedBy: repositoryRoot,
+      maximumBytes: 1024 * 1024,
+    }),
+    bookSourceDigest(repositoryRoot),
+  ]);
+  assert.doesNotThrow(() => assertBookPdfSemanticArtifactIdentity({
+    baseline,
+    manifestBytes,
+    pdfBytes,
+  }));
+  assert.equal(source.digest, baseline.artifact.source_digest);
+});
+
+test("recognized diagnostics with exit zero remain known debt, never a pass", () => {
+  const fixture = semanticFixture();
+  const report = auditBookPdfSemanticCaptures(fixture);
+  assert.equal(report.expected_outcome, "known-debt");
+  assert.equal(report.passed, false);
+  assert.equal(report.claim_boundary, BOOK_PDF_SEMANTIC_CLAIM_BOUNDARY);
+  assert.equal(report.sentinels.every(({ state }) => state === "known-debt"), true);
+  assert.deepEqual(report.commands.structure.slice(0, 2), ["pdfinfo", "-struct"]);
+  assert.deepEqual(report.commands.metadata, ["pdfinfo", "public/downloads/test.pdf"]);
+  assert.deepEqual(report.artifact.page_size_points, { width: 594.96, height: 841.92 });
+  assert.equal(report.artifact.tagged, true);
+  assert.equal(report.diagnostics.structure[0].count, 1);
+});
+
+test("unknown, added, or silently removed structure diagnostics fail closed", () => {
+  const added = semanticFixture();
+  added.captures.structure.stderr = Buffer.from(
+    `${knownDiagnostic}\nSyntax Error: a new semantic failure\n`,
+  );
+  assert.throws(
+    () => auditBookPdfSemanticCaptures(added),
+    /emitted unknown diagnostic/u,
+  );
+
+  const removed = semanticFixture();
+  removed.captures.structure.stderr = Buffer.alloc(0);
+  assert.throws(
+    () => auditBookPdfSemanticCaptures(removed),
+    /lost known diagnostic/u,
+  );
+});
+
+test("content anchors must be unique and nonlinear fragment order is exact", () => {
+  const duplicate = semanticFixture();
+  duplicate.captures.default_text.stdout = Buffer.from(
+    "Dashboard anchor Dashboard anchor default tail\nEquation anchor default tail\nFigure anchor default tail\f",
+  );
+  assert.throws(
+    () => auditBookPdfSemanticCaptures(duplicate),
+    /anchor must locate exactly one page/u,
+  );
+
+  const reordered = semanticFixture();
+  reordered.captures.raw_text.stdout = Buffer.from(
+    "Dashboard debt raw\nEquation raw debt\nFigure raw debt\f",
+  );
+  assert.throws(
+    () => auditBookPdfSemanticCaptures(reordered),
+    /lost or reordered fragment/u,
+  );
+});
+
+test("sentinel classes and recorded pages remain exact", () => {
+  const missingClass = semanticFixture();
+  missingClass.baseline.sentinels[2].class = "dashboard-status";
+  assert.throws(
+    () => validateBookPdfSemanticBaseline(missingClass.baseline),
+    /missing sentinel classes: diagram-figure/u,
+  );
+
+  const moved = semanticFixture();
+  moved.baseline.artifact.pages = 2;
+  moved.baseline.sentinels[0].recorded_page = 2;
+  moved.captures.metadata.stdout = Buffer.from(
+    moved.captures.metadata.stdout.toString("utf8").replace("Pages:           1", "Pages:           2"),
+  );
+  moved.baseline.outputs.metadata = summarizeBookPdfSemanticCapture(moved.captures.metadata);
+  for (const name of ["default_text", "raw_text"]) {
+    moved.captures[name].stdout = Buffer.concat([
+      moved.captures[name].stdout,
+      Buffer.from("\f"),
+    ]);
+    moved.baseline.outputs[name] = summarizeBookPdfSemanticCapture(moved.captures[name]);
+  }
+  assert.throws(
+    () => auditBookPdfSemanticCaptures(moved),
+    /moved from recorded page 2 to 1/u,
+  );
+});
+
+test("exact output drift fails after semantic predicates remain satisfied", () => {
+  const fixture = semanticFixture();
+  fixture.captures.structure.stdout = Buffer.from("Document changed\n");
+  assert.throws(
+    () => auditBookPdfSemanticCaptures(fixture),
+    /structure stdout identity changed/u,
+  );
+});
+
+test("a future clean baseline can pass without making a conformance claim", () => {
+  const fixture = semanticFixture("clean");
+  const report = auditBookPdfSemanticCaptures(fixture);
+  assert.equal(report.passed, true);
+  assert.match(report.claim_boundary, /does not establish PDF\/UA or WCAG conformance/u);
+
+  const openSchema = structuredClone(fixture.baseline);
+  openSchema.pdf_ua = true;
+  assert.throws(
+    () => validateBookPdfSemanticBaseline(openSchema),
+    /fields are not closed/u,
+  );
+
+  const nonzero = structuredClone(fixture.baseline);
+  nonzero.outputs.structure.exit_status = 1;
+  assert.throws(
+    () => validateBookPdfSemanticBaseline(nonzero),
+    /exit_status must be zero/u,
+  );
+});
+
+test("semantic artifact paths cannot escape the repository root", () => {
+  const fixture = semanticFixture();
+  fixture.baseline.artifact.pdf = "../outside.pdf";
+  assert.throws(
+    () => validateBookPdfSemanticBaseline(fixture.baseline),
+    /canonical repository-relative path/u,
+  );
+
+  fixture.baseline.artifact.pdf = "public/downloads/test.pdf";
+  fixture.baseline.artifact.manifest = "public/../outside.json";
+  assert.throws(
+    () => validateBookPdfSemanticBaseline(fixture.baseline),
+    /canonical repository-relative path/u,
+  );
+});
+
+test("Poppler receives one private exact-byte snapshot by stable basename", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "20w-semantic-capture-test-"));
+  const temporaryRoot = path.join(root, "snapshots");
+  await mkdir(temporaryRoot);
+  try {
+    const tools = await fakePopplerTools(root);
+    const pdfBytes = Buffer.from("%PDF-1.4\nprivate snapshot\n");
+    const observed = captureBookPdfSemanticOutputs({
+      expectedToolVersions: { pdfinfo: "26.08.0", pdftotext: "26.08.0" },
+      pdfBytes,
+      pdfinfoCommand: tools.pdfinfoCommand,
+      pdftotextCommand: tools.pdftotextCommand,
+      temporaryRoot,
+    });
+    assert.equal(observed.captures.metadata.status, 0);
+    const invocations = (await readFile(tools.log, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    assert.equal(invocations.length, 5);
+    for (const invocation of invocations) {
+      assert.equal(invocation.args.includes("book.pdf"), true);
+      assert.equal(invocation.args.some((argument) => argument.includes("/")), false);
+      assert.equal(invocation.directory_mode, "700");
+      assert.equal(invocation.file_mode, "600");
+      assert.equal(invocation.sha256, sha256(pdfBytes));
+    }
+    assert.deepEqual(await readdir(temporaryRoot), []);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("semantic command failures stay bounded and always remove the PDF snapshot", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "20w-semantic-bounds-test-"));
+  const pdfBytes = Buffer.from("%PDF-1.4\nbounded snapshot\n");
+  try {
+    for (const [behavior, expectation] of [
+      ["wrong-version", /version changed/u],
+      ["timeout", /failed before exit/u],
+      ["oversize", /failed before exit/u],
+    ]) {
+      const temporaryRoot = path.join(root, `snapshots-${behavior}`);
+      await mkdir(temporaryRoot);
+      const tools = await fakePopplerTools(root, behavior);
+      assert.throws(
+        () => captureBookPdfSemanticOutputs({
+          captureLimits: { maximum_bytes: 512, timeout_ms: 500 },
+          expectedToolVersions: { pdfinfo: "26.08.0", pdftotext: "26.08.0" },
+          pdfBytes,
+          pdfinfoCommand: tools.pdfinfoCommand,
+          pdftotextCommand: tools.pdftotextCommand,
+          temporaryRoot,
+        }),
+        expectation,
+      );
+      assert.deepEqual(await readdir(temporaryRoot), []);
+    }
+
+    const temporaryRoot = path.join(root, "snapshots-nonzero");
+    await mkdir(temporaryRoot);
+    const tools = await fakePopplerTools(root, "nonzero");
+    const observed = captureBookPdfSemanticOutputs({
+      captureLimits: { maximum_bytes: 512, timeout_ms: 500 },
+      expectedToolVersions: { pdfinfo: "26.08.0", pdftotext: "26.08.0" },
+      pdfBytes,
+      pdfinfoCommand: tools.pdfinfoCommand,
+      pdftotextCommand: tools.pdftotextCommand,
+      temporaryRoot,
+    });
+    assert.equal(observed.captures.structure.status, 7);
+    assert.deepEqual(await readdir(temporaryRoot), []);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("semantic evidence keeps every command stream separate", async () => {
+  const fixture = semanticFixture();
+  const root = await mkdtemp(path.join(os.tmpdir(), "20w-pdf-semantic-evidence-"));
+  const directory = path.join(root, "audit");
+  try {
+    const report = auditBookPdfSemanticCaptures(fixture);
+    await writeBookPdfSemanticEvidence({
+      captures: fixture.captures,
+      directory,
+      evidenceRoot: root,
+      report,
+    });
+    assert.equal(
+      await readFile(path.join(directory, "pdfinfo.stdout.txt"), "utf8"),
+      fixture.captures.metadata.stdout.toString("utf8"),
+    );
+    assert.equal(
+      await readFile(path.join(directory, "pdfinfo-struct.stderr.txt"), "utf8"),
+      `${knownDiagnostic}\n`,
+    );
+    assert.equal(
+      await readFile(path.join(directory, "pdfinfo-struct-text.stdout.txt"), "utf8"),
+      fixture.captures.structure_text.stdout.toString("utf8"),
+    );
+    assert.equal(
+      await readFile(path.join(directory, "pdftotext-default.stderr.txt"), "utf8"),
+      "",
+    );
+    assert.equal(
+      JSON.parse(await readFile(path.join(directory, "semantic-audit-report.json"), "utf8")).passed,
+      false,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("semantic evidence publishes failure envelopes atomically and cleans partial staging", async () => {
+  const fixture = semanticFixture();
+  fixture.captures.structure.stderr = Buffer.from(
+    `${knownDiagnostic}\nSyntax Error: a new semantic failure\n`,
+  );
+  let auditError;
+  try {
+    auditBookPdfSemanticCaptures(fixture);
+  } catch (error) {
+    auditError = error;
+  }
+  assert.match(auditError?.message ?? "", /emitted unknown diagnostic/u);
+  const root = await mkdtemp(path.join(os.tmpdir(), "20w-pdf-semantic-atomic-"));
+  try {
+    const failureDirectory = path.join(root, "failure");
+    await writeBookPdfSemanticEvidence({
+      captures: fixture.captures,
+      directory: failureDirectory,
+      evidenceRoot: root,
+      failure: { passed: false, status: "invalid", error: { message: auditError.message } },
+    });
+    assert.equal(
+      JSON.parse(await readFile(path.join(failureDirectory, "semantic-audit-error.json"), "utf8")).status,
+      "invalid",
+    );
+    assert.match(
+      JSON.parse(
+        await readFile(path.join(failureDirectory, "semantic-audit-error.json"), "utf8"),
+      ).error.message,
+      /emitted unknown diagnostic/u,
+    );
+
+    const circular = {};
+    circular.self = circular;
+    const partialDirectory = path.join(root, "partial");
+    await assert.rejects(
+      writeBookPdfSemanticEvidence({
+        captures: fixture.captures,
+        directory: partialDirectory,
+        evidenceRoot: root,
+        report: circular,
+      }),
+      /circular/u,
+    );
+    assert.equal((await readdir(root)).some((name) => name.startsWith(".semantic-stage-")), false);
+    await assert.rejects(readFile(partialDirectory), /ENOENT/u);
+    await assert.rejects(
+      writeBookPdfSemanticEvidence({
+        captures: fixture.captures,
+        directory: path.join(root, "nested", "escape"),
+        evidenceRoot: root,
+        report: { passed: false },
+      }),
+      /direct child/u,
+    );
+
+    const outside = await mkdtemp(path.join(os.tmpdir(), "20w-pdf-semantic-outside-"));
+    const linkedRoot = path.join(root, "linked-root");
+    try {
+      await symlink(outside, linkedRoot, "dir");
+      await assert.rejects(
+        writeBookPdfSemanticEvidence({
+          captures: fixture.captures,
+          directory: path.join(linkedRoot, "escaped"),
+          evidenceRoot: linkedRoot,
+          report: { passed: false },
+        }),
+        /linked or non-canonical ancestor/u,
+      );
+      assert.deepEqual(await readdir(outside), []);
+    } finally {
+      await rm(outside, { recursive: true, force: true });
+    }
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
 });

--- a/scripts/mermaid-browser.test.mjs
+++ b/scripts/mermaid-browser.test.mjs
@@ -17,6 +17,12 @@ import {
 } from "./lib/chromium-cdp.mjs";
 
 const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const profileRemovalOptions = Object.freeze({
+  force: true,
+  maxRetries: 5,
+  recursive: true,
+  retryDelay: 100,
+});
 
 test("browser process shutdown waits for a stubborn child before profile cleanup", async () => {
   const profile = await mkdtemp(path.join(os.tmpdir(), "20w-browser-stop-"));
@@ -43,13 +49,13 @@ process.stdout.write("ready\\n");`,
     await stopProcess(browserProcess, { terminationGraceMs: 50, forcedExitWaitMs: 2_000 });
     assert.equal(exited, true, "stopProcess returned before the child exit event");
     if (process.platform !== "win32") assert.equal(browserProcess.signalCode, "SIGKILL");
-    await rm(profile, { recursive: true, force: true });
+    await rm(profile, profileRemovalOptions);
     await assert.rejects(access(profile), (error) => error.code === "ENOENT");
   } finally {
     if (!exited) {
       await stopProcess(browserProcess, { terminationGraceMs: 50, forcedExitWaitMs: 2_000 });
     }
-    await rm(profile, { recursive: true, force: true });
+    await rm(profile, profileRemovalOptions);
   }
 });
 
@@ -286,6 +292,6 @@ test("browser rendering keeps Mermaid stable and mobile language access viewport
     cdp?.socket.close();
     await stopProcess(browserProcess);
     await vite.close();
-    await rm(profile, { recursive: true, force: true });
+    await rm(profile, profileRemovalOptions);
   }
 });


### PR DESCRIPTION
## Summary

- bind the current source/PDF/manifest plus tagged A4 metadata to Poppler 26.08.0 and five separate bounded captures;
- retain six nonlinear known-debt sentinels with exact diagnostic, page, class, and output checks plus atomic failure evidence;
- reject linked or replaced inputs, run Poppler only on a private exact-byte snapshot, and bind #17 to M0;
- add bounded Chromium profile cleanup backoff after the full gate exposed late child writes.

## Validation

- Focused semantic and metadata tests: 14/14 pass.
- Release suite: 35/35 pass.
- Patched Mermaid browser suite: 3/3 pass.
- Site/browser suite: 60/60 pass.
- Go tooling, policy, code-shape, prose, type, lint, documentation, source, math, translation, and PDF validation gates pass.
- The exact aggregate `npm run check` reached 723 workstation tests with 718 pass, four `ENOSPC` failures, and one intentional skip because `/tmp` was 98% full. The four failures were all writes in one unchanged fixture-026 file; no S2 workstation file differs from main.
- Re-running that exact file on a worktree-local temp filesystem passed 6/6. Re-running its dedicated fixture-026 shard passed 77/77.
- The same unchanged main commit also passed the clean GitHub fixture-026 shard before this PR.
- Real `node scripts/audit-book-pdf-semantics.mjs --evidence-dir ...` returns the expected non-zero known-debt result. Report SHA-256: `0327a7996525ecb0d34623a639cc0c52b25bc3886461c470c974d2a9d4a0027c`.
- PDF SHA-256: `aaab0416b8d648394aa5edd7cba25c629768de46cf8b1a4498aff628cd3bc745`.
- Manifest SHA-256: `77f271275a76add72a370727d05cd3655b95a504036830e0018238178fca1dfc`.
- Source digest: `24dfe4226c8b3503a78c4034ea4c38dcd8204b40e0a84b04728c551df07c2710` (170 sources, 413 A4 pages).
- Independent review found no code blocker.

## Boundary

This PR narrows slice 2 to the Poppler/source/artifact sentinel. It does not repair the six defects, capture DOM/AX, or make PDF/UA or WCAG claims. DOM/AX moves to the pinned-Chrome renderer-aware follow-up. #17 remains open.
