### PR TITLE
feat(translation): add read-only candidate preflight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,10 +54,12 @@ the exact diff; this file records why the project changed.
   prior-art record preserves the useful external skill patterns without runtime
   instruction fetching, taste scores or automatic humanising.
 - The Go command now exports deterministic, source-bound translation candidate
-  bundles and imports returned drafts into candidate-only working artifacts.
-  The provider-neutral exchange preserves glossary choices, drafting-tool
-  disclosure and language/domain review metadata, rejects stale English source,
-  and cannot write to the reviewed translation tree or publication manifest.
+  bundles, validates returned bundles without writing, and imports structurally
+  valid drafts into candidate-only working artifacts. The provider-neutral
+  exchange preserves glossary choices, drafting-tool disclosure and
+  language/domain review metadata, rejects stale English source, and cannot
+  write to the reviewed translation tree or publication manifest. Structural
+  validation does not assess translation quality or grant publication authority.
 - Pull-request CI now derives a bounded Go impact plan from the exact base and
   head commits, then runs a common gate plus only the selected Go, release,
   research, site, container, and workstation lanes. Workstation artifacts use

--- a/public/downloads/book-manifest.json
+++ b/public/downloads/book-manifest.json
@@ -4,7 +4,7 @@
   "version": "0.3.0",
   "source_ref": "main",
   "pdf": "public/downloads/20-watts-was-enough-full-concept-book.pdf",
-  "source_digest": "ffb9b0131dbb7e50c7518bd95700cfbf055d379b3c13ee12fcdb00c0dbacd7ef",
+  "source_digest": "dc9fbe445d11fbbc3313719c3bc7608a32a9d66fd58a182b25d1506240e11cfa",
   "source_files": [
     "app/book-content.ts",
     "app/components/book-edition.tsx",

--- a/scripts/book-pdf-semantic-baseline.json
+++ b/scripts/book-pdf-semantic-baseline.json
@@ -7,7 +7,7 @@
     "pdf": "public/downloads/20-watts-was-enough-full-concept-book.pdf",
     "manifest": "public/downloads/book-manifest.json",
     "pdf_sha256": "a3bd7e9fb4982e5fd63d07b301a3dfa7152b1d64dd7c744c9fcf4ceebaa422c8",
-    "manifest_sha256": "51db1b35c64e1962e458a7ac2da94b320a09b646d77b96743c67a454b8d56b93",
+    "manifest_sha256": "c3d050425ab7e41e187099e0cfbb37146aaf4c8921057a48091780b46277447f",
     "size_bytes": 12780003,
     "pages": 412,
     "page_size_name": "A4",
@@ -18,7 +18,7 @@
     "pdf_version": "1.4",
     "tagged": true,
     "source_ref": "main",
-    "source_digest": "ffb9b0131dbb7e50c7518bd95700cfbf055d379b3c13ee12fcdb00c0dbacd7ef",
+    "source_digest": "dc9fbe445d11fbbc3313719c3bc7608a32a9d66fd58a182b25d1506240e11cfa",
     "version": "0.3.0"
   },
   "tools": {

--- a/tooling/cmd/20w/main.go
+++ b/tooling/cmd/20w/main.go
@@ -53,6 +53,7 @@ func usage(writer io.Writer) {
 	fmt.Fprintln(writer, "  20w publication verify-pdf-reproducibility --receipt <new.json> [--root <repository>] [--ref main|vMAJOR.MINOR.PATCH]")
 	fmt.Fprintln(writer, "  20w publication verify-public-transport [--root <repository>] [--check]")
 	fmt.Fprintln(writer, "  20w translation export-candidate --source <concept-or-math.md> --language <code> --output <new.json> [--root <repository>]")
+	fmt.Fprintln(writer, "  20w translation validate-candidate --input <candidate.json> --source <concept-or-math.md> --language <code> [--root <repository>]")
 	fmt.Fprintln(writer, "  20w translation import-candidate --input <candidate.json> --source <concept-or-math.md> --language <code> --output <new-directory> [--root <repository>]")
 	fmt.Fprintln(writer, "  20w github sync-metadata [--root <repository>] [--check | --repository <owner/name>]")
 	fmt.Fprintln(writer, "  20w github sync-labels [--root <repository>] [--check | --repository <owner/name>]")
@@ -138,6 +139,9 @@ func run(arguments []string, stdout, stderr io.Writer) int {
 	case "translation":
 		if len(arguments) >= 2 && arguments[1] == "export-candidate" {
 			return runTranslationExportCandidate(arguments[2:], stdout, stderr)
+		}
+		if len(arguments) >= 2 && arguments[1] == "validate-candidate" {
+			return runTranslationValidateCandidate(arguments[2:], stdout, stderr)
 		}
 		if len(arguments) >= 2 && arguments[1] == "import-candidate" {
 			return runTranslationImportCandidate(arguments[2:], stdout, stderr)

--- a/tooling/cmd/20w/translation.go
+++ b/tooling/cmd/20w/translation.go
@@ -39,6 +39,42 @@ func runTranslationExportCandidate(arguments []string, stdout, stderr io.Writer)
 	return 0
 }
 
+func runTranslationValidateCandidate(arguments []string, stdout, stderr io.Writer) int {
+	flags := flag.NewFlagSet("translation validate-candidate", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	root := flags.String("root", ".", "repository root")
+	input := flags.String("input", "", "returned candidate JSON path")
+	source := flags.String("source", "", "expected canonical concept/math Markdown path")
+	language := flags.String("language", "", "expected non-English two-letter target language")
+	if err := flags.Parse(arguments); err != nil || flags.NArg() != 0 || *input == "" || *source == "" || *language == "" {
+		fmt.Fprintln(stderr, "translation validate-candidate requires --input, --source and --language")
+		return 2
+	}
+	result, err := translationbundle.ValidateCandidate(translationbundle.ValidateOptions{
+		RepositoryRoot:         *root,
+		InputPath:              *input,
+		ExpectedSourcePath:     *source,
+		ExpectedTargetLanguage: *language,
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "Validate translation candidate: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(
+		stdout,
+		"Validated source-bound candidate bundle sha256:%s: %s (source sha256:%s) for %s (target sha256:%s, drafting %s, review %s, %d unresolved glossary terms). No files were written; translation quality was not assessed and this is not publication authority.\n",
+		result.BundleSHA256,
+		result.SourcePath,
+		result.SourceSHA256,
+		result.TargetLanguage,
+		result.TargetSHA256,
+		result.DraftingMode,
+		result.ReviewStatus,
+		result.UnresolvedGlossary,
+	)
+	return 0
+}
+
 func runTranslationImportCandidate(arguments []string, stdout, stderr io.Writer) int {
 	flags := flag.NewFlagSet("translation import-candidate", flag.ContinueOnError)
 	flags.SetOutput(stderr)

--- a/tooling/cmd/20w/translation_test.go
+++ b/tooling/cmd/20w/translation_test.go
@@ -2,16 +2,20 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/lusoris/20-watts-was-enough/tooling/internal/translationbundle"
 )
 
 func TestRunTranslationCandidateCommandsRequireClosedArguments(t *testing.T) {
 	t.Parallel()
 	for _, arguments := range [][]string{
 		{"translation", "export-candidate", "--language", "de"},
+		{"translation", "validate-candidate", "--input", "candidate.json"},
 		{"translation", "import-candidate", "--input", "candidate.json"},
 	} {
 		var stdout bytes.Buffer
@@ -19,6 +23,70 @@ func TestRunTranslationCandidateCommandsRequireClosedArguments(t *testing.T) {
 		if exitCode := run(arguments, &stdout, &stderr); exitCode != 2 || !strings.Contains(stderr.String(), "requires") {
 			t.Fatalf("run(%v) exit/stderr = %d/%q, want usage refusal", arguments, exitCode, stderr.String())
 		}
+	}
+}
+
+func TestRunTranslationValidateCandidateWritesNothingAndClaimsNoQuality(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	source := filepath.Join(root, "concept", "00-test.md")
+	if err := os.MkdirAll(filepath.Dir(source), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(source, []byte("# Source\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	registry := filepath.Join(root, "translations", "eu-languages.json")
+	if err := os.MkdirAll(filepath.Dir(registry), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	registryBody, err := os.ReadFile(filepath.Join("..", "..", "..", "translations", "eu-languages.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(registry, registryBody, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	input := filepath.Join(t.TempDir(), "candidate.json")
+	bundle, err := translationbundle.ExportCandidate(translationbundle.ExportOptions{
+		RepositoryRoot: root,
+		SourcePath:     "concept/00-test.md",
+		TargetLanguage: "de",
+		OutputPath:     input,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	bundle.Target.Markdown = "# Quelle\n"
+	bundle.Drafting = translationbundle.Drafting{
+		Mode: "human-only", Tools: []translationbundle.DraftingTool{}, Notes: "",
+	}
+	body, err := json.MarshalIndent(bundle, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body = append(body, '\n')
+	if err := os.WriteFile(input, body, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := run([]string{
+		"translation", "validate-candidate",
+		"--root", root,
+		"--input", input,
+		"--source", "concept/00-test.md",
+		"--language", "de",
+	}, &stdout, &stderr)
+	if exitCode != 0 || !strings.Contains(stdout.String(), "No files were written") ||
+		!strings.Contains(stdout.String(), "translation quality was not assessed") {
+		t.Fatalf("run() exit/stdout/stderr = %d/%q/%q", exitCode, stdout.String(), stderr.String())
+	}
+	if _, err := os.Lstat(filepath.Join(root, ".workingdir2")); !os.IsNotExist(err) {
+		t.Fatalf("validate command created candidate output: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(root, "translations", "manifest.json")); !os.IsNotExist(err) {
+		t.Fatalf("validate command touched translation authority: %v", err)
 	}
 }
 

--- a/tooling/internal/translationbundle/bundle_test.go
+++ b/tooling/internal/translationbundle/bundle_test.go
@@ -109,6 +109,53 @@ func TestExportCandidateIsDeterministicAndSourceBound(t *testing.T) {
 	}
 }
 
+func TestValidateCandidateIsReadOnlyAndSourceBound(t *testing.T) {
+	t.Parallel()
+	const expectedSourceSHA256 = "b3f391a23f372aad83e72b09020b9dedc5eee6b9daffb2d176db6c752f9d7da0"
+	const expectedTargetSHA256 = "7e6cd71ee235c247db46c1d1247760afa0677395d351694800d44c61ab5637c1"
+	root := repositoryFixture(t)
+	input := returnedFixture(t, root, func(bundle *Bundle) {
+		bundle.Glossary = []GlossaryEntry{{
+			Source: "evidence status", Target: "", Status: "unresolved", Note: "Awaiting German domain review.",
+		}}
+		bundle.Drafting = Drafting{
+			Mode: "machine-assisted",
+			Tools: []DraftingTool{{
+				Name: "example-translator", Version: "sha256:fixture", Purpose: "first-pass wording",
+			}},
+			Notes: "No quality decision recorded.",
+		}
+	})
+	inputBefore, err := os.ReadFile(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := ValidateCandidate(ValidateOptions{
+		RepositoryRoot:         root,
+		InputPath:              input,
+		ExpectedSourcePath:     fixtureSourcePath,
+		ExpectedTargetLanguage: "de",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.BundleSHA256 != digest(inputBefore) || result.SourcePath != fixtureSourcePath || result.SourceSHA256 != expectedSourceSHA256 || result.TargetLanguage != "de" ||
+		result.TargetSHA256 != expectedTargetSHA256 || result.UnresolvedGlossary != 1 || result.DraftingMode != "machine-assisted" ||
+		result.ReviewStatus != "unreviewed" {
+		t.Fatalf("ValidateCandidate() = %#v", result)
+	}
+	inputAfter, err := os.ReadFile(input)
+	if err != nil || !bytes.Equal(inputBefore, inputAfter) {
+		t.Fatalf("read-only validation changed input: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(root, ".workingdir2")); !os.IsNotExist(err) {
+		t.Fatalf("read-only validation created candidate output: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(root, "translations", "manifest.json")); !os.IsNotExist(err) {
+		t.Fatalf("read-only validation touched translation authority: %v", err)
+	}
+}
+
 func TestImportCandidatePreservesDisclosureAndNeverWritesPublicationAuthority(t *testing.T) {
 	t.Parallel()
 	root := repositoryFixture(t)
@@ -149,6 +196,28 @@ func TestImportCandidatePreservesDisclosureAndNeverWritesPublicationAuthority(t 
 	}
 	if _, err := os.Lstat(filepath.Join(root, "translations", "manifest.json")); !os.IsNotExist(err) {
 		t.Fatalf("candidate import touched translation authority: %v", err)
+	}
+}
+
+func TestValidateCandidateRejectsStaleSource(t *testing.T) {
+	t.Parallel()
+	root := repositoryFixture(t)
+	input := returnedFixture(t, root, nil)
+	if err := os.WriteFile(
+		filepath.Join(root, filepath.FromSlash(fixtureSourcePath)),
+		[]byte("# Changed source\n"),
+		0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+	_, err := ValidateCandidate(ValidateOptions{
+		RepositoryRoot:         root,
+		InputPath:              input,
+		ExpectedSourcePath:     fixtureSourcePath,
+		ExpectedTargetLanguage: "de",
+	})
+	if err == nil || !strings.Contains(err.Error(), "stale") {
+		t.Fatalf("ValidateCandidate() error = %v, want stale-source refusal", err)
 	}
 }
 

--- a/tooling/internal/translationbundle/files.go
+++ b/tooling/internal/translationbundle/files.go
@@ -33,6 +33,32 @@ type ImportOptions struct {
 	OutputDirectory        string
 }
 
+// ValidateOptions selects one returned bundle and its expected canonical identity.
+type ValidateOptions struct {
+	RepositoryRoot         string
+	InputPath              string
+	ExpectedSourcePath     string
+	ExpectedTargetLanguage string
+}
+
+// ValidationResult reports the checked identities without granting publication authority.
+type ValidationResult struct {
+	BundleSHA256       string
+	SourcePath         string
+	SourceSHA256       string
+	TargetLanguage     string
+	TargetSHA256       string
+	UnresolvedGlossary int
+	DraftingMode       string
+	ReviewStatus       string
+}
+
+type validatedCandidate struct {
+	root   string
+	bundle Bundle
+	body   []byte
+}
+
 // ImportResult reports exact candidate artifact identities.
 type ImportResult struct {
 	MarkdownPath       string
@@ -80,53 +106,48 @@ func ExportCandidate(options ExportOptions) (Bundle, error) {
 	return bundle, nil
 }
 
-// ImportCandidate validates a returned bundle against current Git source and
+// ValidateCandidate checks a returned bundle against current canonical source without
+// writing candidate artifacts or changing translation publication authority.
+func ValidateCandidate(options ValidateOptions) (ValidationResult, error) {
+	candidate, err := validateReturnedCandidate(options)
+	if err != nil {
+		return ValidationResult{}, err
+	}
+	return ValidationResult{
+		BundleSHA256:       digest(candidate.body),
+		SourcePath:         candidate.bundle.Source.Path,
+		SourceSHA256:       candidate.bundle.Source.SHA256,
+		TargetLanguage:     candidate.bundle.Target.Language,
+		TargetSHA256:       digest([]byte(candidate.bundle.Target.Markdown)),
+		UnresolvedGlossary: countUnresolvedGlossary(candidate.bundle.Glossary),
+		DraftingMode:       candidate.bundle.Drafting.Mode,
+		ReviewStatus:       candidate.bundle.Review.Status,
+	}, nil
+}
+
+// ImportCandidate validates a returned bundle against current canonical source and
 // writes only candidate-marked artifacts. It never edits translations/ or its manifest.
 func ImportCandidate(options ImportOptions) (ImportResult, error) {
-	root, err := resolveRepositoryRoot(options.RepositoryRoot)
+	validation := ValidateOptions{
+		RepositoryRoot:         options.RepositoryRoot,
+		InputPath:              options.InputPath,
+		ExpectedSourcePath:     options.ExpectedSourcePath,
+		ExpectedTargetLanguage: options.ExpectedTargetLanguage,
+	}
+	candidate, err := validateReturnedCandidate(validation)
 	if err != nil {
 		return ImportResult{}, err
 	}
-	languages, err := loadOfficialTargetLanguages(root)
-	if err != nil {
-		return ImportResult{}, err
-	}
-	if !sourcePathPattern.MatchString(options.ExpectedSourcePath) {
-		return ImportResult{}, errors.New("expected translation source must be canonical concept/math Markdown")
-	}
-	if err := requireOfficialTargetLanguage(languages, options.ExpectedTargetLanguage); err != nil {
-		return ImportResult{}, err
-	}
-	body, err := readStableRegularFile(options.InputPath, maximumBundleBytes)
-	if err != nil {
-		return ImportResult{}, fmt.Errorf("read returned candidate bundle: %w", err)
-	}
-	bundle, err := decodeBundle(body)
-	if err != nil {
-		return ImportResult{}, err
-	}
-	if err := validateBundle(bundle, true); err != nil {
-		return ImportResult{}, fmt.Errorf("validate returned candidate bundle: %w", err)
-	}
-	if err := requireOfficialTargetLanguage(languages, bundle.Target.Language); err != nil {
-		return ImportResult{}, err
-	}
-	if bundle.Source.Path != options.ExpectedSourcePath || bundle.Target.Language != options.ExpectedTargetLanguage {
-		return ImportResult{}, errors.New("returned candidate does not match the expected source path and target language")
-	}
-	if err := bindCurrentSource(root, bundle.Source); err != nil {
-		return ImportResult{}, err
-	}
-	receipt, unresolved := candidateReceipt(bundle, body)
+	receipt, unresolved := candidateReceipt(candidate.bundle, candidate.body)
 	receiptBody, err := encodeJSON(receipt)
 	if err != nil {
 		return ImportResult{}, fmt.Errorf("encode candidate receipt: %w", err)
 	}
-	output, err := safeCandidateOutput(root, options.OutputDirectory)
+	output, err := safeCandidateOutput(candidate.root, options.OutputDirectory)
 	if err != nil {
 		return ImportResult{}, err
 	}
-	markdownPath, receiptPath, err := writeCandidateDirectory(output, []byte(bundle.Target.Markdown), receiptBody)
+	markdownPath, receiptPath, err := writeCandidateDirectory(output, []byte(candidate.bundle.Target.Markdown), receiptBody)
 	if err != nil {
 		return ImportResult{}, err
 	}
@@ -136,6 +157,44 @@ func ImportCandidate(options ImportOptions) (ImportResult, error) {
 		TargetSHA256:       receipt.Target.SHA256,
 		UnresolvedGlossary: unresolved,
 	}, nil
+}
+
+func validateReturnedCandidate(options ValidateOptions) (validatedCandidate, error) {
+	root, err := resolveRepositoryRoot(options.RepositoryRoot)
+	if err != nil {
+		return validatedCandidate{}, err
+	}
+	languages, err := loadOfficialTargetLanguages(root)
+	if err != nil {
+		return validatedCandidate{}, err
+	}
+	if !sourcePathPattern.MatchString(options.ExpectedSourcePath) {
+		return validatedCandidate{}, errors.New("expected translation source must be canonical concept/math Markdown")
+	}
+	if err := requireOfficialTargetLanguage(languages, options.ExpectedTargetLanguage); err != nil {
+		return validatedCandidate{}, err
+	}
+	body, err := readStableRegularFile(options.InputPath, maximumBundleBytes)
+	if err != nil {
+		return validatedCandidate{}, fmt.Errorf("read returned candidate bundle: %w", err)
+	}
+	bundle, err := decodeBundle(body)
+	if err != nil {
+		return validatedCandidate{}, err
+	}
+	if err := validateBundle(bundle, true); err != nil {
+		return validatedCandidate{}, fmt.Errorf("validate returned candidate bundle: %w", err)
+	}
+	if err := requireOfficialTargetLanguage(languages, bundle.Target.Language); err != nil {
+		return validatedCandidate{}, err
+	}
+	if bundle.Source.Path != options.ExpectedSourcePath || bundle.Target.Language != options.ExpectedTargetLanguage {
+		return validatedCandidate{}, errors.New("returned candidate does not match the expected source path and target language")
+	}
+	if err := bindCurrentSource(root, bundle.Source); err != nil {
+		return validatedCandidate{}, err
+	}
+	return validatedCandidate{root: root, bundle: bundle, body: body}, nil
 }
 
 func bindCurrentSource(root string, source Source) error {
@@ -151,12 +210,7 @@ func bindCurrentSource(root string, source Source) error {
 }
 
 func candidateReceipt(bundle Bundle, body []byte) (Receipt, int) {
-	unresolved := 0
-	for _, entry := range bundle.Glossary {
-		if entry.Status == "unresolved" {
-			unresolved++
-		}
-	}
+	unresolved := countUnresolvedGlossary(bundle.Glossary)
 	return Receipt{
 		Schema:       1,
 		Authority:    candidateAuthorityLabel,
@@ -174,6 +228,16 @@ func candidateReceipt(bundle Bundle, body []byte) (Receipt, int) {
 		Drafting: bundle.Drafting,
 		Review:   bundle.Review,
 	}, unresolved
+}
+
+func countUnresolvedGlossary(entries []GlossaryEntry) int {
+	unresolved := 0
+	for _, entry := range entries {
+		if entry.Status == "unresolved" {
+			unresolved++
+		}
+	}
+	return unresolved
 }
 
 func encodeJSON(value any) ([]byte, error) {

--- a/translations/README.md
+++ b/translations/README.md
@@ -57,6 +57,21 @@ each material tool, version or dated service identity, and purpose. Glossary
 entries are either `unresolved` with an empty target or `preferred` with the
 wording a reviewer should check.
 
+Check a returned bundle before creating any candidate artifact:
+
+```bash
+go -C tooling run ./cmd/20w translation validate-candidate \
+  --root .. \
+  --input ../.workingdir2/cache/translation-candidates/de-thesis.json \
+  --source concept/00-thesis-and-principles.md \
+  --language de
+```
+
+This read-only preflight rejects a stale or altered English source, unexpected
+path or language, ambiguous metadata and missing drafting disclosure. It does
+not assess the German wording, record a human review or grant publication
+authority.
+
 Import the returned bundle into a new candidate directory:
 
 ```bash
@@ -74,15 +89,16 @@ malformed reviewer/glossary metadata, symlinks, oversized files and an existing
 output. Repository-local output is allowed only under
 `.workingdir2/cache/translation-candidates/`. The result is named
 `candidate-not-for-publication.md` and its receipt says
-`candidate-only-not-publication-authority`; neither command writes beneath the
-public `translations/` tree or changes `manifest.json`.
+`candidate-only-not-publication-authority`; none of the candidate commands
+writes beneath the public `translations/` tree or changes `manifest.json`.
 
 The candidate boundary deliberately uses canonical path, embedded bytes and
 SHA-256 rather than requiring a `.git` directory. This permits work from a
-tagged source archive or release checkout. Import also requires the operator to
-repeat the expected source path and language, then compares the bundle with the
-current local source. The later pull request and reviewed manifest supply the
-Git revision and publication authority; the digest alone does not claim that a
+tagged source archive or release checkout. Validation and import both require
+the operator to repeat the expected source path and language, then compare the
+bundle with the current local source. The later pull request and reviewed
+manifest supply the Git revision and publication authority; the digest alone
+does not claim that a
 candidate came from `main`.
 
 After a competent human has checked meaning, terminology, negation,


### PR DESCRIPTION
# Pull request

## Summary

- Add `20w translation validate-candidate`, a provider-neutral, read-only
  preflight that reuses the import path's strict returned-bundle validation and
  reports exact bundle, source, and target SHA-256 identities plus disclosure,
  review-status, and unresolved-glossary metadata.
- Reject stale canonical source, unexpected source/language identity, closed-
  schema violations, symlinks, oversized inputs, and incomplete drafting
  disclosure without creating candidate artifacts or touching reviewed
  translation/publication authority.
- Test the no-write and stale-source boundaries, pin the exact expected source
  and target fixture digests, document the preflight-only workflow, and refresh
  the source-bound book manifest/semantic identity. The English PDF bytes are
  unchanged.

Relates to #13. This does not run the German bakeoff or supply its glossary.

## Research traceability

- **Claim IDs:** none; this is structural maintenance tooling, not a research claim.
- **Principle bundles:** none; no mechanism or principle is proposed.
- **Experiment or fixture IDs:** none; issue #13 remains prospective and no model/provider run occurred.
- **Evidence and result authority:** `NO_RESULT`; structural candidate preflight only, with no translation-quality or publication authority.
- **Contributors and accountable approver:** OpenAI Codex implemented and validated the patch; maintainer PR review remains the accountable approval. Not a claim-eligible output.
- **Funding, material support, and competing interests:** none known; not applicable to this tooling-only change.
- **Material AI, automation, or external services:** OpenAI Codex assisted code, tests, documentation, and review on 2026-08-31. Exact Go, Node 26.8.1, npm 12.0.2, Chrome for Testing 152.0.7977.64, and Poppler 26.08.0 checks were retained for maintainer verification. No translation model or provider was invoked.
- **Ethics, rights, safety, misuse, and data-plan triggers:** no trigger; no participant data, model weights, provider text, or translated content was acquired, generated, or published.
- **Intended reader:** translation contributors and repository maintainers preparing a future candidate exchange.
- **Domain-accuracy review:** no scientific meaning or German wording changed; the patch validates transport structure and canonical source identity only.
- **Curious-reader review:** reader-editor pass confirmed that the README and CLI output distinguish structural validation from German quality, human review, and publication.

## Checklist

- [x] I separated source observation, proposed translation, and project hypothesis where applicable.
- [x] New or changed empirical claims have stable `C-` IDs, scoped evidence status, primary sources, and explicit boundary conditions.
- [x] New mechanisms were checked against existing `P-` bundles and the strongest ordinary engineering null.
- [x] Imported, quoted, adapted, or generated material has provenance and a recorded reuse basis; public availability or citation alone was not treated as permission to copy.
- [x] Smoke, construction, development, and specification-only work remains `NO_RESULT`; no result or authority was promoted without an eligible run.
- [x] Quantitative statements define symbols, units, assumptions, uncertainty, and the measured system boundary.
- [x] Contributor credit, support, conflicts, and material tool use are disclosed at the authority this change claims.
- [x] Triggered ethics, misuse, collaboration, and research-object stewardship requirements were satisfied before the affected work began.
- [x] Editable sources and affected generated artifacts, indexes, plots, book files, or manifests were updated together.
- [x] A changed `Scope` gives its intended reader an entry ramp; acronyms and project terms are explained before they carry the argument.
- [x] I ran the relevant validation commands and list them below.

## Validation

```text
go -C tooling test -race -count=1 ./internal/translationbundle ./cmd/20w
  passed
go -C tooling vet ./internal/translationbundle ./cmd/20w
  passed
npm run validate:translations
  passed; 0 reviewed translations
npm run check:prose
  passed
npm run test:release
  passed; 35/35
npm run generate:book-pdf
  passed twice before and after rebase under the locked renderer; each run rendered twice identically
npm run validate:book-pdf
  passed; 170 source files
node scripts/audit-book-pdf-semantics.mjs --evidence-dir .workingdir2/evidence/design/2026-08-31-translation-preflight-post-rebase-semantic-final
  expected known-debt exit 1; exact existing five nonlinear sentinels and 14 Em + 613 Strong diagnostics; no PDF/UA or WCAG claim
pdfinfo -struct public/downloads/20-watts-was-enough-full-concept-book.pdf
  exit 0; exact baseline diagnostics above
pdftoppm/pdftotext pages 1, 4, 22, 35, 377, 386, 412
  visual and reading-order sample inspected; no new blank, clip, overlap, crop, or off-page defect; post-rebase PNGs byte-identical
env PATH=/tmp/20wtn.TQ12nd:... CHROME_PATH=/tmp/20w-reader-reflow-cache.TjGO1Y/cache/pinned-chrome-152/chrome-linux64/chrome TMPDIR=/tmp/20wtg.TjNHg2 npm run check
  passed before the independent mechanical main rebase; workstation 723 tests, 722 pass, 1 explicit skip, 0 fail; final Pages validation passed
git diff --check
  passed after rebase and amend
```

Per maintainer direction, the full workstation aggregate was not repeated after
rebasing the validated slice onto independent main changes. The locked
source-bound render, race/vet, translation, release, PDF, semantic, visual, and
diff checks above were repeated on the final commit instead.
