### PR TITLE
fix(ci): map scripts to exact consumers

### DIFF
--- a/.github/ci-impact.json
+++ b/.github/ci-impact.json
@@ -45,7 +45,32 @@
         "package-lock.json",
         "package.json",
         "requirements-ci.txt",
-        "scripts/**",
+        "scripts/AGENTS.md",
+        "scripts/audit-code-shape.mjs",
+        "scripts/audit-code-shape.test.mjs",
+        "scripts/audit-prose-style.mjs",
+        "scripts/audit-prose-style.test.mjs",
+        "scripts/audit-test-coverage.mjs",
+        "scripts/book-source.mjs",
+        "scripts/code-shape-baseline.json",
+        "scripts/engineering-policy.test.mjs",
+        "scripts/generate-book-pdf.mjs",
+        "scripts/install-locked-npm.mjs",
+        "scripts/install-locked-npm.test.mjs",
+        "scripts/lib/atomic-file-pair.mjs",
+        "scripts/lib/book-pdf-generation-options.mjs",
+        "scripts/lib/book-pdf-integrity.mjs",
+        "scripts/lib/book-renderer-identity.mjs",
+        "scripts/lib/chromium-cdp.mjs",
+        "scripts/lib/opened-file.mjs",
+        "scripts/lib/pdf-metadata.mjs",
+        "scripts/lib/portable-operations.mjs",
+        "scripts/lib/strict-json.mjs",
+        "scripts/lib/workstation-manifests.mjs",
+        "scripts/npm-runtime-lock.json",
+        "scripts/validate-engineering-policy.mjs",
+        "scripts/validate-node-runtime.mjs",
+        "scripts/validate-workstation.mjs",
         "tooling/AGENTS.md",
         "tooling/cmd/20w/**",
         "tooling/go.mod",
@@ -245,6 +270,24 @@
       ],
       "lanes": [
         "research",
+        "site"
+      ]
+    },
+    {
+      "id": "script-publication-semantic-baseline",
+      "paths": [
+        "scripts/book-pdf-semantic-baseline.json"
+      ],
+      "lanes": [
+        "release"
+      ]
+    },
+    {
+      "id": "script-site-tests",
+      "paths": [
+        "scripts/mermaid-browser.test.mjs"
+      ],
+      "lanes": [
         "site"
       ]
     },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,11 @@ the exact diff; this file records why the project changed.
   exact-tag release validation remain complete. Workstation manifests retain
   their coverage, readiness and reader consumers, and dependency review runs
   only for full pull requests or an explicit dependency lane.
+- Script impact now follows exact executable consumers instead of a blanket
+  `scripts/**` full-gate rule. The browser reader regression selects the site
+  lane and the checked PDF semantic baseline selects its release validation;
+  shared script authorities stay explicitly full, while every unclassified or
+  newly added script still expands to the full gate.
 - The README, contribution guide and public help route now expose current
   status, roadmap stages, live milestone work, authority boundaries and focused
   entry checks before implementation detail. The portal overview leads with the

--- a/decisions/0054-classify-script-impact-by-executable-consumer.md
+++ b/decisions/0054-classify-script-impact-by-executable-consumer.md
@@ -1,0 +1,56 @@
+# 0054 — Classify script impact by executable consumer
+
+- **Status:** accepted
+- **Date:** 2026-08-31
+- **Extends:** [0043](0043-impact-scope-pull-request-ci.md) and
+  [0052](0052-impact-scope-every-pull-request.md)
+- **Related:** [issue #7](https://github.com/lusoris/20-watts-was-enough/issues/7)
+
+## Context
+
+The impact map assigned every path under `scripts/` to the full gate. That was
+safe while script dependencies were unclassified, but it also meant a focused
+reader regression test ran every workstation shard. Directory ownership was
+standing in for the executable consumer.
+
+The current browser reader regression's only project-local import is the
+shared Chromium CDP helper, and the test runs in `test:site`. The checked PDF
+semantic baseline is read by the release test suite, which verifies its closed
+shape and exact PDF, manifest and book-source identities. The standalone
+Poppler capture remains a separate review tool until the locked PDF-tools image
+owns that environment.
+
+## Decision
+
+1. Remove the recursive `scripts/**` full-gate mapping. Map a script narrowly
+   only when its complete current CI consumer is known.
+2. Select `site` for `scripts/mermaid-browser.test.mjs` and `release` for
+   `scripts/book-pdf-semantic-baseline.json`.
+3. Keep shared policy, runtime, workstation, renderer and trust-boundary
+   scripts as explicit full-gate paths. Renderer-affecting paths retain the
+   independent renderer-reproducibility signal.
+4. Do not add a fallback script rule. A script omitted from the explicit map
+   is an unmapped path and therefore expands to full CI. New files cannot
+   acquire a narrow lane merely by matching a directory prefix.
+5. Keep mapping, planner, strict-JSON and CI-workflow changes inside the
+   selector-authority boundary, so this decision's own pull request runs the
+   full gate.
+
+## Consequences
+
+- A reader-only change to the browser regression runs the common checks and
+  site lane instead of unrelated workstation shards.
+- A semantic-baseline-only change runs the release tests that parse the
+  baseline and bind it to the tracked publication artifacts. It does not claim
+  that a fresh Poppler audit or PDF/UA conformance check ran.
+- Unknown and newly added scripts remain safe by costing full CI. Further lane
+  reductions require another exact dependency and consumer audit plus an
+  executable representative mapping test.
+- `main`, manual and tagged-release validation remain complete. Issue #7 stays
+  open for its separate full-gate wall-time target.
+
+## Supersession
+
+Supersede this record if CI derives script dependencies mechanically from one
+validated authority, if a merge queue replaces path-scoped pull-request
+validation, or if the fail-closed rule for unmapped paths changes.

--- a/decisions/README.md
+++ b/decisions/README.md
@@ -59,3 +59,4 @@ than silently changing its outcome.
 | [0051](0051-add-a-seventh-fixture-026-shard-after-live-timing.md) | Add a seventh Fixture 026 shard after live timing | accepted |
 | [0052](0052-impact-scope-every-pull-request.md) | Impact-scope every pull request | accepted |
 | [0053](0053-lock-the-poppler-pdf-tools-image-foundation.md) | Lock the Poppler PDF-tools image foundation | accepted |
+| [0054](0054-classify-script-impact-by-executable-consumer.md) | Classify script impact by executable consumer | accepted |

--- a/docs/publication-workflow.md
+++ b/docs/publication-workflow.md
@@ -131,6 +131,14 @@ always run the proof and add its
 receipt to the checksum-bound release assets. A mismatch blocks the boundary;
 the receipt remains engineering evidence and is not a scientific result.
 
+Script impact is classified by an exact executable consumer, not by the
+`scripts/` directory name. The browser reader regression therefore selects the
+site lane, while the checked PDF semantic baseline selects the release lane
+that reads and binds it to the tracked PDF, manifest and book source. Shared
+policy, runtime and renderer scripts remain explicit full-gate authority.
+Every other script path is deliberately unmatched and therefore expands to the
+full gate; a new file cannot inherit a narrow lane from its directory alone.
+
 The two render containers use disjoint output, work and browser-cache
 directories, but currently share that one read-only installed JavaScript
 dependency tree. Their byte comparison therefore tests deterministic rendering

--- a/tooling/internal/ciplan/mapping_test.go
+++ b/tooling/internal/ciplan/mapping_test.go
@@ -33,8 +33,11 @@ func TestRepositoryImpactMappingIsClosedAndRoutesRepresentativeChanges(t *testin
 		{path: ".github/public-transport.json", mode: "impact", lanes: []string{"go", "site"}},
 		{path: "renovate.json", mode: "impact", lanes: []string{"dependency"}},
 		{path: "package-lock.json", mode: "full", lanes: []string{"full", "renderer"}, reason: "full-authority-changed"},
+		{path: "scripts/book-pdf-semantic-baseline.json", mode: "impact", lanes: []string{"release"}},
 		{path: "scripts/generate-book-pdf.mjs", mode: "full", lanes: []string{"full", "renderer"}, reason: "full-authority-changed"},
 		{path: "scripts/audit-prose-style.mjs", mode: "full", lanes: []string{"full"}, reason: "full-authority-changed"},
+		{path: "scripts/mermaid-browser.test.mjs", mode: "impact", lanes: []string{"site"}},
+		{path: "scripts/unclassified-future-check.mjs", mode: "full", lanes: []string{"full", "renderer"}, reason: "unmapped-path:scripts/unclassified-future-check.mjs"},
 		{path: "experiments/workstation/fixture-026/runner.mjs", mode: "impact", lanes: []string{"workstation-fixture-026"}},
 		{path: "experiments/workstation/fixture-007/runner.mjs", mode: "impact", lanes: []string{"container", "workstation-fixture-007"}},
 		{path: "tooling/internal/pdfrender/render.go", mode: "impact", lanes: []string{"go", "release", "renderer", "site"}},
@@ -49,6 +52,21 @@ func TestRepositoryImpactMappingIsClosedAndRoutesRepresentativeChanges(t *testin
 			(test.reason != "" && plan.Reason != test.reason) {
 			t.Fatalf("path %s produced %#v, want %s/%v", test.path, plan, test.mode, test.lanes)
 		}
+	}
+}
+
+func TestReaderLikeDiffSelectsOnlyItsPublicationConsumers(t *testing.T) {
+	t.Parallel()
+	root := filepath.Clean(filepath.Join("..", "..", ".."))
+	plan := selectTestPaths(t, root, testOptions(root), []string{
+		"CHANGELOG.md",
+		"app/globals.css",
+		"scripts/mermaid-browser.test.mjs",
+	})
+	want := []string{"release", "renderer", "research", "site"}
+	if plan.Mode != "impact" || plan.Reason != "mapped-change-set" ||
+		!reflect.DeepEqual(plan.Lanes, want) {
+		t.Fatalf("reader-like plan = %#v, want impact/%v", plan, want)
 	}
 }
 


### PR DESCRIPTION
## What changed

- classify the PDF semantic baseline as a release-lane consumer;
- classify the Mermaid browser regression as a site-lane consumer;
- retain an explicit full-gate list for shared policy, runtime, renderer, and workstation scripts;
- fail closed to the full gate for every unmapped or newly added script path.

## Why

The repository previously treated every change under scripts/ as full authority. This keeps authority-bearing scripts conservative while allowing narrow tests and data baselines to select only the consumers that execute them.

## Validation

- full npm run check passed on the pre-rebase tree in 21m18s;
- 723 workstation tests: 722 passed, one intentional skip;
- 61 site/browser tests passed;
- Pages build: 2,437 modules and 383 validated output files;
- post-rebase ciplan race tests and vet passed;
- post-rebase engineering-policy and prose checks passed.

The full local log is retained outside Git in the worktree evidence directory with SHA-256 3f6e957f64f6bc4949a8160133aa1b51ac749e6251e32fdfdae1808aa5dc05ab.

Closes no issue. Advances #7; the issue remains open until live CI timing reaches its target window.
