### PR TITLE
fix(site): contain continuous-book list reflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,10 @@ the exact diff; this file records why the project changed.
   Print hides the screen-only overflow cue and resets the diagram caption from
   sticky positioning so the caption stays with the figure before the following
   prose. The diagram's nodes, edges, labels and scientific meaning are unchanged.
+- Long entries in the continuous book's generated field-coverage lists now
+  wrap within the reading column at 320 CSS pixels while wide diagrams retain
+  their labelled local scroll regions. Browser coverage now also verifies the
+  existing action bar in a 720 CSS pixel viewport rendered at DPR 2.
 - Linked operational manifests outside the public reader-artifact allowlist
   now remain canonical GitHub-source links instead of being copied under
   hidden static paths that the Pages safety validator rejects.

--- a/app/globals.css
+++ b/app/globals.css
@@ -2012,6 +2012,10 @@ button {
   max-width: 78ch;
 }
 
+.book-prose li {
+  overflow-wrap: anywhere;
+}
+
 .book-prose h1,
 .book-prose h2,
 .book-prose h3,

--- a/public/downloads/book-manifest.json
+++ b/public/downloads/book-manifest.json
@@ -4,7 +4,7 @@
   "version": "0.3.0",
   "source_ref": "main",
   "pdf": "public/downloads/20-watts-was-enough-full-concept-book.pdf",
-  "source_digest": "730988588f176343fb67f8cf6ba43f85a28c7e8cf2a29bbc47cc4d681b794325",
+  "source_digest": "62e2e5397deeb1edf310c3e1ea7131f940eb2ed0e1d2d27ae7de9961e3ffe1dd",
   "source_files": [
     "app/book-content.ts",
     "app/components/book-edition.tsx",

--- a/scripts/book-pdf-semantic-baseline.json
+++ b/scripts/book-pdf-semantic-baseline.json
@@ -7,7 +7,7 @@
     "pdf": "public/downloads/20-watts-was-enough-full-concept-book.pdf",
     "manifest": "public/downloads/book-manifest.json",
     "pdf_sha256": "a3bd7e9fb4982e5fd63d07b301a3dfa7152b1d64dd7c744c9fcf4ceebaa422c8",
-    "manifest_sha256": "27fd723c9c28d99740322d3153e6bf8776a380dc4b2e955dd841e29001b04f10",
+    "manifest_sha256": "0ec1875803ee7bc0cf7c84c42584de871d1f8555e5022fae64cb1588802e4025",
     "size_bytes": 12780003,
     "pages": 412,
     "page_size_name": "A4",
@@ -18,7 +18,7 @@
     "pdf_version": "1.4",
     "tagged": true,
     "source_ref": "main",
-    "source_digest": "730988588f176343fb67f8cf6ba43f85a28c7e8cf2a29bbc47cc4d681b794325",
+    "source_digest": "62e2e5397deeb1edf310c3e1ea7131f940eb2ed0e1d2d27ae7de9961e3ffe1dd",
     "version": "0.3.0"
   },
   "tools": {

--- a/scripts/mermaid-browser.test.mjs
+++ b/scripts/mermaid-browser.test.mjs
@@ -115,6 +115,101 @@ const diagramSnapshotExpression = `(() => {
   };
 })()`;
 
+async function assertBookReflowSurface(cdp, address) {
+  await cdp.send("Emulation.setDeviceMetricsOverride", {
+    width: 320,
+    height: 1200,
+    deviceScaleFactor: 1,
+    mobile: true,
+  });
+  await new Promise((resolve) => setTimeout(resolve, 250));
+  const reflow = (await cdp.send("Runtime.evaluate", {
+    expression: `(() => {
+      const root = document.documentElement;
+      const fieldCoverage = document.querySelector('#book-research-field-coverage-md .book-prose');
+      const wideRegions = [...document.querySelectorAll('.diagram-wide .diagram-scroll-region')];
+      return {
+        clientWidth: root.clientWidth,
+        scrollWidth: root.scrollWidth,
+        fieldCoverage: fieldCoverage && {
+          clientWidth: fieldCoverage.clientWidth,
+          scrollWidth: fieldCoverage.scrollWidth,
+        },
+        wideRegions: wideRegions.length,
+        locallyOverflowing: wideRegions.filter(
+          (region) => region.scrollWidth > region.clientWidth + 1,
+        ).length,
+      };
+    })()`,
+    returnByValue: true,
+  })).result?.value;
+  assert.ok(reflow.fieldCoverage, JSON.stringify(reflow));
+  assert.ok(reflow.wideRegions > 0, JSON.stringify(reflow));
+  assert.equal(reflow.locallyOverflowing, reflow.wideRegions, JSON.stringify(reflow));
+  assert.ok(reflow.fieldCoverage.scrollWidth <= reflow.fieldCoverage.clientWidth, JSON.stringify(reflow));
+  assert.ok(reflow.scrollWidth <= reflow.clientWidth, JSON.stringify(reflow));
+
+  // This layout models a 1,440-device-pixel surface at DPR 2.
+  // DPR emulation alone is not a browser-zoom or text-zoom assertion.
+  await cdp.send("Emulation.setDeviceMetricsOverride", {
+    width: 720,
+    height: 600,
+    deviceScaleFactor: 2,
+    mobile: false,
+  });
+  const bookUrl = `http://127.0.0.1:${address.port}/book/`;
+  const navigation = await cdp.send("Page.navigate", { url: bookUrl });
+  assert.equal(navigation.errorText, undefined);
+  const deadline = Date.now() + 20_000;
+  let ready = false;
+  while (Date.now() < deadline) {
+    const result = await cdp.send("Runtime.evaluate", {
+      expression: `document.readyState === "complete" && document.querySelectorAll(".book-actions > *").length === 4`,
+      returnByValue: true,
+    });
+    ready = result.result?.value === true;
+    if (ready) break;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  assert.equal(ready, true, "Web-book actions did not render in the 720 CSS pixel lane");
+  const denseViewport = (await cdp.send("Runtime.evaluate", {
+    expression: `(() => {
+      const root = document.documentElement;
+      const actions = document.querySelector('.book-actions');
+      const bounds = actions?.getBoundingClientRect();
+      const controls = [...(actions?.children ?? [])].map((control) => {
+        const rect = control.getBoundingClientRect();
+        return { left: rect.left, right: rect.right };
+      });
+      return {
+        clientWidth: root.clientWidth,
+        scrollWidth: root.scrollWidth,
+        devicePixelRatio,
+        actions: bounds && { left: bounds.left, right: bounds.right },
+        controls,
+      };
+    })()`,
+    returnByValue: true,
+  })).result?.value;
+  assert.equal(denseViewport.devicePixelRatio, 2, JSON.stringify(denseViewport));
+  assert.ok(denseViewport.actions, JSON.stringify(denseViewport));
+  assert.ok(
+    denseViewport.actions.left >= 0 && denseViewport.actions.right <= denseViewport.clientWidth,
+    JSON.stringify(denseViewport),
+  );
+  assert.equal(
+    denseViewport.controls.every(
+      (control) => control.left >= 0 && control.right <= denseViewport.clientWidth,
+    ),
+    true,
+    JSON.stringify(denseViewport),
+  );
+  assert.ok(
+    denseViewport.scrollWidth <= denseViewport.clientWidth,
+    JSON.stringify(denseViewport),
+  );
+}
+
 async function assertMobilePortalSurface(cdp, address) {
   await cdp.send("Emulation.setDeviceMetricsOverride", {
     width: 375,
@@ -203,8 +298,8 @@ async function assertMobilePortalSurface(cdp, address) {
   assert.ok(snapshot.contrast.funnelIndex >= 4.5, JSON.stringify(snapshot));
 }
 
-test("browser rendering keeps Mermaid stable and mobile language access viewport-bound", {
-  timeout: 120_000,
+test("browser rendering keeps Mermaid stable and publication controls reflowing", {
+  timeout: 150_000,
 }, async () => {
   const browser = await firstExistingChromium();
   const debugPort = await reserveLocalPort();
@@ -287,6 +382,7 @@ test("browser rendering keeps Mermaid stable and mobile language access viewport
     assert.equal(stable.rendered, stable.diagrams);
     assert.deepEqual(stable.svgIds, first.svgIds, "Mermaid SVG identity changed after readiness");
 
+    await assertBookReflowSurface(cdp, address);
     await assertMobilePortalSurface(cdp, address);
   } finally {
     cdp?.socket.close();


### PR DESCRIPTION
## Summary

- contain long continuous-book list entries at a 320 CSS-pixel viewport with one book-scoped wrapping rule
- preserve all 35 wide Mermaid diagrams as labelled local scroll regions
- add browser regressions for root/list containment and the existing four-control action bar at 720 CSS pixels with DPR 2
- refresh the source-bound book manifest and semantic baseline after the combined page-27 render

The earlier diagram hypothesis was falsified: hiding the wide diagrams did not change root width. Before this patch the root was `320/371`; the first generated list was `250/336`, and a second long book list then surfaced at `x=321`. After the patch the root is `320/320`, the field-coverage list is contained, and all `35/35` wide diagram regions still overflow only locally.

DPR 2 is a high-density containment check, not browser or text zoom. The true 200% text-zoom matrix and generic duplicate-selector inventory remain open in #10.

## Verification

- exact Node 26.8.1 / Chrome for Testing 152 focused publication and browser tests: 26/26
- `npm run validate:book-pdf` (170 source files)
- exact Poppler 26.08.0 semantic recapture: five expected `known-debt` sentinels, no added or removed defect
- two renderer runs were byte-identical; the 412-page PDF remains `a3bd7e9fb4982e5fd63d07b301a3dfa7152b1d64dd7c744c9fcf4ceebaa422c8`
- full `npm run check`: 723 workstation tests (722 pass, 1 intentional skip), 61 site/browser tests, 2,437-module Pages build, 383-file site validation

Progresses #10 without closing its remaining consolidation and true-zoom work.