### PR TITLE
feat(experiment): freeze CLRS controller shakedown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ the exact diff; this file records why the project changed.
   the deterministic final-layer design.
   Recorded base-image checks remain `NO_RESULT`; final assembly, publication
   and exact-digest CI consumption stay open behind issue 20.
+- Decision 0055 and a source-bound Go contract now freeze the CLRS-Text
+  controller shakedown to six named task families, a bounded 48-example
+  construction plan and explicit fixed-four-endpoint semantics for segment
+  intersection. The shared registry removes the controller's parallel task
+  list; no generator image, dataset, model run or scientific result is added.
 - A versioned PDF semantic sentinel now binds the current source, book, A4 and
   tag metadata, Poppler tool identity, separate structure and text streams,
   exact diagnostics, and six nonlinear content anchors. Atomic evidence keeps

--- a/decisions/0055-freeze-clrs-text-as-a-controller-shakedown.md
+++ b/decisions/0055-freeze-clrs-text-as-a-controller-shakedown.md
@@ -1,0 +1,108 @@
+# 0055 — Freeze CLRS-Text as a controller shakedown
+
+- **Status:** accepted
+- **Date:** 2026-08-31
+- **Related:** [issue #12](https://github.com/lusoris/20-watts-was-enough/issues/12)
+- **Source lock:** [`tooling/clrs-generator/upstream.json`](../tooling/clrs-generator/upstream.json)
+- **Generation contract:** [`tooling/clrs-generator/contract.json`](../tooling/clrs-generator/contract.json)
+
+## Context
+
+The typed-specialist controller needs a procedural workload before learned
+model comparisons are worth running. CLRS-Text provides textual inputs and
+exact references for classical algorithms, but those properties do not make it
+evidence that specialists beat a general model. Exact conventional programs
+remain the strongest task-specific null.
+
+The official generator and paper use thirty tasks and vary requested input
+length. Their published Gemma 2B training grid includes size 10 for each task
+selected below. Size 8 lies between published training sizes but is absent from
+each selected training list; the first integer above the published maximum is
+32 for four tasks and 11 for matrix-chain order. These labels describe the
+published grid only. They do not describe the distribution of a future project
+model.
+
+Segment intersection is different. The official sampler deletes its `length`
+argument and always samples four endpoints; the paper likewise states that its
+size parameter does not affect the prompt. Repeating several requested lengths
+would create different labels for the same size semantics.
+
+## Decision
+
+1. Use CLRS-Text only as a development shakedown for request typing, routing,
+   deadlines, cancellation, arbitration, exact verification, abstention and
+   whole-task accounting. Every contract, fixture and smoke output remains
+   `NO_RESULT`.
+2. Freeze these six task-family bindings and construction cells:
+
+   | Task | Interface family | Requested lengths and limited roles |
+   | --- | --- | --- |
+   | `insertion_sort` | sequence | 10 published-training, 8 published-interpolation, 32 published-extrapolation |
+   | `binary_search` | search | 10 published-training, 8 published-interpolation, 32 published-extrapolation |
+   | `matrix_chain_order` | dynamic programming | 10 published-training, 8 published-interpolation, 11 published-extrapolation |
+   | `bellman_ford` | graph | 10 published-training, 8 published-interpolation, 32 published-extrapolation |
+   | `kmp_matcher` | string | 10 published-training, 8 published-interpolation, 32 published-extrapolation |
+   | `segments_intersect` | geometry | one fixed-four-endpoint control requested at length 4; no length-generalisation label |
+
+3. Use the first three official validation seeds, `[3, 14, 35]`, one sample per
+   task/length/seed cell, no hints, six-decimal float truncation and the split
+   name `shakedown`. The closed plan therefore expects six JSON files and 48
+   examples. These choices minimise the controller construction set; they are
+   not a sampling or statistical-power claim.
+4. Treat [`contract.json`](../tooling/clrs-generator/contract.json) and its
+   source-bound Go identity
+   `sha256:cc14fce405e8fa7d4719f1fc906e28d5e4b73235085c8f0722795efded2891a8`
+   as the fixture-selection authority. The Go validator rejects reordered,
+   missing, renamed or expanded tasks, changed size roles, seeds, semantics,
+   output counts or byte bounds. Its machine state remains
+   `blocked_on_generator_image`.
+5. Keep generation separate from the controller. A later decision or bounded
+   implementation must pin and exercise a dataset-generator OCI image before
+   it may emit fixture bytes. That image may contain the upstream Python
+   generator; the controller and released `20w` binary remain Go and consume
+   only the neutral, strictly validated JSON boundary. Generation runs without
+   network access and within the contract's file, example and byte caps. The
+   future image boundary must also enforce cancellation, a wall-clock timeout
+   and descendant-process cleanup because the upstream segment sampler uses
+   rejection sampling without an internal attempt cap.
+6. Do not download or generate the dataset in this foundation change. A
+   generator image, generated-byte digests, exact Go programs, learned
+   candidates, comparators, run identity, resource receipt, energy boundary
+   and confirmation protocol remain absent. The later import bridge must bind
+   every file and candidate record to the complete generation-contract identity
+   before it may expose fixture bytes.
+7. Defer the numerical meaning of *small* until named model candidates,
+   hardware opportunity, a quality floor and the whole-task energy boundary
+   can be frozen together.
+
+## Source, licence and disclosure
+
+The source lock was rechecked against the official
+[`google-deepmind/clrs`](https://github.com/google-deepmind/clrs/tree/d33c3cfc765a18950194205a1ddb92a0981a355e)
+commit. It binds the commit, tree, Apache-2.0 `LICENSE`, generator and
+requirements bytes by digest. No upstream dataset or source body is copied
+into this repository. The task and size rationale was checked against the
+official generator and the
+[CLRS-Text paper, version 1](https://arxiv.org/abs/2406.04229v1).
+
+OpenAI Codex was materially used on 2026-08-31 for official-source inspection,
+drafting, implementation and automated checks under maintainer direction. It
+is not an author or accountable approver. No independent scientific, legal or
+security review is claimed, and no model or dataset execution occurred.
+
+## Consequences
+
+- The controller policy and fixture-planning package now share one six-task Go
+  registry instead of maintaining parallel task lists.
+- A contract identity can be reproduced without Python, network access or
+  generated fixtures. It establishes construction provenance only.
+- Segment intersection can test the fixed geometry route and verifier, but it
+  cannot support a length-generalisation statement.
+- Any change to task membership or the frozen generation cells requires a
+  superseding decision and a new contract identity.
+
+## Supersession
+
+Supersede this record if CLRS-Text is replaced, a selected family changes, the
+generation grid or fixed-segment treatment changes, or this development suite
+is admitted into a separately frozen claim-eligible protocol.

--- a/decisions/README.md
+++ b/decisions/README.md
@@ -60,3 +60,4 @@ than silently changing its outcome.
 | [0052](0052-impact-scope-every-pull-request.md) | Impact-scope every pull request | accepted |
 | [0053](0053-lock-the-poppler-pdf-tools-image-foundation.md) | Lock the Poppler PDF-tools image foundation | accepted |
 | [0054](0054-classify-script-impact-by-executable-consumer.md) | Classify script impact by executable consumer | accepted |
+| [0055](0055-freeze-clrs-text-as-a-controller-shakedown.md) | Freeze CLRS-Text as a controller shakedown | accepted |

--- a/tooling/clrs-generator/contract.json
+++ b/tooling/clrs-generator/contract.json
@@ -1,0 +1,82 @@
+{
+  "schema_version": 1,
+  "authority": "NO_RESULT",
+  "purpose": "controller_shakedown",
+  "issue": "https://github.com/lusoris/20-watts-was-enough/issues/12",
+  "source_id": "sha256:7ec3b6b7528d04f517c4e9b7c3e0cd0f7034a775d225d469d1aca5c00fec10d1",
+  "generation_state": "blocked_on_generator_image",
+  "split_name": "shakedown",
+  "samples_per_cell": 1,
+  "use_hints": false,
+  "num_decimals_in_float": 6,
+  "seeds": [3, 14, 35],
+  "tasks": [
+    {
+      "task": "insertion_sort",
+      "family": "sequence",
+      "length_semantics": "declared_length",
+      "sizes": [
+        {"role": "published_training_size", "requested_length": 10},
+        {"role": "published_interpolation_probe", "requested_length": 8},
+        {"role": "published_extrapolation_probe", "requested_length": 32}
+      ]
+    },
+    {
+      "task": "binary_search",
+      "family": "search",
+      "length_semantics": "declared_length",
+      "sizes": [
+        {"role": "published_training_size", "requested_length": 10},
+        {"role": "published_interpolation_probe", "requested_length": 8},
+        {"role": "published_extrapolation_probe", "requested_length": 32}
+      ]
+    },
+    {
+      "task": "matrix_chain_order",
+      "family": "dynamic_programming",
+      "length_semantics": "declared_length",
+      "sizes": [
+        {"role": "published_training_size", "requested_length": 10},
+        {"role": "published_interpolation_probe", "requested_length": 8},
+        {"role": "published_extrapolation_probe", "requested_length": 11}
+      ]
+    },
+    {
+      "task": "bellman_ford",
+      "family": "graph",
+      "length_semantics": "declared_length",
+      "sizes": [
+        {"role": "published_training_size", "requested_length": 10},
+        {"role": "published_interpolation_probe", "requested_length": 8},
+        {"role": "published_extrapolation_probe", "requested_length": 32}
+      ]
+    },
+    {
+      "task": "kmp_matcher",
+      "family": "string",
+      "length_semantics": "declared_length",
+      "sizes": [
+        {"role": "published_training_size", "requested_length": 10},
+        {"role": "published_interpolation_probe", "requested_length": 8},
+        {"role": "published_extrapolation_probe", "requested_length": 32}
+      ]
+    },
+    {
+      "task": "segments_intersect",
+      "family": "geometry",
+      "length_semantics": "fixed_four_endpoints",
+      "sizes": [
+        {"role": "fixed_geometry_control", "requested_length": 4}
+      ]
+    }
+  ],
+  "output": {
+    "expected_files": 6,
+    "expected_examples": 48,
+    "max_dataset_bytes": 4194304,
+    "max_total_bytes": 25165824,
+    "max_prompt_bytes": 1048576,
+    "max_reference_bytes": 1048576,
+    "max_requested_length": 32
+  }
+}

--- a/tooling/internal/clrsfixture/contract.go
+++ b/tooling/internal/clrsfixture/contract.go
@@ -1,0 +1,364 @@
+package clrsfixture
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"path"
+)
+
+const (
+	generationContractSchemaVersion = 1
+	maximumGenerationContractBytes  = 32 << 10
+	generationPurpose               = "controller_shakedown"
+	generationIssue                 = "https://github.com/lusoris/20-watts-was-enough/issues/12"
+	generationSplit                 = "shakedown"
+	generationState                 = "blocked_on_generator_image"
+)
+
+// TaskKind is one algorithm admitted to the six-family controller shakedown.
+type TaskKind string
+
+const (
+	TaskInsertionSort     TaskKind = "insertion_sort"
+	TaskBinarySearch      TaskKind = "binary_search"
+	TaskMatrixChainOrder  TaskKind = "matrix_chain_order"
+	TaskBellmanFord       TaskKind = "bellman_ford"
+	TaskKMPMatcher        TaskKind = "kmp_matcher"
+	TaskSegmentsIntersect TaskKind = "segments_intersect"
+)
+
+// TaskFamily records the interface family represented by one selected task.
+type TaskFamily string
+
+const (
+	FamilySequence           TaskFamily = "sequence"
+	FamilySearch             TaskFamily = "search"
+	FamilyDynamicProgramming TaskFamily = "dynamic_programming"
+	FamilyGraph              TaskFamily = "graph"
+	FamilyString             TaskFamily = "string"
+	FamilyGeometry           TaskFamily = "geometry"
+)
+
+// SizeRole labels sizes relative to the published CLRS-Text Gemma 2B grid.
+// It does not describe the distribution of a future project model.
+type SizeRole string
+
+const (
+	SizePublishedTrain         SizeRole = "published_training_size"
+	SizePublishedInterpolation SizeRole = "published_interpolation_probe"
+	SizePublishedExtrapolation SizeRole = "published_extrapolation_probe"
+	SizeFixedGeometryControl   SizeRole = "fixed_geometry_control"
+)
+
+// SizeSelection is one requested generator length and its limited role.
+type SizeSelection struct {
+	Role            SizeRole `json:"role"`
+	RequestedLength int64    `json:"requested_length"`
+}
+
+// GenerationTask freezes one task, family, size semantics and size selection.
+type GenerationTask struct {
+	Task            TaskKind        `json:"task"`
+	Family          TaskFamily      `json:"family"`
+	LengthSemantics LengthSemantics `json:"length_semantics"`
+	Sizes           []SizeSelection `json:"sizes"`
+}
+
+// GenerationOutput bounds the complete generated construction fixture set.
+type GenerationOutput struct {
+	ExpectedFiles      int   `json:"expected_files"`
+	ExpectedExamples   int   `json:"expected_examples"`
+	MaxDatasetBytes    int64 `json:"max_dataset_bytes"`
+	MaxTotalBytes      int64 `json:"max_total_bytes"`
+	MaxPromptBytes     int   `json:"max_prompt_bytes"`
+	MaxReferenceBytes  int   `json:"max_reference_bytes"`
+	MaxRequestedLength int64 `json:"max_requested_length"`
+}
+
+// GenerationContract is the closed, non-executable CLRS-Text fixture plan.
+// A separately pinned generator image is required before any bytes are made.
+type GenerationContract struct {
+	SchemaVersion      int              `json:"schema_version"`
+	Authority          string           `json:"authority"`
+	Purpose            string           `json:"purpose"`
+	Issue              string           `json:"issue"`
+	SourceID           string           `json:"source_id"`
+	GenerationState    string           `json:"generation_state"`
+	SplitName          string           `json:"split_name"`
+	SamplesPerCell     int              `json:"samples_per_cell"`
+	UseHints           bool             `json:"use_hints"`
+	NumDecimalsInFloat int              `json:"num_decimals_in_float"`
+	Seeds              []int64          `json:"seeds"`
+	Tasks              []GenerationTask `json:"tasks"`
+	Output             GenerationOutput `json:"output"`
+}
+
+// TaskPlan is the deterministic, candidate-independent projection for one file.
+type TaskPlan struct {
+	Task               TaskKind
+	Family             TaskFamily
+	LengthSemantics    LengthSemantics
+	Sizes              []SizeSelection
+	OutputRelativePath string
+	ExpectedExamples   int
+}
+
+// GenerationPlan is a pure projection; it does not invoke the Python generator.
+type GenerationPlan struct {
+	Authority          string
+	SourceID           SourceID
+	ContractID         ContractID
+	GenerationState    string
+	SplitName          string
+	SamplesPerCell     int
+	UseHints           bool
+	NumDecimalsInFloat int
+	Seeds              []int64
+	Tasks              []TaskPlan
+	Output             GenerationOutput
+}
+
+type taskDefinition struct {
+	task      TaskKind
+	family    TaskFamily
+	semantics LengthSemantics
+	sizes     []SizeSelection
+}
+
+var shakedownTaskDefinitions = []taskDefinition{
+	{TaskInsertionSort, FamilySequence, LengthDeclaredInput, scalableSizes(32)},
+	{TaskBinarySearch, FamilySearch, LengthDeclaredInput, scalableSizes(32)},
+	{TaskMatrixChainOrder, FamilyDynamicProgramming, LengthDeclaredInput, scalableSizes(11)},
+	{TaskBellmanFord, FamilyGraph, LengthDeclaredInput, scalableSizes(32)},
+	{TaskKMPMatcher, FamilyString, LengthDeclaredInput, scalableSizes(32)},
+	{TaskSegmentsIntersect, FamilyGeometry, LengthFixedFourEndpoints, []SizeSelection{{Role: SizeFixedGeometryControl, RequestedLength: 4}}},
+}
+
+// ShakedownTasks returns the single task registry shared by fixtures and policy.
+func ShakedownTasks() []TaskKind {
+	tasks := make([]TaskKind, len(shakedownTaskDefinitions))
+	for index, definition := range shakedownTaskDefinitions {
+		tasks[index] = definition.task
+	}
+	return tasks
+}
+
+// ReadGenerationContract reads and validates one bounded contract.
+func ReadGenerationContract(reader io.Reader, source SourceRecord) (GenerationContract, error) {
+	body, err := readBounded(reader, maximumGenerationContractBytes)
+	if err != nil {
+		return GenerationContract{}, fmt.Errorf("read CLRS generation contract: %w", err)
+	}
+	return ParseGenerationContract(body, source)
+}
+
+// ParseGenerationContract validates one complete contract without network use.
+func ParseGenerationContract(body []byte, source SourceRecord) (GenerationContract, error) {
+	if len(body) == 0 || len(body) > maximumGenerationContractBytes {
+		return GenerationContract{}, fmt.Errorf("CLRS generation contract size = %d, want 1..%d", len(body), maximumGenerationContractBytes)
+	}
+	var contract GenerationContract
+	if err := decodeStrict(body, 7, &contract); err != nil {
+		return GenerationContract{}, fmt.Errorf("parse CLRS generation contract: %w", err)
+	}
+	if err := contract.Validate(source); err != nil {
+		return GenerationContract{}, err
+	}
+	return contract, nil
+}
+
+// Validate rejects a contract that drifts from the accepted shakedown scope.
+func (contract GenerationContract) Validate(source SourceRecord) error {
+	sourceID, err := source.Identity()
+	if err != nil {
+		return fmt.Errorf("validate CLRS generation source: %w", err)
+	}
+	if err := contract.validateHeader(sourceID); err != nil {
+		return err
+	}
+	if err := validateSeeds(contract.Seeds); err != nil {
+		return err
+	}
+	if err := validateTasks(contract.Tasks); err != nil {
+		return err
+	}
+	return contract.validateOutput()
+}
+
+// Identity binds the validated contract to the exact upstream source record.
+func (contract GenerationContract) Identity(source SourceRecord) (ContractID, error) {
+	if err := contract.Validate(source); err != nil {
+		return ContractID{}, err
+	}
+	sourceID, err := source.Identity()
+	if err != nil {
+		return ContractID{}, fmt.Errorf("identify CLRS generation source: %w", err)
+	}
+	builder := newIdentityBuilder("20w/clrs-generation-contract/v1")
+	builder.addBytes(sourceID[:])
+	addContractHeader(&builder, contract)
+	for _, seed := range contract.Seeds {
+		builder.addInt64(seed)
+	}
+	for _, task := range contract.Tasks {
+		builder.addString(string(task.Task))
+		builder.addString(string(task.Family))
+		builder.addString(string(task.LengthSemantics))
+		for _, size := range task.Sizes {
+			builder.addString(string(size.Role))
+			builder.addInt64(size.RequestedLength)
+		}
+	}
+	addOutputIdentity(&builder, contract.Output)
+	return ContractID(builder.sum()), nil
+}
+
+// Plan returns a deep-copied deterministic projection of the frozen contract.
+func (contract GenerationContract) Plan(source SourceRecord) (GenerationPlan, error) {
+	contractID, err := contract.Identity(source)
+	if err != nil {
+		return GenerationPlan{}, err
+	}
+	sourceID, err := source.Identity()
+	if err != nil {
+		return GenerationPlan{}, fmt.Errorf("identify CLRS generation source: %w", err)
+	}
+	plan := GenerationPlan{
+		Authority:          ResultAuthority,
+		SourceID:           sourceID,
+		ContractID:         contractID,
+		GenerationState:    contract.GenerationState,
+		SplitName:          contract.SplitName,
+		SamplesPerCell:     contract.SamplesPerCell,
+		UseHints:           contract.UseHints,
+		NumDecimalsInFloat: contract.NumDecimalsInFloat,
+		Seeds:              append([]int64(nil), contract.Seeds...),
+		Tasks:              make([]TaskPlan, 0, len(contract.Tasks)),
+		Output:             contract.Output,
+	}
+	for _, task := range contract.Tasks {
+		sizes := append([]SizeSelection(nil), task.Sizes...)
+		plan.Tasks = append(plan.Tasks, TaskPlan{
+			Task:               task.Task,
+			Family:             task.Family,
+			LengthSemantics:    task.LengthSemantics,
+			Sizes:              sizes,
+			OutputRelativePath: path.Join(contract.SplitName, string(task.Task)+".json"),
+			ExpectedExamples:   len(sizes) * len(contract.Seeds) * contract.SamplesPerCell,
+		})
+	}
+	return plan, nil
+}
+
+func (contract GenerationContract) validateHeader(sourceID SourceID) error {
+	if contract.SchemaVersion != generationContractSchemaVersion {
+		return fmt.Errorf("CLRS generation schema = %d, want %d", contract.SchemaVersion, generationContractSchemaVersion)
+	}
+	if contract.Authority != ResultAuthority || contract.Purpose != generationPurpose || contract.Issue != generationIssue {
+		return errors.New("CLRS generation authority, purpose, or issue binding is invalid")
+	}
+	if contract.SourceID != sourceID.String() {
+		return fmt.Errorf("CLRS generation source = %q, want %q", contract.SourceID, sourceID.String())
+	}
+	if contract.GenerationState != generationState || contract.SplitName != generationSplit ||
+		contract.SamplesPerCell != 1 || contract.UseHints || contract.NumDecimalsInFloat != 6 {
+		return errors.New("CLRS generation parameters differ from the accepted bounded shakedown")
+	}
+	return nil
+}
+
+func validateSeeds(seeds []int64) error {
+	if len(seeds) != 3 {
+		return fmt.Errorf("CLRS generation seed count = %d, want 3", len(seeds))
+	}
+	expected := [...]int64{3, 14, 35}
+	for index, seed := range seeds {
+		if seed != expected[index] || seed < math.MinInt32 || seed > math.MaxInt32 {
+			return fmt.Errorf("CLRS generation seeds = %v, want %v", seeds, expected)
+		}
+	}
+	return nil
+}
+
+func validateTasks(tasks []GenerationTask) error {
+	if len(tasks) != len(shakedownTaskDefinitions) {
+		return fmt.Errorf("CLRS generation task count = %d, want %d", len(tasks), len(shakedownTaskDefinitions))
+	}
+	for index, expected := range shakedownTaskDefinitions {
+		actual := tasks[index]
+		if actual.Task != expected.task || actual.Family != expected.family || actual.LengthSemantics != expected.semantics {
+			return fmt.Errorf("CLRS generation task %d = %q/%q/%q, want accepted family binding", index, actual.Task, actual.Family, actual.LengthSemantics)
+		}
+		if !equalSizes(actual.Sizes, expected.sizes) {
+			return fmt.Errorf("CLRS generation sizes for %s = %v, want %v", actual.Task, actual.Sizes, expected.sizes)
+		}
+	}
+	return nil
+}
+
+func (contract GenerationContract) validateOutput() error {
+	expectedExamples := 0
+	maxLength := int64(0)
+	for _, task := range contract.Tasks {
+		expectedExamples += len(task.Sizes) * len(contract.Seeds) * contract.SamplesPerCell
+		for _, size := range task.Sizes {
+			if size.RequestedLength > maxLength {
+				maxLength = size.RequestedLength
+			}
+		}
+	}
+	output := contract.Output
+	if output.ExpectedFiles != len(contract.Tasks) || output.ExpectedExamples != expectedExamples || output.MaxRequestedLength != maxLength {
+		return errors.New("CLRS generation output counts do not match the selected cells")
+	}
+	if output.MaxDatasetBytes != 4<<20 || output.MaxTotalBytes != int64(output.ExpectedFiles)*output.MaxDatasetBytes {
+		return errors.New("CLRS generation dataset and total byte bounds differ from the accepted contract")
+	}
+	if output.MaxPromptBytes != 1<<20 || output.MaxReferenceBytes != 1<<20 {
+		return errors.New("CLRS generation example byte bounds differ from the accepted contract")
+	}
+	return nil
+}
+
+func scalableSizes(extrapolation int64) []SizeSelection {
+	return []SizeSelection{
+		{Role: SizePublishedTrain, RequestedLength: 10},
+		{Role: SizePublishedInterpolation, RequestedLength: 8},
+		{Role: SizePublishedExtrapolation, RequestedLength: extrapolation},
+	}
+}
+
+func equalSizes(left, right []SizeSelection) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}
+
+func addContractHeader(builder *identityBuilder, contract GenerationContract) {
+	for _, value := range []string{
+		contract.Authority, contract.Purpose, contract.Issue, contract.SourceID,
+		contract.GenerationState, contract.SplitName,
+	} {
+		builder.addString(value)
+	}
+	builder.addInt64(int64(contract.SamplesPerCell))
+	builder.addBool(contract.UseHints)
+	builder.addInt64(int64(contract.NumDecimalsInFloat))
+}
+
+func addOutputIdentity(builder *identityBuilder, output GenerationOutput) {
+	for _, value := range []int64{
+		int64(output.ExpectedFiles), int64(output.ExpectedExamples), output.MaxDatasetBytes,
+		output.MaxTotalBytes, int64(output.MaxPromptBytes), int64(output.MaxReferenceBytes), output.MaxRequestedLength,
+	} {
+		builder.addInt64(value)
+	}
+}

--- a/tooling/internal/clrsfixture/contract_test.go
+++ b/tooling/internal/clrsfixture/contract_test.go
@@ -1,0 +1,170 @@
+package clrsfixture
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+const expectedContractIdentity = "sha256:cc14fce405e8fa7d4719f1fc906e28d5e4b73235085c8f0722795efded2891a8"
+
+func TestTrackedGenerationContractBindsClosedShakedown(t *testing.T) {
+	t.Parallel()
+	source := trackedSourceRecord(t)
+	contract := trackedGenerationContract(t, source)
+	identity, err := contract.Identity(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if identity.String() != expectedContractIdentity {
+		t.Fatalf("generation identity = %s, want %s", identity, expectedContractIdentity)
+	}
+	if contract.Authority != ResultAuthority || contract.Output.ExpectedFiles != 6 || contract.Output.ExpectedExamples != 48 {
+		t.Fatalf("generation authority/counts = %q/%d/%d", contract.Authority, contract.Output.ExpectedFiles, contract.Output.ExpectedExamples)
+	}
+	if got := ShakedownTasks(); !reflect.DeepEqual(got, []TaskKind{
+		TaskInsertionSort,
+		TaskBinarySearch,
+		TaskMatrixChainOrder,
+		TaskBellmanFord,
+		TaskKMPMatcher,
+		TaskSegmentsIntersect,
+	}) {
+		t.Fatalf("shakedown tasks = %v", got)
+	}
+}
+
+func TestGenerationPlanIsDeterministicAndDefensive(t *testing.T) {
+	t.Parallel()
+	source := trackedSourceRecord(t)
+	contract := trackedGenerationContract(t, source)
+	first, err := contract.Plan(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := contract.Plan(source)
+	if err != nil || !reflect.DeepEqual(first, second) {
+		t.Fatalf("same generation contract produced different plans: %v", err)
+	}
+	if first.Authority != ResultAuthority || first.ContractID.String() != expectedContractIdentity || len(first.Tasks) != 6 {
+		t.Fatalf("plan identity = %#v", first)
+	}
+	if first.GenerationState != generationState {
+		t.Fatalf("generation state = %q, want %q", first.GenerationState, generationState)
+	}
+	expectedExamples := []int{9, 9, 9, 9, 9, 3}
+	for index, task := range first.Tasks {
+		if task.ExpectedExamples != expectedExamples[index] || task.OutputRelativePath != generationSplit+"/"+string(task.Task)+".json" {
+			t.Fatalf("task plan %d = %#v", index, task)
+		}
+	}
+	first.Seeds[0] = 99
+	first.Tasks[0].Sizes[0].Role = SizeFixedGeometryControl
+	first.Tasks[0].Sizes[0].RequestedLength = 99
+	third, err := contract.Plan(source)
+	if err != nil || third.Seeds[0] != 3 || third.Tasks[0].Sizes[0] != (SizeSelection{Role: SizePublishedTrain, RequestedLength: 10}) {
+		t.Fatalf("caller mutation escaped plan copy: %#v, %v", third, err)
+	}
+}
+
+func TestParseGenerationContractRejectsScopeDrift(t *testing.T) {
+	t.Parallel()
+	source := trackedSourceRecord(t)
+	valid := string(trackedGenerationContractBytes(t))
+	tests := map[string]string{
+		"duplicate":            strings.Replace(valid, `"authority": "NO_RESULT"`, `"authority": "NO_RESULT", "authority": "NO_RESULT"`, 1),
+		"unknown":              strings.Replace(valid, `"schema_version": 1`, `"schema_version": 1, "extra": true`, 1),
+		"trailing":             valid + `{}`,
+		"wrong authority":      strings.Replace(valid, `"NO_RESULT"`, `"RESULT"`, 1),
+		"wrong source":         strings.Replace(valid, contractSourceIdentity(t), "sha256:"+strings.Repeat("a", 64), 1),
+		"unblocked generation": strings.Replace(valid, generationState, "ready", 1),
+		"wrong purpose":        strings.Replace(valid, generationPurpose, "benchmark", 1),
+		"wrong issue":          strings.Replace(valid, "/issues/12", "/issues/13", 1),
+		"wrong split":          strings.Replace(valid, generationSplit, "train", 1),
+		"hints enabled":        strings.Replace(valid, `"use_hints": false`, `"use_hints": true`, 1),
+		"float drift":          strings.Replace(valid, `"num_decimals_in_float": 6`, `"num_decimals_in_float": 5`, 1),
+		"seed drift":           strings.Replace(valid, `[3, 14, 35]`, `[3, 14, 36]`, 1),
+		"task order drift":     strings.Replace(valid, `"task": "insertion_sort"`, `"task": "binary_search"`, 1),
+		"family drift":         strings.Replace(valid, `"family": "sequence"`, `"family": "graph"`, 1),
+		"semantics drift":      strings.Replace(valid, `"length_semantics": "fixed_four_endpoints"`, `"length_semantics": "declared_length"`, 1),
+		"size role drift":      strings.Replace(valid, `"published_training_size"`, `"fixed_geometry_control"`, 1),
+		"size value drift":     strings.Replace(valid, `"requested_length": 32`, `"requested_length": 31`, 1),
+		"example count drift":  strings.Replace(valid, `"expected_examples": 48`, `"expected_examples": 47`, 1),
+		"byte bound drift":     strings.Replace(valid, `"max_total_bytes": 25165824`, `"max_total_bytes": 1`, 1),
+	}
+	for name, body := range tests {
+		name, body := name, body
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := ParseGenerationContract([]byte(body), source); err == nil {
+				t.Fatalf("ParseGenerationContract accepted %s", name)
+			}
+		})
+	}
+	changedSource := source
+	changedSource.InspectedOn = "2026-08-31"
+	if _, err := ParseGenerationContract([]byte(valid), changedSource); err == nil {
+		t.Fatal("ParseGenerationContract accepted a different valid source identity")
+	}
+}
+
+func TestReadGenerationContractEnforcesReaderBound(t *testing.T) {
+	t.Parallel()
+	source := trackedSourceRecord(t)
+	oversized := bytes.NewReader(bytes.Repeat([]byte{' '}, maximumGenerationContractBytes+1))
+	if _, err := ReadGenerationContract(oversized, source); err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("ReadGenerationContract oversized error = %v", err)
+	}
+	if _, err := ReadGenerationContract(nil, source); err == nil || !strings.Contains(err.Error(), "nil") {
+		t.Fatalf("ReadGenerationContract nil error = %v", err)
+	}
+	if _, err := ParseGenerationContract([]byte{0xff, '{', '}'}, source); err == nil {
+		t.Fatal("ParseGenerationContract accepted invalid UTF-8")
+	}
+}
+
+func trackedGenerationContract(t *testing.T, source SourceRecord) GenerationContract {
+	t.Helper()
+	contract, err := ParseGenerationContract(trackedGenerationContractBytes(t), source)
+	if err != nil {
+		t.Fatalf("parse tracked generation contract: %v", err)
+	}
+	return contract
+}
+
+func trackedGenerationContractBytes(t *testing.T) []byte {
+	t.Helper()
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("locate generation contract test")
+	}
+	body, err := os.ReadFile(filepath.Join(filepath.Dir(filename), "..", "..", "clrs-generator", "contract.json"))
+	if err != nil {
+		t.Fatalf("read tracked generation contract: %v", err)
+	}
+	return body
+}
+
+func contractSourceIdentity(t *testing.T) string {
+	t.Helper()
+	id, err := trackedSourceRecord(t).Identity()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return id.String()
+}
+
+func FuzzParseGenerationContract(f *testing.F) {
+	f.Add([]byte(`{"schema_version":1}`))
+	f.Add([]byte(`{"authority":"NO_RESULT","authority":"RESULT"}`))
+	f.Fuzz(func(t *testing.T, body []byte) {
+		if len(body) > maximumGenerationContractBytes+1 {
+			return
+		}
+		_, _ = ParseGenerationContract(body, trackedSourceRecord(t))
+	})
+}

--- a/tooling/internal/clrsfixture/identity.go
+++ b/tooling/internal/clrsfixture/identity.go
@@ -10,6 +10,9 @@ import (
 // SourceID binds one validated upstream source record.
 type SourceID [sha256.Size]byte
 
+// ContractID binds one validated generation contract to its exact source.
+type ContractID [sha256.Size]byte
+
 // CandidateID binds candidate-visible input without incorporating its answer.
 type CandidateID [sha256.Size]byte
 
@@ -17,6 +20,10 @@ type CandidateID [sha256.Size]byte
 type VerifierID [sha256.Size]byte
 
 func (id SourceID) String() string {
+	return "sha256:" + hex.EncodeToString(id[:])
+}
+
+func (id ContractID) String() string {
 	return "sha256:" + hex.EncodeToString(id[:])
 }
 

--- a/tooling/internal/specialistcontrol/policy.go
+++ b/tooling/internal/specialistcontrol/policy.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"sort"
 	"time"
+
+	"github.com/lusoris/20-watts-was-enough/tooling/internal/clrsfixture"
 )
 
 const (
@@ -18,25 +20,18 @@ const (
 )
 
 // TaskKind is one accepted CLRS-Text development-shakedown task family.
-type TaskKind string
+type TaskKind = clrsfixture.TaskKind
 
 const (
-	TaskInsertionSort     TaskKind = "insertion_sort"
-	TaskBinarySearch      TaskKind = "binary_search"
-	TaskMatrixChainOrder  TaskKind = "matrix_chain_order"
-	TaskBellmanFord       TaskKind = "bellman_ford"
-	TaskKMPMatcher        TaskKind = "kmp_matcher"
-	TaskSegmentsIntersect TaskKind = "segments_intersect"
+	TaskInsertionSort     = clrsfixture.TaskInsertionSort
+	TaskBinarySearch      = clrsfixture.TaskBinarySearch
+	TaskMatrixChainOrder  = clrsfixture.TaskMatrixChainOrder
+	TaskBellmanFord       = clrsfixture.TaskBellmanFord
+	TaskKMPMatcher        = clrsfixture.TaskKMPMatcher
+	TaskSegmentsIntersect = clrsfixture.TaskSegmentsIntersect
 )
 
-var taskKinds = []TaskKind{
-	TaskInsertionSort,
-	TaskBinarySearch,
-	TaskMatrixChainOrder,
-	TaskBellmanFord,
-	TaskKMPMatcher,
-	TaskSegmentsIntersect,
-}
+var taskKinds = clrsfixture.ShakedownTasks()
 
 // Limits are caller-owned development bounds. They are not model, dataset, or
 // claim thresholds.


### PR DESCRIPTION
## Outcome

Freezes the CLRS-Text development shakedown to six algorithm families and a bounded 48-example construction plan. The contract remains `NO_RESULT` and blocked on a separately pinned generator image; this PR downloads or generates no dataset and runs no model.

It also makes the fixture package the single Go task registry consumed by the specialist controller.

Closes no issue; advances #12.

## Verification

- `npm run check` (723 tests; 722 pass; 1 intentional skip; 61 browser/site checks; 383 Pages files)
- `go -C tooling test -race ./internal/clrsfixture ./internal/specialistcontrol`
- `go -C tooling vet ./internal/clrsfixture ./internal/specialistcontrol`
- `npm run validate:policy`
- `npm run check:prose`
- `git diff --check`