### PR TITLE
fix(ci): impact-scope every pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
 
 permissions: {}
@@ -52,16 +52,11 @@ jobs:
           CURRENT_SHA: ${{ github.sha }}
           EVENT_NAME: ${{ github.event_name }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          PR_DRAFT: ${{ github.event.pull_request.draft }}
         run: |
           set -euo pipefail
           mkdir -p build
-          if [[ "$EVENT_NAME" == "pull_request" && "$PR_DRAFT" == "true" ]]; then
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
             go -C tooling run ./cmd/20w ci plan --root .. \
-              --base "$BASE_SHA" --head "$HEAD_SHA" --json \
-              > build/ci-impact-plan.json
-          elif [[ "$EVENT_NAME" == "pull_request" ]]; then
-            go -C tooling run ./cmd/20w ci plan --root .. --full \
               --base "$BASE_SHA" --head "$HEAD_SHA" --json \
               > build/ci-impact-plan.json
           elif [[ "$EVENT_NAME" == "push" ]]; then
@@ -685,7 +680,7 @@ jobs:
               ;;
             impact)
               if [[ "$EVENT_NAME" != "pull_request" ]]; then
-                echo "::error::impact mode is allowed only for draft pull requests"
+                echo "::error::impact mode is allowed only for pull requests"
                 exit 1
               fi
               require_state quality-full "$RESULT_QUALITY_FULL" skipped

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,12 +71,13 @@ the exact diff; this file records why the project changed.
 - Documentation validation now treats byte-identical Mermaid bodies as staged
   source-ownership debt. The exact checked baseline may shrink through reviewed
   owner repairs, while unknown, changed, malformed, or stale groups fail closed.
-- Draft pull requests retain bounded impact-scoped feedback, while every
-  non-draft or ready pull request now runs the complete sharded matrix before
-  merge. Workstation manifest edits also select their coverage, readiness and
-  reader consumers; dependency review runs only for full pull requests or an
-  explicit dependency lane, and routine issue metadata no longer inherits the
-  full gate from a broad `.github/**` rule.
+- Every pull-request code update now uses the exact Go impact plan regardless
+  of draft state, so mapped site, prose and isolated experiment changes do not
+  execute unrelated workstation shards. Unknown, non-additive, shared and
+  selector-authority changes still expand to full CI; `main`, manual and
+  exact-tag release validation remain complete. Workstation manifests retain
+  their coverage, readiness and reader consumers, and dependency review runs
+  only for full pull requests or an explicit dependency lane.
 - The README, contribution guide and public help route now expose current
   status, roadmap stages, live milestone work, authority boundaries and focused
   entry checks before implementation detail. The portal overview leads with the

--- a/decisions/0052-impact-scope-every-pull-request.md
+++ b/decisions/0052-impact-scope-every-pull-request.md
@@ -1,0 +1,67 @@
+# 0052 — Impact-scope every pull request
+
+- **Status:** accepted
+- **Date:** 2026-08-31
+- **Partly supersedes:** [0048](0048-gate-ready-pull-requests-with-the-full-ci-matrix.md),
+  where pull-request readiness forced the full matrix
+- **Extends:** [0043](0043-impact-scope-pull-request-ci.md)
+- **Related:** [issue #7](https://github.com/lusoris/20-watts-was-enough/issues/7)
+
+## Context
+
+The ready-pull-request matrix preserved the complete pre-merge gate, but
+[run 33339407471](https://github.com/lusoris/20-watts-was-enough/actions/runs/33339407471)
+took 9 minutes 16 seconds and
+[run 33342736733](https://github.com/lusoris/20-watts-was-enough/actions/runs/33342736733)
+took 8 minutes 26 seconds. Every mapped prose, site or isolated experiment
+change paid for unrelated workstation artifacts merely because the pull
+request was ready.
+
+The Go planner already classifies exact base-to-head changes and expands every
+unknown, non-additive or authority-changing diff to the full gate. The missing
+step is to use that result for every pull-request code update. Pushes to
+`main`, manual dispatches and exact-tag releases retain their complete gates.
+
+## Decision
+
+1. Every opened, synchronised or reopened pull request derives its plan from
+   the exact base and head commits, regardless of draft state. Readiness-only
+   transitions do not rerun an identical plan.
+2. Keep the existing fail-closed expansion for selector and mapping changes,
+   shared authority, unknown or invalid paths, missing revisions, empty or
+   excessive change sets, unavailable Git diffs, renames, deletions, copies
+   and type changes.
+3. Pushes to `main` and manual dispatches remain full. The release workflow
+   keeps its separate complete exact-tag validation before it publishes fresh
+   evidence.
+4. The required `CI success` job may accept impact mode only for a pull
+   request. It must still reject every skipped selected lane, every executed
+   unselected lane and every malformed selector.
+5. Changes to the impact map, CI workflow, Go planner or strict JSON boundary
+   select the full gate. This policy change therefore cannot validate itself
+   through its narrower pull-request rule.
+6. `npm run check` remains the local merge floor. Impact CI proves only that
+   the mapped boundaries passed; it does not claim that the aggregate gate ran.
+
+## Consequences
+
+- A mapped site, prose or isolated fixture change no longer executes unrelated
+  workstation shards before merge.
+- Pull-request draft state no longer changes validation authority, so two
+  state-only workflow triggers are removed.
+- An incomplete path map costs time when a path is unknown and forces full CI.
+  Logical dependency omissions remain a review risk, which is why shared
+  sources and selector authorities stay full and representative mappings stay
+  executable policy.
+- Complete automated validation for an ordinary mapped change occurs after
+  merge on `main`, unless a maintainer runs the manual full workflow first.
+  Branch protection therefore does not by itself prove that the aggregate
+  pre-merge gate ran.
+- Issue #7 remains open for measured full-gate wall time; this decision changes
+  when that gate runs, not its assertions, shards or authority.
+
+## Supersession
+
+Supersede this record if a merge queue restores a complete pre-merge integration
+stage, pull requests return to an unconditional full gate, or the path-to-lane
+authority and its fail-closed rules change materially.

--- a/decisions/README.md
+++ b/decisions/README.md
@@ -53,7 +53,8 @@ than silently changing its outcome.
 | [0045](0045-rewrite-renderer-layer-timestamps-before-recording-image-identity.md) | Rewrite renderer layer timestamps before recording image identity | accepted |
 | [0046](0046-project-the-research-roadmap-into-github-milestones.md) | Project the research roadmap into GitHub milestones | accepted |
 | [0047](0047-keep-cloudflare-as-the-public-pages-tls-authority.md) | Keep Cloudflare as the public Pages TLS authority | accepted |
-| [0048](0048-gate-ready-pull-requests-with-the-full-ci-matrix.md) | Gate ready pull requests with the full CI matrix | accepted |
+| [0048](0048-gate-ready-pull-requests-with-the-full-ci-matrix.md) | Gate ready pull requests with the full CI matrix | accepted; readiness-based full-matrix rule partly superseded by [0052](0052-impact-scope-every-pull-request.md) |
 | [0049](0049-adopt-bounded-maintenance-automation.md) | Adopt bounded maintenance automation | accepted |
 | [0050](0050-review-the-book-and-pdf-as-one-publication.md) | Review the book and PDF as one publication | accepted |
 | [0051](0051-add-a-seventh-fixture-026-shard-after-live-timing.md) | Add a seventh Fixture 026 shard after live timing | accepted |
+| [0052](0052-impact-scope-every-pull-request.md) | Impact-scope every pull request | accepted |

--- a/docs/publication-workflow.md
+++ b/docs/publication-workflow.md
@@ -122,11 +122,12 @@ then byte-compares the complete PDF and `book-manifest.json` outputs. The
 command does not publish either render. It writes one new deterministic receipt
 under the bounded evidence or release-input directories and removes only its
 own builder names and image tags. The dedicated renderer-selected CI gate
-retains the receipt for 30 days. Ready pull requests and main pushes preserve
-their exact diff even in full mode, so this expensive proof does not run for a
-known unrelated change. Manual, unavailable, invalid, unmapped and
-selector-authority diffs select it fail-closed; non-additive diffs inspect both
-retained paths. Tagged releases always run the proof and add its
+retains the receipt for 30 days. Pull requests and `main` pushes preserve their
+exact diff, so this expensive proof does not run for a known unrelated change;
+the pull request may remain impact-scoped while the `main` plan stays full.
+Manual, unavailable, invalid, unmapped and selector-authority diffs select it
+fail-closed; non-additive diffs inspect both retained paths. Tagged releases
+always run the proof and add its
 receipt to the checksum-bound release assets. A mismatch blocks the boundary;
 the receipt remains engineering evidence and is not a scientific result.
 

--- a/experiments/workstation/README.md
+++ b/experiments/workstation/README.md
@@ -56,10 +56,12 @@ energy comparison, or claim-promotion evidence.
 
 `npm run check` remains the complete local merge floor and runs the workstation
 inventory as one serial suite. GitHub full CI separates the non-workstation
-quality gate from workstation core and a closed test matrix. Fixture 026 uses
-six fixed file-level jobs and Fixture 029 uses two; the other nine artifacts
-retain one job each. Impact plans expand only the selected artifact, while a
-full plan requires all 17 matrix entries. The eight-job concurrency cap is a
+quality gate from workstation core and a closed test matrix. Under
+[decision 0051](../../decisions/0051-add-a-seventh-fixture-026-shard-after-live-timing.md),
+Fixture 026 uses seven fixed file-level jobs and Fixture 029 uses two; the other
+nine artifacts retain one job each. Impact plans expand only the selected
+artifact, while a
+full plan requires all 18 matrix entries. The eight-job concurrency cap is a
 scheduling bound, not experiment parallelism or scientific evidence.
 
 With eight GitHub runners available, the workstation matrix is initially

--- a/scripts/engineering-policy.test.mjs
+++ b/scripts/engineering-policy.test.mjs
@@ -652,19 +652,20 @@ test("real PDF reproducibility acceptance stays in the renderer-selected and tag
 
 test("CI impact selection is projected once and every job state fails closed", () => {
   const valid = workflow("ci");
-  const planFinding = ".github/workflows/ci.yml: draft pull requests must use an exact impact diff, ready pull requests and main pushes must preserve an exact diff in full mode, and manual runs must fail closed";
+  const planFinding = ".github/workflows/ci.yml: pull requests must use an exact impact diff, main pushes must preserve an exact diff in full mode, and manual runs must fail closed";
   assert.deepEqual(validateCiImpactWorkflowObject(valid), []);
 
-  const readyBypass = structuredClone(valid);
-  const plan = readyBypass.jobs["impact-plan"].steps.find((step) => step.id === "plan");
+  const forcedPullRequestFull = structuredClone(valid);
+  const plan = forcedPullRequestFull.jobs["impact-plan"].steps.find((step) => step.id === "plan");
   plan.run = plan.run.replace(
-    'if [[ "$EVENT_NAME" == "pull_request" && "$PR_DRAFT" == "true" ]]',
-    'if [[ "$EVENT_NAME" == "pull_request" ]]',
+    "go -C tooling run ./cmd/20w ci plan --root .. \\",
+    "go -C tooling run ./cmd/20w ci plan --root .. --full \\",
   );
-  assert.ok(validateCiImpactWorkflowObject(readyBypass).includes(planFinding));
+  assert.ok(validateCiImpactWorkflowObject(forcedPullRequestFull).includes(planFinding));
 
   const ambientDraftState = structuredClone(valid);
-  delete ambientDraftState.jobs["impact-plan"].steps.find((step) => step.id === "plan").env.PR_DRAFT;
+  ambientDraftState.jobs["impact-plan"].steps.find((step) => step.id === "plan").env.PR_DRAFT
+    = "${{ github.event.pull_request.draft }}";
   assert.ok(validateCiImpactWorkflowObject(ambientDraftState).includes(planFinding));
 
   for (const mutate of [
@@ -687,13 +688,13 @@ test("CI impact selection is projected once and every job state fails closed", (
     assert.ok(validateCiImpactWorkflowObject(weakenedRouting).includes(planFinding));
   }
 
-  for (const eventType of ["ready_for_review", "converted_to_draft"]) {
-    const missingTransition = structuredClone(valid);
-    missingTransition.on.pull_request.types = missingTransition.on.pull_request.types.filter(
+  for (const eventType of ["opened", "synchronize", "reopened"]) {
+    const missingCodeUpdate = structuredClone(valid);
+    missingCodeUpdate.on.pull_request.types = missingCodeUpdate.on.pull_request.types.filter(
       (type) => type !== eventType,
     );
-    assert.ok(validateCiImpactWorkflowObject(missingTransition).includes(
-      ".github/workflows/ci.yml: CI must run on main pushes, manual dispatches, and every draft or ready pull-request transition",
+    assert.ok(validateCiImpactWorkflowObject(missingCodeUpdate).includes(
+      ".github/workflows/ci.yml: CI must run on main pushes, manual dispatches, and every pull-request code update",
     ));
   }
 

--- a/scripts/validate-engineering-policy.mjs
+++ b/scripts/validate-engineering-policy.mjs
@@ -807,17 +807,12 @@ function validateCiImpactPlanJob(jobs, relativePath, findings) {
     CURRENT_SHA: "${{ github.sha }}",
     EVENT_NAME: "${{ github.event_name }}",
     HEAD_SHA: "${{ github.event.pull_request.head.sha }}",
-    PR_DRAFT: "${{ github.event.pull_request.draft }}",
   };
   const expectedPlanSource = [
     "set -euo pipefail",
     "mkdir -p build",
-    'if [[ "$EVENT_NAME" == "pull_request" && "$PR_DRAFT" == "true" ]]; then',
+    'if [[ "$EVENT_NAME" == "pull_request" ]]; then',
     "  go -C tooling run ./cmd/20w ci plan --root .. \\",
-    '    --base "$BASE_SHA" --head "$HEAD_SHA" --json \\',
-    "    > build/ci-impact-plan.json",
-    'elif [[ "$EVENT_NAME" == "pull_request" ]]; then',
-    "  go -C tooling run ./cmd/20w ci plan --root .. --full \\",
     '    --base "$BASE_SHA" --head "$HEAD_SHA" --json \\',
     "    > build/ci-impact-plan.json",
     'elif [[ "$EVENT_NAME" == "push" ]]; then',
@@ -837,7 +832,7 @@ function validateCiImpactPlanJob(jobs, relativePath, findings) {
     Object.keys(planStep?.env ?? {}).length === Object.keys(expectedEnvironment).length
       && propertiesMatch(planStep?.env, expectedEnvironment)
       && String(planStep?.run ?? "").trim() === expectedPlanSource,
-    `${relativePath}: draft pull requests must use an exact impact diff, ready pull requests and main pushes must preserve an exact diff in full mode, and manual runs must fail closed`,
+    `${relativePath}: pull requests must use an exact impact diff, main pushes must preserve an exact diff in full mode, and manual runs must fail closed`,
   );
 }
 
@@ -1064,7 +1059,7 @@ function validateCiImpactSuccessJob(jobs, relativePath, findings) {
       'require_selection workstation-artifacts "$RESULT_WORKSTATION_ARTIFACTS" "$SELECT_WORKSTATION"',
       'require_selection container-smoke "$RESULT_CONTAINER" "$SELECT_CONTAINER"',
       'require_selection dependency-review "$RESULT_DEPENDENCY_REVIEW" "$SELECT_DEPENDENCY"',
-      'impact mode is allowed only for draft pull requests',
+      'impact mode is allowed only for pull requests',
       '"$SELECT_CONTAINER" "$SELECT_DEPENDENCY" "$SELECT_GO"',
       'full plan exposed a non-false semantic selector: $selector',
       "full plan did not expose its closed workstation matrix",
@@ -1101,12 +1096,12 @@ export function validateCiImpactWorkflowObject(
       && pullRequest.branches.length === 1
       && pullRequest.branches[0] === "main"
       && Array.isArray(pullRequest?.types)
-      && pullRequest.types.length === 5
-      && ["opened", "synchronize", "reopened", "ready_for_review", "converted_to_draft"]
+      && pullRequest.types.length === 3
+      && ["opened", "synchronize", "reopened"]
         .every((type) => pullRequest.types.includes(type))
       && Object.keys(pullRequest ?? {}).length === 2
       && Object.prototype.hasOwnProperty.call(trigger ?? {}, "workflow_dispatch"),
-    `${relativePath}: CI must run on main pushes, manual dispatches, and every draft or ready pull-request transition`,
+    `${relativePath}: CI must run on main pushes, manual dispatches, and every pull-request code update`,
   );
   const jobs = workflow?.jobs ?? {};
   validateCiImpactPlanJob(jobs, relativePath, findings);


### PR DESCRIPTION
## What changed

- derive the Go impact plan from the exact base and head for every pull-request code update, independent of draft state;
- remove readiness-only workflow triggers that reran an identical plan;
- retain fail-closed full mode for unknown, non-additive, shared, selector-authority, malformed, missing-revision and excessive diffs;
- retain complete gates for `main`, manual dispatch and exact-tag release validation;
- keep the required `CI success` aggregator strict about every selected and skipped lane;
- record decision 0052, update the publication workflow and changelog, and correct the workstation guide to decision 0051's seven Fixture 026 shards and 18 matrix entries.

The impact map and Go planner remain the single lane-selection authority. This workflow change itself selects full CI, so the new narrower rule cannot validate its own merge.

## Verification

- `npm run check` — exit 0 with exact Node 26.8.1, npm 12.0.2 and Go 1.27.0; 723 workstation tests: 722 passed, one intentional skip
- `npm run check:impact-common` — passed
- `npm run test:policy` — 52/52 passed
- `go -C tooling test -race ./internal/ciplan` and `go -C tooling vet ./internal/ciplan` — passed
- `npm run validate:tooling`, `npm run validate:docs`, and `npm run check:prose` — passed
- post-rebase planner projection — `mode=full`, `reason=selector-authority-changed`, lanes `full,renderer`
- post-rebase diff check — clean

The source-bound aggregate receipt records exit 0 and log SHA-256 `e63b064140301d5e2f9517388b2c4ff9e6ae2adf96ea88721923fc2fb2514c40`. The tested patch was then rebased as one conflict-free commit onto current `main`; the focused policy, planner, prose, documentation and diff gates were rerun after that rebase.

Refs #7. The issue remains open for measured full-gate wall-time work; this changes when the full gate runs, not its assertions or research authority.
