### PR TITLE
chore(github): map issues 20 and 21 to M0

### DIFF
--- a/.github/issue-milestones.json
+++ b/.github/issue-milestones.json
@@ -10,6 +10,8 @@
     { "issue": 12, "milestone": "M1" },
     { "issue": 13, "milestone": "M0" },
     { "issue": 14, "milestone": "M0" },
-    { "issue": 17, "milestone": "M0" }
+    { "issue": 17, "milestone": "M0" },
+    { "issue": 20, "milestone": "M0" },
+    { "issue": 21, "milestone": "M0" }
   ]
 }


### PR DESCRIPTION
## Summary

- Record issues #20 and #21 under M0 in the canonical issue-milestone manifest.
- Preserve #17 and all unrelated metadata.

## Validation

- Go metadata manifest validation passed: 33 labels, 6 milestones, 11 issue assignments.
- Git diff validation passed; the PR changes only .github/issue-milestones.json.