### PR TITLE
feat(experiment): bind CLRS imports to generation contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ the exact diff; this file records why the project changed.
   construction plan and explicit fixed-four-endpoint semantics for segment
   intersection. The shared registry removes the controller's parallel task
   list; no generator image, dataset, model run or scientific result is added.
+- The CLRS-Text importer now admits only the exact task files and length/seed
+  cells selected by that source-bound generation contract. Candidate and held-
+  reference records carry versioned source-and-contract identities, remain
+  separated, and must pass deterministic pairing validation before controller
+  use. No dataset is generated or executed; every record remains `NO_RESULT`.
 - A versioned PDF semantic sentinel now binds the current source, book, A4 and
   tag metadata, Poppler tool identity, separate structure and text streams,
   exact diagnostics, and six nonlinear content anchors. Atomic evidence keeps

--- a/tooling/internal/clrsfixture/import.go
+++ b/tooling/internal/clrsfixture/import.go
@@ -24,7 +24,8 @@ const (
 	LengthFixedFourEndpoints LengthSemantics = "fixed_four_endpoints"
 )
 
-// ImportLimits are safety caps, not selected experiment sizes or sample counts.
+// ImportLimits are caller safety caps. The generation contract can only narrow
+// them; it cannot enlarge them.
 type ImportLimits struct {
 	MaxDatasetBytes   int64
 	MaxExamples       int
@@ -39,7 +40,9 @@ type CandidateExample struct {
 	ID                 CandidateID
 	Authority          string
 	Source             SourceID
-	Task               string
+	Contract           ContractID
+	OutputRelativePath string
+	Task               TaskKind
 	Ordinal            uint64
 	Prompt             string
 	LengthSemantics    LengthSemantics
@@ -54,26 +57,40 @@ type VerifierExample struct {
 	ID          VerifierID
 	Authority   string
 	Source      SourceID
+	Contract    ContractID
 	CandidateID CandidateID
 	Reference   string
 }
 
 // CandidateSet contains only values safe to send across a candidate seam.
 type CandidateSet struct {
-	Authority       string
-	Source          SourceID
-	DatasetName     string
-	Task            string
-	LengthSemantics LengthSemantics
-	Examples        []CandidateExample
+	Authority          string
+	Source             SourceID
+	Contract           ContractID
+	OutputRelativePath string
+	DatasetName        string
+	Task               TaskKind
+	LengthSemantics    LengthSemantics
+	Examples           []CandidateExample
 }
 
 // VerifierSet contains the exact answers for a separate verifier boundary.
 type VerifierSet struct {
-	Authority   string
-	Source      SourceID
-	DatasetName string
-	Examples    []VerifierExample
+	Authority          string
+	Source             SourceID
+	Contract           ContractID
+	OutputRelativePath string
+	DatasetName        string
+	Task               TaskKind
+	LengthSemantics    LengthSemantics
+	Examples           []VerifierExample
+}
+
+// PairedExample is returned only after both separated records have been
+// validated against their source-bound generation contract.
+type PairedExample struct {
+	Candidate CandidateExample
+	Verifier  VerifierExample
 }
 
 type upstreamDataset struct {
@@ -102,25 +119,48 @@ type checkedExample struct {
 	useHints        bool
 }
 
-// ImportDataset splits one exact upstream JSON file into candidate and verifier
-// views. It does not select tasks, lengths, seeds, splits, or sample counts.
+type contractScope struct {
+	sourceID   SourceID
+	contractID ContractID
+	plan       GenerationPlan
+	task       TaskPlan
+}
+
+type importScope struct {
+	contractScope
+	maxDatasetBytes   int64
+	maxPromptBytes    int
+	maxReferenceBytes int
+	maxDeclaredLength int64
+}
+
+type cellKey struct {
+	length int64
+	seed   int64
+}
+
+type cellCounter struct {
+	allowed map[cellKey]int
+	seen    map[cellKey]int
+	task    TaskPlan
+	plan    GenerationPlan
+}
+
+// ImportDataset splits the one exact task file selected by outputRelativePath
+// into candidate and verifier views. Task, length, seed, hint, and sample-count
+// authority comes only from the validated generation contract.
 func ImportDataset(
 	reader io.Reader,
 	source SourceRecord,
-	semantics LengthSemantics,
+	contract GenerationContract,
+	outputRelativePath string,
 	limits ImportLimits,
 ) (CandidateSet, VerifierSet, error) {
-	if err := limits.Validate(); err != nil {
+	scope, err := newImportScope(source, contract, outputRelativePath, limits)
+	if err != nil {
 		return CandidateSet{}, VerifierSet{}, err
 	}
-	sourceID, err := source.Identity()
-	if err != nil {
-		return CandidateSet{}, VerifierSet{}, fmt.Errorf("validate CLRS import source: %w", err)
-	}
-	if !validLengthSemantics(semantics) {
-		return CandidateSet{}, VerifierSet{}, fmt.Errorf("unsupported CLRS length semantics %q", semantics)
-	}
-	body, err := readBounded(reader, limits.MaxDatasetBytes)
+	body, err := readBounded(reader, scope.maxDatasetBytes)
 	if err != nil {
 		return CandidateSet{}, VerifierSet{}, fmt.Errorf("read CLRS dataset: %w", err)
 	}
@@ -128,26 +168,109 @@ func ImportDataset(
 	if err := decodeStrict(body, 5, &dataset); err != nil {
 		return CandidateSet{}, VerifierSet{}, fmt.Errorf("parse CLRS dataset: %w", err)
 	}
-	task, err := validateDatasetName(dataset.Name)
-	if err != nil {
-		return CandidateSet{}, VerifierSet{}, err
+	expectedName := datasetName(scope.task.Task)
+	if dataset.Name != expectedName {
+		return CandidateSet{}, VerifierSet{}, fmt.Errorf("CLRS dataset name = %q, want %q for %s", dataset.Name, expectedName, outputRelativePath)
 	}
-	if len(dataset.Examples) == 0 || len(dataset.Examples) > limits.MaxExamples {
-		return CandidateSet{}, VerifierSet{}, fmt.Errorf("CLRS example count = %d, want 1..%d", len(dataset.Examples), limits.MaxExamples)
+	if len(dataset.Examples) != scope.task.ExpectedExamples {
+		return CandidateSet{}, VerifierSet{}, fmt.Errorf(
+			"CLRS example count = %d, want exactly %d for %s",
+			len(dataset.Examples), scope.task.ExpectedExamples, outputRelativePath,
+		)
 	}
-	candidates := newCandidateSet(sourceID, dataset.Name, task, semantics, len(dataset.Examples))
-	verifiers := newVerifierSet(sourceID, dataset.Name, len(dataset.Examples))
+
+	candidates := newCandidateSet(scope.contractScope, dataset.Name, len(dataset.Examples))
+	verifiers := newVerifierSet(scope.contractScope, dataset.Name, len(dataset.Examples))
+	cells := newCellCounter(scope.contractScope)
 	for index, raw := range dataset.Examples {
-		checked, checkErr := checkExample(raw, task, semantics, limits)
+		checked, checkErr := checkUpstreamExample(raw, scope)
 		if checkErr != nil {
 			return CandidateSet{}, VerifierSet{}, fmt.Errorf("validate CLRS example %d: %w", index, checkErr)
 		}
-		candidate := makeCandidate(sourceID, dataset.Name, task, semantics, uint64(index), checked)
-		verifier := makeVerifier(sourceID, candidate.ID, checked.reference)
+		if checkErr := cells.observe(checked.requestedLength, checked.seed); checkErr != nil {
+			return CandidateSet{}, VerifierSet{}, fmt.Errorf("validate CLRS example %d: %w", index, checkErr)
+		}
+		candidate := makeCandidate(scope.contractScope, dataset.Name, uint64(index), checked)
+		verifier := makeVerifier(scope.contractScope, candidate.ID, checked.reference)
 		candidates.Examples = append(candidates.Examples, candidate)
 		verifiers.Examples = append(verifiers.Examples, verifier)
 	}
+	if err := cells.complete(); err != nil {
+		return CandidateSet{}, VerifierSet{}, err
+	}
+	if _, err := PairExamples(source, contract, outputRelativePath, candidates, verifiers); err != nil {
+		return CandidateSet{}, VerifierSet{}, fmt.Errorf("validate imported CLRS records: %w", err)
+	}
 	return candidates, verifiers, nil
+}
+
+// PairExamples validates both separated sets against the caller's exact
+// contract-selected output path, recomputes every identity, and returns
+// verifier records in candidate order. It rejects identity-inconsistent,
+// missing, duplicate, foreign, or contract-incomplete records.
+func PairExamples(
+	source SourceRecord,
+	contract GenerationContract,
+	outputRelativePath string,
+	candidates CandidateSet,
+	verifiers VerifierSet,
+) ([]PairedExample, error) {
+	scope, err := newContractScope(source, contract, outputRelativePath)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateCandidateSetMetadata(scope, candidates); err != nil {
+		return nil, err
+	}
+	if err := validateVerifierSetMetadata(scope, verifiers); err != nil {
+		return nil, err
+	}
+	if len(candidates.Examples) != scope.task.ExpectedExamples {
+		return nil, fmt.Errorf("CLRS candidate count = %d, want exactly %d", len(candidates.Examples), scope.task.ExpectedExamples)
+	}
+	if len(verifiers.Examples) != scope.task.ExpectedExamples {
+		return nil, fmt.Errorf("CLRS verifier count = %d, want exactly %d", len(verifiers.Examples), scope.task.ExpectedExamples)
+	}
+
+	byCandidate := make(map[CandidateID]VerifierExample, len(verifiers.Examples))
+	for index, verifier := range verifiers.Examples {
+		if err := validateVerifierRecord(scope, verifier); err != nil {
+			return nil, fmt.Errorf("validate CLRS verifier %d: %w", index, err)
+		}
+		if _, exists := byCandidate[verifier.CandidateID]; exists {
+			return nil, fmt.Errorf("CLRS verifier %d duplicates candidate identity %s", index, verifier.CandidateID.String())
+		}
+		byCandidate[verifier.CandidateID] = verifier
+	}
+
+	cells := newCellCounter(scope)
+	seenCandidates := make(map[CandidateID]struct{}, len(candidates.Examples))
+	pairs := make([]PairedExample, 0, len(candidates.Examples))
+	for index, candidate := range candidates.Examples {
+		if err := validateCandidateRecord(scope, candidates.DatasetName, uint64(index), candidate); err != nil {
+			return nil, fmt.Errorf("validate CLRS candidate %d: %w", index, err)
+		}
+		if _, exists := seenCandidates[candidate.ID]; exists {
+			return nil, fmt.Errorf("CLRS candidate %d duplicates identity %s", index, candidate.ID.String())
+		}
+		seenCandidates[candidate.ID] = struct{}{}
+		if err := cells.observe(candidate.RequestedLength, candidate.Seed); err != nil {
+			return nil, fmt.Errorf("validate CLRS candidate %d: %w", index, err)
+		}
+		verifier, exists := byCandidate[candidate.ID]
+		if !exists {
+			return nil, fmt.Errorf("CLRS candidate %d has no verifier", index)
+		}
+		pairs = append(pairs, PairedExample{Candidate: candidate, Verifier: verifier})
+		delete(byCandidate, candidate.ID)
+	}
+	if err := cells.complete(); err != nil {
+		return nil, err
+	}
+	if len(byCandidate) != 0 {
+		return nil, fmt.Errorf("CLRS verifier set contains %d foreign candidate bindings", len(byCandidate))
+	}
+	return pairs, nil
 }
 
 // Validate rejects limits that are non-positive or too large to remain useful
@@ -169,102 +292,214 @@ func (limits ImportLimits) Validate() error {
 	return nil
 }
 
-func checkExample(raw upstreamExample, task string, semantics LengthSemantics, limits ImportLimits) (checkedExample, error) {
-	if raw.Prompt == "" || len(raw.Prompt) > limits.MaxPromptBytes || strings.IndexByte(raw.Prompt, 0) >= 0 {
-		return checkedExample{}, fmt.Errorf("prompt must contain 1..%d non-NUL bytes", limits.MaxPromptBytes)
+func newImportScope(
+	source SourceRecord,
+	contract GenerationContract,
+	outputRelativePath string,
+	limits ImportLimits,
+) (importScope, error) {
+	if err := limits.Validate(); err != nil {
+		return importScope{}, err
 	}
-	if !strings.HasPrefix(raw.Prompt, task+":\n") {
-		return checkedExample{}, fmt.Errorf("prompt does not bind dataset task %q", task)
+	scope, err := newContractScope(source, contract, outputRelativePath)
+	if err != nil {
+		return importScope{}, err
+	}
+	if limits.MaxExamples < scope.task.ExpectedExamples {
+		return importScope{}, fmt.Errorf(
+			"CLRS caller example limit = %d, below required task count %d",
+			limits.MaxExamples, scope.task.ExpectedExamples,
+		)
+	}
+	for _, size := range scope.task.Sizes {
+		if size.RequestedLength > limits.MaxDeclaredLength {
+			return importScope{}, fmt.Errorf(
+				"CLRS caller declared-length limit = %d, below selected length %d",
+				limits.MaxDeclaredLength, size.RequestedLength,
+			)
+		}
+	}
+	return importScope{
+		contractScope:     scope,
+		maxDatasetBytes:   smallerInt64(limits.MaxDatasetBytes, scope.plan.Output.MaxDatasetBytes),
+		maxPromptBytes:    smallerInt(limits.MaxPromptBytes, scope.plan.Output.MaxPromptBytes),
+		maxReferenceBytes: smallerInt(limits.MaxReferenceBytes, scope.plan.Output.MaxReferenceBytes),
+		maxDeclaredLength: smallerInt64(limits.MaxDeclaredLength, scope.plan.Output.MaxRequestedLength),
+	}, nil
+}
+
+func newContractScope(
+	source SourceRecord,
+	contract GenerationContract,
+	outputRelativePath string,
+) (contractScope, error) {
+	plan, err := contract.Plan(source)
+	if err != nil {
+		return contractScope{}, fmt.Errorf("validate CLRS import contract: %w", err)
+	}
+	for _, task := range plan.Tasks {
+		if outputRelativePath == task.OutputRelativePath {
+			return contractScope{
+				sourceID:   plan.SourceID,
+				contractID: plan.ContractID,
+				plan:       plan,
+				task:       task,
+			}, nil
+		}
+	}
+	return contractScope{}, fmt.Errorf("CLRS output path %q is not selected by the generation contract", outputRelativePath)
+}
+
+func checkUpstreamExample(raw upstreamExample, scope importScope) (checkedExample, error) {
+	if err := validatePrompt(raw.Prompt, scope.task.Task, scope.maxPromptBytes); err != nil {
+		return checkedExample{}, err
 	}
 	if len(raw.References) != 1 {
 		return checkedExample{}, fmt.Errorf("reference count = %d, want exactly 1", len(raw.References))
 	}
-	reference := raw.References[0]
-	if reference == "" || len(reference) > limits.MaxReferenceBytes || strings.IndexByte(reference, 0) >= 0 {
-		return checkedExample{}, fmt.Errorf("reference must contain 1..%d non-NUL bytes", limits.MaxReferenceBytes)
+	if err := validateReference(raw.References[0], scope.maxReferenceBytes); err != nil {
+		return checkedExample{}, err
 	}
 	if raw.Auxiliary.Length == nil || raw.Auxiliary.Seed == nil || raw.Auxiliary.UseHints == nil {
 		return checkedExample{}, errors.New("auxiliary length, seed, and use_hints are all required")
 	}
-	if *raw.Auxiliary.Length <= 0 || *raw.Auxiliary.Length > limits.MaxDeclaredLength {
-		return checkedExample{}, fmt.Errorf("declared length = %d, want 1..%d", *raw.Auxiliary.Length, limits.MaxDeclaredLength)
+	if *raw.Auxiliary.Length <= 0 || *raw.Auxiliary.Length > scope.maxDeclaredLength {
+		return checkedExample{}, fmt.Errorf("declared length = %d, want 1..%d", *raw.Auxiliary.Length, scope.maxDeclaredLength)
 	}
 	if *raw.Auxiliary.Seed < math.MinInt32 || *raw.Auxiliary.Seed > math.MaxInt32 {
 		return checkedExample{}, errors.New("seed is outside the upstream signed 32-bit range")
 	}
-	effectiveSize := *raw.Auxiliary.Length
-	if semantics == LengthFixedFourEndpoints {
-		effectiveSize = 4
+	if *raw.Auxiliary.UseHints != scope.plan.UseHints {
+		return checkedExample{}, fmt.Errorf("use_hints = %t, want contract value %t", *raw.Auxiliary.UseHints, scope.plan.UseHints)
+	}
+	effectiveSize, err := effectiveInputSize(*raw.Auxiliary.Length, scope.task.LengthSemantics)
+	if err != nil {
+		return checkedExample{}, err
 	}
 	return checkedExample{
 		requestedLength: *raw.Auxiliary.Length,
 		effectiveSize:   effectiveSize,
 		seed:            *raw.Auxiliary.Seed,
 		prompt:          raw.Prompt,
-		reference:       reference,
+		reference:       raw.References[0],
 		useHints:        *raw.Auxiliary.UseHints,
 	}, nil
 }
 
-func validateDatasetName(name string) (string, error) {
-	const prefix = "clrs_text_"
-	if !strings.HasPrefix(name, prefix) {
-		return "", fmt.Errorf("CLRS dataset name %q lacks %q prefix", name, prefix)
+func validatePrompt(prompt string, task TaskKind, maximumBytes int) error {
+	if prompt == "" || len(prompt) > maximumBytes || strings.IndexByte(prompt, 0) >= 0 {
+		return fmt.Errorf("prompt must contain 1..%d non-NUL bytes", maximumBytes)
 	}
-	task := strings.TrimPrefix(name, prefix)
-	if len(task) == 0 || len(task) > 64 {
-		return "", fmt.Errorf("CLRS task name length = %d, want 1..64", len(task))
+	if !strings.HasPrefix(prompt, string(task)+":\n") {
+		return fmt.Errorf("prompt does not bind contract task %q", task)
 	}
-	previousUnderscore := false
-	for index, character := range []byte(task) {
-		letter := character >= 'a' && character <= 'z'
-		digit := character >= '0' && character <= '9'
-		underscore := character == '_'
-		if !letter && !(index > 0 && digit) && !(index > 0 && underscore && !previousUnderscore && index < len(task)-1) {
-			return "", fmt.Errorf("CLRS task name %q is not lowercase snake case", task)
+	return nil
+}
+
+func validateReference(reference string, maximumBytes int) error {
+	if reference == "" || len(reference) > maximumBytes || strings.IndexByte(reference, 0) >= 0 {
+		return fmt.Errorf("reference must contain 1..%d non-NUL bytes", maximumBytes)
+	}
+	return nil
+}
+
+func effectiveInputSize(requestedLength int64, semantics LengthSemantics) (int64, error) {
+	switch semantics {
+	case LengthDeclaredInput:
+		return requestedLength, nil
+	case LengthFixedFourEndpoints:
+		return 4, nil
+	default:
+		return 0, fmt.Errorf("unsupported CLRS length semantics %q", semantics)
+	}
+}
+
+func newCellCounter(scope contractScope) cellCounter {
+	allowed := make(map[cellKey]int, len(scope.task.Sizes)*len(scope.plan.Seeds))
+	for _, size := range scope.task.Sizes {
+		for _, seed := range scope.plan.Seeds {
+			allowed[cellKey{length: size.RequestedLength, seed: seed}] = scope.plan.SamplesPerCell
 		}
-		previousUnderscore = underscore
 	}
-	return task, nil
+	return cellCounter{
+		allowed: allowed,
+		seen:    make(map[cellKey]int, len(allowed)),
+		task:    scope.task,
+		plan:    scope.plan,
+	}
 }
 
-func validLengthSemantics(semantics LengthSemantics) bool {
-	return semantics == LengthDeclaredInput || semantics == LengthFixedFourEndpoints
+func (counter *cellCounter) observe(length, seed int64) error {
+	key := cellKey{length: length, seed: seed}
+	allowed, selected := counter.allowed[key]
+	if !selected {
+		return fmt.Errorf("length/seed cell (%d, %d) is not selected by the generation contract", length, seed)
+	}
+	counter.seen[key]++
+	if counter.seen[key] > allowed {
+		return fmt.Errorf(
+			"length/seed cell (%d, %d) multiplicity = %d, want %d",
+			length, seed, counter.seen[key], allowed,
+		)
+	}
+	return nil
 }
 
-func newCandidateSet(source SourceID, datasetName, task string, semantics LengthSemantics, capacity int) CandidateSet {
+func (counter cellCounter) complete() error {
+	for _, size := range counter.task.Sizes {
+		for _, seed := range counter.plan.Seeds {
+			key := cellKey{length: size.RequestedLength, seed: seed}
+			if counter.seen[key] != counter.allowed[key] {
+				return fmt.Errorf(
+					"length/seed cell (%d, %d) multiplicity = %d, want %d",
+					key.length, key.seed, counter.seen[key], counter.allowed[key],
+				)
+			}
+		}
+	}
+	return nil
+}
+
+func newCandidateSet(scope contractScope, datasetName string, capacity int) CandidateSet {
 	return CandidateSet{
-		Authority:       ResultAuthority,
-		Source:          source,
-		DatasetName:     datasetName,
-		Task:            task,
-		LengthSemantics: semantics,
-		Examples:        make([]CandidateExample, 0, capacity),
+		Authority:          ResultAuthority,
+		Source:             scope.sourceID,
+		Contract:           scope.contractID,
+		OutputRelativePath: scope.task.OutputRelativePath,
+		DatasetName:        datasetName,
+		Task:               scope.task.Task,
+		LengthSemantics:    scope.task.LengthSemantics,
+		Examples:           make([]CandidateExample, 0, capacity),
 	}
 }
 
-func newVerifierSet(source SourceID, datasetName string, capacity int) VerifierSet {
+func newVerifierSet(scope contractScope, datasetName string, capacity int) VerifierSet {
 	return VerifierSet{
-		Authority:   ResultAuthority,
-		Source:      source,
-		DatasetName: datasetName,
-		Examples:    make([]VerifierExample, 0, capacity),
+		Authority:          ResultAuthority,
+		Source:             scope.sourceID,
+		Contract:           scope.contractID,
+		OutputRelativePath: scope.task.OutputRelativePath,
+		DatasetName:        datasetName,
+		Task:               scope.task.Task,
+		LengthSemantics:    scope.task.LengthSemantics,
+		Examples:           make([]VerifierExample, 0, capacity),
 	}
 }
 
 func makeCandidate(
-	source SourceID,
+	scope contractScope,
 	datasetName string,
-	task string,
-	semantics LengthSemantics,
 	ordinal uint64,
 	example checkedExample,
 ) CandidateExample {
-	builder := newIdentityBuilder("20w/clrs-candidate/v1")
-	builder.addBytes(source[:])
+	builder := newIdentityBuilder("20w/clrs-candidate/v2")
+	builder.addString(ResultAuthority)
+	builder.addBytes(scope.sourceID[:])
+	builder.addBytes(scope.contractID[:])
+	builder.addString(scope.task.OutputRelativePath)
 	builder.addString(datasetName)
-	builder.addString(task)
-	builder.addString(string(semantics))
+	builder.addString(string(scope.task.Task))
+	builder.addString(string(scope.task.LengthSemantics))
 	builder.addUint64(ordinal)
 	builder.addInt64(example.requestedLength)
 	builder.addInt64(example.effectiveSize)
@@ -274,11 +509,13 @@ func makeCandidate(
 	return CandidateExample{
 		ID:                 CandidateID(builder.sum()),
 		Authority:          ResultAuthority,
-		Source:             source,
-		Task:               task,
+		Source:             scope.sourceID,
+		Contract:           scope.contractID,
+		OutputRelativePath: scope.task.OutputRelativePath,
+		Task:               scope.task.Task,
 		Ordinal:            ordinal,
 		Prompt:             example.prompt,
-		LengthSemantics:    semantics,
+		LengthSemantics:    scope.task.LengthSemantics,
 		RequestedLength:    example.requestedLength,
 		EffectiveInputSize: example.effectiveSize,
 		Seed:               example.seed,
@@ -286,16 +523,122 @@ func makeCandidate(
 	}
 }
 
-func makeVerifier(source SourceID, candidateID CandidateID, reference string) VerifierExample {
-	builder := newIdentityBuilder("20w/clrs-verifier/v1")
-	builder.addBytes(source[:])
+func makeVerifier(
+	scope contractScope,
+	candidateID CandidateID,
+	reference string,
+) VerifierExample {
+	builder := newIdentityBuilder("20w/clrs-verifier/v2")
+	builder.addString(ResultAuthority)
+	builder.addBytes(scope.sourceID[:])
+	builder.addBytes(scope.contractID[:])
 	builder.addBytes(candidateID[:])
 	builder.addString(reference)
 	return VerifierExample{
 		ID:          VerifierID(builder.sum()),
 		Authority:   ResultAuthority,
-		Source:      source,
+		Source:      scope.sourceID,
+		Contract:    scope.contractID,
 		CandidateID: candidateID,
 		Reference:   reference,
 	}
+}
+
+func validateCandidateSetMetadata(scope contractScope, set CandidateSet) error {
+	if set.Authority != ResultAuthority {
+		return fmt.Errorf("CLRS candidate authority = %q, want %q", set.Authority, ResultAuthority)
+	}
+	if set.Source != scope.sourceID || set.Contract != scope.contractID {
+		return errors.New("CLRS candidate set source or contract identity is foreign")
+	}
+	if set.OutputRelativePath != scope.task.OutputRelativePath ||
+		set.DatasetName != datasetName(scope.task.Task) ||
+		set.Task != scope.task.Task ||
+		set.LengthSemantics != scope.task.LengthSemantics {
+		return errors.New("CLRS candidate set metadata does not match the selected contract task")
+	}
+	return nil
+}
+
+func validateVerifierSetMetadata(scope contractScope, set VerifierSet) error {
+	if set.Authority != ResultAuthority {
+		return fmt.Errorf("CLRS verifier authority = %q, want %q", set.Authority, ResultAuthority)
+	}
+	if set.Source != scope.sourceID || set.Contract != scope.contractID {
+		return errors.New("CLRS verifier set source or contract identity is foreign")
+	}
+	if set.OutputRelativePath != scope.task.OutputRelativePath ||
+		set.DatasetName != datasetName(scope.task.Task) ||
+		set.Task != scope.task.Task ||
+		set.LengthSemantics != scope.task.LengthSemantics {
+		return errors.New("CLRS verifier set metadata does not match the selected contract task")
+	}
+	return nil
+}
+
+func validateCandidateRecord(
+	scope contractScope,
+	datasetName string,
+	ordinal uint64,
+	candidate CandidateExample,
+) error {
+	if candidate.RequestedLength <= 0 || candidate.RequestedLength > scope.plan.Output.MaxRequestedLength {
+		return fmt.Errorf(
+			"declared length = %d, want 1..%d",
+			candidate.RequestedLength, scope.plan.Output.MaxRequestedLength,
+		)
+	}
+	if candidate.Seed < math.MinInt32 || candidate.Seed > math.MaxInt32 {
+		return errors.New("seed is outside the upstream signed 32-bit range")
+	}
+	if candidate.UseHints != scope.plan.UseHints {
+		return fmt.Errorf("use_hints = %t, want contract value %t", candidate.UseHints, scope.plan.UseHints)
+	}
+	if err := validatePrompt(candidate.Prompt, scope.task.Task, scope.plan.Output.MaxPromptBytes); err != nil {
+		return err
+	}
+	effectiveSize, err := effectiveInputSize(candidate.RequestedLength, scope.task.LengthSemantics)
+	if err != nil {
+		return err
+	}
+	expected := makeCandidate(scope, datasetName, ordinal, checkedExample{
+		requestedLength: candidate.RequestedLength,
+		effectiveSize:   effectiveSize,
+		seed:            candidate.Seed,
+		prompt:          candidate.Prompt,
+		useHints:        candidate.UseHints,
+	})
+	if candidate != expected {
+		return errors.New("candidate record or identity does not match its contract-bound contents")
+	}
+	return nil
+}
+
+func validateVerifierRecord(scope contractScope, verifier VerifierExample) error {
+	if err := validateReference(verifier.Reference, scope.plan.Output.MaxReferenceBytes); err != nil {
+		return err
+	}
+	expected := makeVerifier(scope, verifier.CandidateID, verifier.Reference)
+	if verifier != expected {
+		return errors.New("verifier record or identity does not match its contract-bound contents")
+	}
+	return nil
+}
+
+func datasetName(task TaskKind) string {
+	return "clrs_text_" + string(task)
+}
+
+func smallerInt(left, right int) int {
+	if left < right {
+		return left
+	}
+	return right
+}
+
+func smallerInt64(left, right int64) int64 {
+	if left < right {
+		return left
+	}
+	return right
 }

--- a/tooling/internal/clrsfixture/import_test.go
+++ b/tooling/internal/clrsfixture/import_test.go
@@ -2,6 +2,7 @@ package clrsfixture
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"strings"
@@ -10,30 +11,62 @@ import (
 
 func TestImportDatasetSeparatesCandidateFromVerifier(t *testing.T) {
 	t.Parallel()
-	source := trackedSourceRecord(t)
-	left := oneExampleDataset("future_task", "input", "answer-left", 7, 3, false)
-	right := oneExampleDataset("future_task", "input", "answer-right", 7, 3, false)
-	leftCandidates, leftVerifiers, err := ImportDataset(strings.NewReader(left), source, LengthDeclaredInput, testImportLimits())
-	if err != nil {
-		t.Fatal(err)
-	}
-	rightCandidates, rightVerifiers, err := ImportDataset(strings.NewReader(right), source, LengthDeclaredInput, testImportLimits())
-	if err != nil {
-		t.Fatal(err)
-	}
+	fixture := newImportFixture(t, TaskInsertionSort)
+	left := completeDataset(fixture)
+	right := completeDataset(fixture)
+	right.Examples[0].References[0] = "changed verifier-only answer"
+
+	leftCandidates, leftVerifiers := importFixtureDataset(t, fixture, left, testImportLimits())
+	rightCandidates, rightVerifiers := importFixtureDataset(t, fixture, right, testImportLimits())
 	if !reflect.DeepEqual(leftCandidates, rightCandidates) {
-		t.Fatal("candidate-visible records changed when only the reference changed")
+		t.Fatal("candidate-visible records changed when only a reference changed")
 	}
-	if reflect.DeepEqual(leftVerifiers, rightVerifiers) || leftVerifiers.Examples[0].ID == rightVerifiers.Examples[0].ID {
-		t.Fatal("verifier-only record did not bind the changed reference")
+	if reflect.DeepEqual(leftVerifiers, rightVerifiers) ||
+		leftVerifiers.Examples[0].ID == rightVerifiers.Examples[0].ID {
+		t.Fatal("verifier-only records did not bind the changed reference")
 	}
-	changedInput := oneExampleDataset("future_task", "different-input", "answer-left", 7, 3, false)
-	changedCandidates, _, err := ImportDataset(strings.NewReader(changedInput), source, LengthDeclaredInput, testImportLimits())
+	changedInput := completeDataset(fixture)
+	changedInput.Examples[0].Prompt += " changed candidate input"
+	changedCandidates, _ := importFixtureDataset(t, fixture, changedInput, testImportLimits())
+	if changedCandidates.Examples[0].ID == leftCandidates.Examples[0].ID {
+		t.Fatal("candidate identity did not bind the changed prompt")
+	}
+
+	pairs, err := PairExamples(
+		fixture.source,
+		fixture.contract,
+		fixture.task.OutputRelativePath,
+		leftCandidates,
+		leftVerifiers,
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if changedCandidates.Examples[0].ID == leftCandidates.Examples[0].ID {
-		t.Fatal("candidate identity did not bind candidate-visible input")
+	if len(pairs) != fixture.task.ExpectedExamples ||
+		pairs[0].Candidate.ID != pairs[0].Verifier.CandidateID {
+		t.Fatalf("validated pairs = %#v", pairs)
+	}
+	sourceID, err := fixture.source.Identity()
+	if err != nil {
+		t.Fatal(err)
+	}
+	contractID, err := fixture.contract.Identity(fixture.source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if leftCandidates.Authority != ResultAuthority || leftVerifiers.Authority != ResultAuthority ||
+		leftCandidates.Source != sourceID || leftVerifiers.Source != sourceID ||
+		leftCandidates.Contract != contractID || leftVerifiers.Contract != contractID {
+		t.Fatalf("set bindings = %#v / %#v", leftCandidates, leftVerifiers)
+	}
+	for index := range leftCandidates.Examples {
+		candidate := leftCandidates.Examples[index]
+		verifier := leftVerifiers.Examples[index]
+		if candidate.Authority != ResultAuthority || verifier.Authority != ResultAuthority ||
+			candidate.Source != sourceID || verifier.Source != sourceID ||
+			candidate.Contract != contractID || verifier.Contract != contractID {
+			t.Fatalf("example %d bindings = %#v / %#v", index, candidate, verifier)
+		}
 	}
 	candidateType := reflect.TypeOf(CandidateExample{})
 	for index := 0; index < candidateType.NumField(); index++ {
@@ -44,217 +77,671 @@ func TestImportDatasetSeparatesCandidateFromVerifier(t *testing.T) {
 	}
 }
 
-func TestImportDatasetModelsBothLengthSemanticsWithoutTaskRegistry(t *testing.T) {
+func TestImportDatasetDerivesTaskPathAndLengthSemanticsFromContract(t *testing.T) {
 	t.Parallel()
-	source := trackedSourceRecord(t)
-	body := oneExampleDataset("unregistered_geometry_probe", "points", "false", 31, 94, true)
-	declared, _, err := ImportDataset(strings.NewReader(body), source, LengthDeclaredInput, testImportLimits())
-	if err != nil {
-		t.Fatal(err)
-	}
-	fixed, _, err := ImportDataset(strings.NewReader(body), source, LengthFixedFourEndpoints, testImportLimits())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if declared.Task != "unregistered_geometry_probe" || declared.Examples[0].EffectiveInputSize != 31 {
-		t.Fatalf("declared-length record = %#v", declared.Examples[0])
-	}
-	if fixed.Examples[0].RequestedLength != 31 || fixed.Examples[0].EffectiveInputSize != 4 {
-		t.Fatalf("fixed-endpoint record = %#v", fixed.Examples[0])
-	}
-	if fixed.Examples[0].LengthSemantics != LengthFixedFourEndpoints || fixed.Authority != ResultAuthority {
-		t.Fatalf("fixed-endpoint metadata = %#v", fixed)
-	}
-	if declared.Examples[0].ID == fixed.Examples[0].ID {
-		t.Fatal("candidate identity did not bind length semantics")
-	}
-}
-
-func TestImportDatasetUsesOrdinalToDistinguishDuplicateSamples(t *testing.T) {
-	t.Parallel()
-	example := `{"prompt":"task:\ninput","references":["answer"],"auxiliary":{"length":7,"seed":3,"use_hints":false}}`
-	body := fmt.Sprintf(`{"name":"clrs_text_task","examples":[%s,%s]}`, example, example)
-	candidates, verifiers, err := ImportDataset(
-		strings.NewReader(body),
-		trackedSourceRecord(t),
-		LengthDeclaredInput,
+	insertion := newImportFixture(t, TaskInsertionSort)
+	insertionCandidates, _ := importFixtureDataset(
+		t,
+		insertion,
+		completeDataset(insertion),
 		testImportLimits(),
 	)
-	if err != nil {
-		t.Fatal(err)
+	first := insertionCandidates.Examples[0]
+	if insertionCandidates.Task != TaskInsertionSort ||
+		insertionCandidates.OutputRelativePath != insertion.task.OutputRelativePath ||
+		insertionCandidates.LengthSemantics != LengthDeclaredInput ||
+		first.EffectiveInputSize != first.RequestedLength {
+		t.Fatalf("insertion contract projection = %#v / %#v", insertionCandidates, first)
 	}
-	if candidates.Examples[0].Ordinal != 0 || candidates.Examples[1].Ordinal != 1 {
-		t.Fatalf("ordinals = %d/%d, want 0/1", candidates.Examples[0].Ordinal, candidates.Examples[1].Ordinal)
-	}
-	if candidates.Examples[0].ID == candidates.Examples[1].ID || verifiers.Examples[0].ID == verifiers.Examples[1].ID {
-		t.Fatal("duplicate samples did not receive distinct deterministic identities")
-	}
-}
 
-func TestCandidateIdentityBindsVisibleMetadata(t *testing.T) {
-	t.Parallel()
-	source := trackedSourceRecord(t)
-	base := oneExampleDataset("task", "input", "answer", 7, 3, false)
-	baseCandidates, _, err := ImportDataset(strings.NewReader(base), source, LengthDeclaredInput, testImportLimits())
-	if err != nil {
-		t.Fatal(err)
+	segments := newImportFixture(t, TaskSegmentsIntersect)
+	segmentCandidates, _ := importFixtureDataset(
+		t,
+		segments,
+		completeDataset(segments),
+		testImportLimits(),
+	)
+	if len(segmentCandidates.Examples) != 3 {
+		t.Fatalf("segment example count = %d, want 3", len(segmentCandidates.Examples))
 	}
-	variations := []string{
-		oneExampleDataset("task", "input", "answer", 8, 3, false),
-		oneExampleDataset("task", "input", "answer", 7, 4, false),
-		oneExampleDataset("task", "input", "answer", 7, 3, true),
-	}
-	for _, body := range variations {
-		candidates, _, importErr := ImportDataset(strings.NewReader(body), source, LengthDeclaredInput, testImportLimits())
-		if importErr != nil {
-			t.Fatal(importErr)
-		}
-		if candidates.Examples[0].ID == baseCandidates.Examples[0].ID {
-			t.Fatal("candidate identity did not bind visible length, seed, or hints metadata")
+	for _, candidate := range segmentCandidates.Examples {
+		if candidate.RequestedLength != 4 || candidate.EffectiveInputSize != 4 ||
+			candidate.LengthSemantics != LengthFixedFourEndpoints {
+			t.Fatalf("fixed geometry candidate = %#v", candidate)
 		}
 	}
+
+	body := marshalDataset(t, completeDataset(insertion))
+	for _, outputPath := range []string{
+		"",
+		"./" + insertion.task.OutputRelativePath,
+		"insertion_sort.json",
+		generationSplit + "/not_selected.json",
+	} {
+		if _, _, err := ImportDataset(
+			bytes.NewReader(body),
+			insertion.source,
+			insertion.contract,
+			outputPath,
+			testImportLimits(),
+		); err == nil {
+			t.Fatalf("ImportDataset accepted unselected output path %q", outputPath)
+		}
+	}
+	wrongName := completeDataset(insertion)
+	wrongName.Name = datasetName(TaskBinarySearch)
+	if _, _, err := ImportDataset(
+		bytes.NewReader(marshalDataset(t, wrongName)),
+		insertion.source,
+		insertion.contract,
+		insertion.task.OutputRelativePath,
+		testImportLimits(),
+	); err == nil {
+		t.Fatal("ImportDataset accepted a foreign task name at the selected path")
+	}
 }
 
-func TestImportDatasetIsDeterministicAndPreservesExactBytes(t *testing.T) {
+func TestImportDatasetAcceptsEachExactContractTaskFile(t *testing.T) {
 	t.Parallel()
-	source := trackedSourceRecord(t)
-	body := oneExampleDataset("binary_search", "key: [1 2]\nreturn:\n", "1\n\n", 5, -7, false)
-	firstCandidates, firstVerifiers, err := ImportDataset(strings.NewReader(body), source, LengthDeclaredInput, testImportLimits())
-	if err != nil {
-		t.Fatal(err)
-	}
-	secondCandidates, secondVerifiers, err := ImportDataset(strings.NewReader(body), source, LengthDeclaredInput, testImportLimits())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !reflect.DeepEqual(firstCandidates, secondCandidates) || !reflect.DeepEqual(firstVerifiers, secondVerifiers) {
-		t.Fatal("same source bytes produced different imports")
-	}
-	if firstCandidates.Examples[0].Prompt != "binary_search:\nkey: [1 2]\nreturn:\n" || firstVerifiers.Examples[0].Reference != "1\n\n" {
-		t.Fatalf("exact text changed: %#v / %#v", firstCandidates.Examples[0], firstVerifiers.Examples[0])
-	}
-	if firstVerifiers.Examples[0].CandidateID != firstCandidates.Examples[0].ID {
-		t.Fatal("verifier does not bind candidate identity")
-	}
-	if len(firstCandidates.Examples[0].ID.String()) != len("sha256:")+64 || len(firstVerifiers.Examples[0].ID.String()) != len("sha256:")+64 {
-		t.Fatal("deterministic identity is not a SHA-256 identity")
-	}
-}
-
-func TestImportDatasetRejectsMalformedExamples(t *testing.T) {
-	t.Parallel()
-	valid := oneExampleDataset("task", "input", "answer", 7, 3, false)
-	example := `{"prompt":"task:\ninput","references":["answer"],"auxiliary":{"length":7,"seed":3,"use_hints":false}}`
-	tests := map[string]string{
-		"unknown top level":   strings.Replace(valid, `"name":`, `"unknown":true,"name":`, 1),
-		"duplicate field":     strings.Replace(valid, `"name":"clrs_text_task"`, `"name":"clrs_text_task","name":"clrs_text_task"`, 1),
-		"trailing":            valid + `{}`,
-		"bad name prefix":     strings.Replace(valid, "clrs_text_task", "task", 1),
-		"bad task shape":      strings.Replace(valid, "clrs_text_task", "clrs_text_Task", 1),
-		"prompt mismatch":     strings.Replace(valid, `task:\ninput`, `other:\ninput`, 1),
-		"empty examples":      `{"name":"clrs_text_task","examples":[]}`,
-		"missing reference":   strings.Replace(valid, `"references":["answer"]`, `"references":[]`, 1),
-		"multiple references": strings.Replace(valid, `"references":["answer"]`, `"references":["answer","other"]`, 1),
-		"empty prompt":        strings.Replace(valid, `task:\ninput`, "", 1),
-		"NUL prompt":          strings.Replace(valid, `task:\ninput`, `task:\n\u0000`, 1),
-		"zero length":         strings.Replace(valid, `"length":7`, `"length":0`, 1),
-		"large length":        strings.Replace(valid, `"length":7`, `"length":101`, 1),
-		"large seed":          strings.Replace(valid, `"seed":3`, `"seed":2147483648`, 1),
-		"fractional seed":     strings.Replace(valid, `"seed":3`, `"seed":3.5`, 1),
-		"missing length":      strings.Replace(valid, `"length":7,`, "", 1),
-		"missing seed":        strings.Replace(valid, `,"seed":3`, "", 1),
-		"missing hints":       strings.Replace(valid, `,"use_hints":false`, "", 1),
-		"unknown auxiliary":   strings.Replace(valid, `"use_hints":false`, `"use_hints":false,"extra":true`, 1),
-		"too many examples":   fmt.Sprintf(`{"name":"clrs_text_task","examples":[%s,%s]}`, example, example),
-	}
-	for name, body := range tests {
-		name, body := name, body
-		t.Run(name, func(t *testing.T) {
+	for _, task := range ShakedownTasks() {
+		task := task
+		t.Run(string(task), func(t *testing.T) {
 			t.Parallel()
-			limits := testImportLimits()
-			limits.MaxExamples = 1
-			if _, _, err := ImportDataset(strings.NewReader(body), trackedSourceRecord(t), LengthDeclaredInput, limits); err == nil {
-				t.Fatalf("ImportDataset accepted %s", name)
+			fixture := newImportFixture(t, task)
+			candidates, verifiers := importFixtureDataset(
+				t,
+				fixture,
+				completeDataset(fixture),
+				testImportLimits(),
+			)
+			if len(candidates.Examples) != fixture.task.ExpectedExamples ||
+				len(verifiers.Examples) != fixture.task.ExpectedExamples ||
+				candidates.OutputRelativePath != fixture.task.OutputRelativePath ||
+				candidates.DatasetName != datasetName(task) {
+				t.Fatalf("contract task import = %#v / %#v", candidates, verifiers)
 			}
 		})
 	}
 }
 
-func TestImportDatasetRejectsBoundaryViolations(t *testing.T) {
+func TestImportDatasetRequiresExactContractCells(t *testing.T) {
 	t.Parallel()
-	source := trackedSourceRecord(t)
-	limits := testImportLimits()
-	limits.MaxDatasetBytes = 8
-	if _, _, err := ImportDataset(strings.NewReader(oneExampleDataset("task", "input", "answer", 7, 3, false)), source, LengthDeclaredInput, limits); err == nil {
-		t.Fatal("ImportDataset accepted oversized dataset")
+	fixture := newImportFixture(t, TaskInsertionSort)
+	valid := completeDataset(fixture)
+	importFixtureDataset(t, fixture, valid, testImportLimits())
+
+	tests := []struct {
+		name   string
+		mutate func(*upstreamDataset)
+	}{
+		{
+			name: "missing example",
+			mutate: func(dataset *upstreamDataset) {
+				dataset.Examples = dataset.Examples[:len(dataset.Examples)-1]
+			},
+		},
+		{
+			name: "extra example",
+			mutate: func(dataset *upstreamDataset) {
+				dataset.Examples = append(dataset.Examples, dataset.Examples[0])
+			},
+		},
+		{
+			name: "duplicate cell",
+			mutate: func(dataset *upstreamDataset) {
+				dataset.Examples[len(dataset.Examples)-1] = dataset.Examples[0]
+			},
+		},
+		{
+			name: "unselected length",
+			mutate: func(dataset *upstreamDataset) {
+				dataset.Examples[0].Auxiliary.Length = int64Pointer(9)
+			},
+		},
+		{
+			name: "unselected seed",
+			mutate: func(dataset *upstreamDataset) {
+				dataset.Examples[0].Auxiliary.Seed = int64Pointer(4)
+			},
+		},
+		{
+			name: "hints drift",
+			mutate: func(dataset *upstreamDataset) {
+				dataset.Examples[0].Auxiliary.UseHints = boolPointer(true)
+			},
+		},
+		{
+			name: "prompt task drift",
+			mutate: func(dataset *upstreamDataset) {
+				dataset.Examples[0].Prompt = string(TaskBinarySearch) + ":\nforeign"
+			},
+		},
 	}
-	limits = testImportLimits()
-	limits.MaxPromptBytes = len("task:\ninput") - 1
-	if _, _, err := ImportDataset(strings.NewReader(oneExampleDataset("task", "input", "answer", 7, 3, false)), source, LengthDeclaredInput, limits); err == nil {
-		t.Fatal("ImportDataset accepted oversized prompt")
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			dataset := completeDataset(fixture)
+			test.mutate(&dataset)
+			if _, _, err := ImportDataset(
+				bytes.NewReader(marshalDataset(t, dataset)),
+				fixture.source,
+				fixture.contract,
+				fixture.task.OutputRelativePath,
+				testImportLimits(),
+			); err == nil {
+				t.Fatalf("ImportDataset accepted %s", test.name)
+			}
+		})
 	}
-	limits = testImportLimits()
-	limits.MaxReferenceBytes = len("answer") - 1
-	if _, _, err := ImportDataset(strings.NewReader(oneExampleDataset("task", "input", "answer", 7, 3, false)), source, LengthDeclaredInput, limits); err == nil {
-		t.Fatal("ImportDataset accepted oversized reference")
+}
+
+func TestImportDatasetEnforcesContractAndCallerBounds(t *testing.T) {
+	t.Parallel()
+	fixture := newImportFixture(t, TaskInsertionSort)
+	dataset := completeDataset(fixture)
+	body := marshalDataset(t, dataset)
+
+	tests := []struct {
+		name   string
+		reader *bytes.Reader
+		limits ImportLimits
+	}{
+		{
+			name:   "caller dataset bytes",
+			reader: bytes.NewReader(body),
+			limits: withImportLimits(func(limits *ImportLimits) { limits.MaxDatasetBytes = int64(len(body) - 1) }),
+		},
+		{
+			name:   "caller example count",
+			reader: bytes.NewReader(body),
+			limits: withImportLimits(func(limits *ImportLimits) { limits.MaxExamples = fixture.task.ExpectedExamples - 1 }),
+		},
+		{
+			name:   "caller prompt bytes",
+			reader: bytes.NewReader(body),
+			limits: withImportLimits(func(limits *ImportLimits) { limits.MaxPromptBytes = len(dataset.Examples[0].Prompt) - 1 }),
+		},
+		{
+			name:   "caller reference bytes",
+			reader: bytes.NewReader(body),
+			limits: withImportLimits(func(limits *ImportLimits) { limits.MaxReferenceBytes = len(dataset.Examples[0].References[0]) - 1 }),
+		},
+		{
+			name:   "caller declared length",
+			reader: bytes.NewReader(body),
+			limits: withImportLimits(func(limits *ImportLimits) { limits.MaxDeclaredLength = 31 }),
+		},
 	}
-	if _, _, err := ImportDataset(nil, source, LengthDeclaredInput, testImportLimits()); err == nil {
-		t.Fatal("ImportDataset accepted nil reader")
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			if _, _, err := ImportDataset(
+				test.reader,
+				fixture.source,
+				fixture.contract,
+				fixture.task.OutputRelativePath,
+				test.limits,
+			); err == nil {
+				t.Fatalf("ImportDataset accepted %s", test.name)
+			}
+		})
 	}
-	if _, _, err := ImportDataset(bytes.NewReader([]byte{0xff, '{', '}'}), source, LengthDeclaredInput, testImportLimits()); err == nil {
+
+	contractOversize := append([]byte(nil), body...)
+	contractOversize = append(
+		contractOversize,
+		bytes.Repeat([]byte{' '}, int(fixture.plan.Output.MaxDatasetBytes)+1-len(contractOversize))...,
+	)
+	wideDatasetLimit := testImportLimits()
+	wideDatasetLimit.MaxDatasetBytes = maximumDatasetBytesCeiling
+	if _, _, err := ImportDataset(
+		bytes.NewReader(contractOversize),
+		fixture.source,
+		fixture.contract,
+		fixture.task.OutputRelativePath,
+		wideDatasetLimit,
+	); err == nil {
+		t.Fatal("ImportDataset accepted bytes beyond the contract dataset cap")
+	}
+
+	largePrompt := completeDataset(fixture)
+	largePrompt.Examples[0].Prompt = string(fixture.task.Task) + ":\n" +
+		strings.Repeat("p", fixture.plan.Output.MaxPromptBytes)
+	if _, _, err := ImportDataset(
+		bytes.NewReader(marshalDataset(t, largePrompt)),
+		fixture.source,
+		fixture.contract,
+		fixture.task.OutputRelativePath,
+		testImportLimits(),
+	); err == nil {
+		t.Fatal("ImportDataset accepted a prompt beyond the contract cap")
+	}
+	largeReference := completeDataset(fixture)
+	largeReference.Examples[0].References[0] = strings.Repeat(
+		"r",
+		fixture.plan.Output.MaxReferenceBytes+1,
+	)
+	if _, _, err := ImportDataset(
+		bytes.NewReader(marshalDataset(t, largeReference)),
+		fixture.source,
+		fixture.contract,
+		fixture.task.OutputRelativePath,
+		testImportLimits(),
+	); err == nil {
+		t.Fatal("ImportDataset accepted a reference beyond the contract cap")
+	}
+	if _, _, err := ImportDataset(
+		nil,
+		fixture.source,
+		fixture.contract,
+		fixture.task.OutputRelativePath,
+		testImportLimits(),
+	); err == nil {
+		t.Fatal("ImportDataset accepted a nil reader")
+	}
+	if _, _, err := ImportDataset(
+		bytes.NewReader([]byte{0xff, '{', '}'}),
+		fixture.source,
+		fixture.contract,
+		fixture.task.OutputRelativePath,
+		testImportLimits(),
+	); err == nil {
 		t.Fatal("ImportDataset accepted invalid UTF-8")
 	}
-}
 
-func TestImportDatasetRejectsInvalidPolicyInputs(t *testing.T) {
-	t.Parallel()
-	source := trackedSourceRecord(t)
-	body := oneExampleDataset("task", "input", "answer", 7, 3, false)
-	if _, _, err := ImportDataset(strings.NewReader(body), source, LengthSemantics("unknown"), testImportLimits()); err == nil {
-		t.Fatal("ImportDataset accepted unknown length semantics")
-	}
-	badSource := source
-	badSource.Authority = "RESULT"
-	if _, _, err := ImportDataset(strings.NewReader(body), badSource, LengthDeclaredInput, testImportLimits()); err == nil {
-		t.Fatal("ImportDataset accepted invalid source record")
-	}
 	badLimits := testImportLimits()
 	badLimits.MaxExamples = 0
-	if _, _, err := ImportDataset(strings.NewReader(body), source, LengthDeclaredInput, badLimits); err == nil {
-		t.Fatal("ImportDataset accepted unbounded example count")
+	if _, _, err := ImportDataset(
+		bytes.NewReader(body),
+		fixture.source,
+		fixture.contract,
+		fixture.task.OutputRelativePath,
+		badLimits,
+	); err == nil {
+		t.Fatal("ImportDataset accepted an invalid caller limit")
+	}
+	badSource := fixture.source
+	badSource.Authority = "RESULT"
+	if _, _, err := ImportDataset(
+		bytes.NewReader(body),
+		badSource,
+		fixture.contract,
+		fixture.task.OutputRelativePath,
+		testImportLimits(),
+	); err == nil {
+		t.Fatal("ImportDataset accepted a foreign source")
+	}
+	badContract := fixture.contract
+	badContract.UseHints = true
+	if _, _, err := ImportDataset(
+		bytes.NewReader(body),
+		fixture.source,
+		badContract,
+		fixture.task.OutputRelativePath,
+		testImportLimits(),
+	); err == nil {
+		t.Fatal("ImportDataset accepted an invalid generation contract")
 	}
 }
 
-func oneExampleDataset(task, input, reference string, length, seed int64, useHints bool) string {
-	prompt := task + ":\n" + input
-	return fmt.Sprintf(
-		`{"name":%q,"examples":[{"prompt":%q,"references":[%q],"auxiliary":{"length":%d,"seed":%d,"use_hints":%t}}]}`,
-		"clrs_text_"+task,
-		prompt,
-		reference,
-		length,
-		seed,
-		useHints,
+func TestImportDatasetIdentitiesAreDeterministicAndDomainBound(t *testing.T) {
+	t.Parallel()
+	fixture := newImportFixture(t, TaskInsertionSort)
+	dataset := completeDataset(fixture)
+	firstCandidates, firstVerifiers := importFixtureDataset(t, fixture, dataset, testImportLimits())
+	secondCandidates, secondVerifiers := importFixtureDataset(t, fixture, dataset, testImportLimits())
+	if !reflect.DeepEqual(firstCandidates, secondCandidates) ||
+		!reflect.DeepEqual(firstVerifiers, secondVerifiers) {
+		t.Fatal("same contract-bound source bytes produced different records")
+	}
+	const (
+		expectedCandidate = "sha256:c1f6a32dd519964047131461dba2e4254b278361dcb4baf6f291d1a0ae64bf2a"
+		expectedVerifier  = "sha256:dd26ea47469278245a1c5cecb1a53fe07dd88b9cc6f2fd64abca328aefe492c0"
 	)
+	if got := firstCandidates.Examples[0].ID.String(); got != expectedCandidate {
+		t.Fatalf("first candidate identity = %s, want %s", got, expectedCandidate)
+	}
+	if got := firstVerifiers.Examples[0].ID.String(); got != expectedVerifier {
+		t.Fatalf("first verifier identity = %s, want %s", got, expectedVerifier)
+	}
+
+	scope, err := newContractScope(fixture.source, fixture.contract, fixture.task.OutputRelativePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidate := firstCandidates.Examples[0]
+	checked := checkedExample{
+		requestedLength: candidate.RequestedLength,
+		effectiveSize:   candidate.EffectiveInputSize,
+		seed:            candidate.Seed,
+		prompt:          candidate.Prompt,
+		useHints:        candidate.UseHints,
+	}
+	baseCandidate := makeCandidate(scope, firstCandidates.DatasetName, candidate.Ordinal, checked)
+	changedSource := scope
+	changedSource.sourceID[0] ^= 1
+	if makeCandidate(changedSource, firstCandidates.DatasetName, candidate.Ordinal, checked).ID == baseCandidate.ID {
+		t.Fatal("candidate identity does not bind SourceID")
+	}
+	changedContract := scope
+	changedContract.contractID[0] ^= 1
+	if makeCandidate(changedContract, firstCandidates.DatasetName, candidate.Ordinal, checked).ID == baseCandidate.ID {
+		t.Fatal("candidate identity does not bind ContractID")
+	}
+	baseVerifier := makeVerifier(scope, baseCandidate.ID, firstVerifiers.Examples[0].Reference)
+	if makeVerifier(changedSource, baseCandidate.ID, firstVerifiers.Examples[0].Reference).ID == baseVerifier.ID {
+		t.Fatal("verifier identity does not bind SourceID")
+	}
+	if makeVerifier(changedContract, baseCandidate.ID, firstVerifiers.Examples[0].Reference).ID == baseVerifier.ID {
+		t.Fatal("verifier identity does not bind ContractID")
+	}
+}
+
+func TestPairExamplesRejectsMutatedOrForeignRecords(t *testing.T) {
+	t.Parallel()
+	fixture := newImportFixture(t, TaskInsertionSort)
+	candidates, verifiers := importFixtureDataset(
+		t,
+		fixture,
+		completeDataset(fixture),
+		testImportLimits(),
+	)
+	reordered := cloneVerifierSet(verifiers)
+	for left, right := 0, len(reordered.Examples)-1; left < right; left, right = left+1, right-1 {
+		reordered.Examples[left], reordered.Examples[right] = reordered.Examples[right], reordered.Examples[left]
+	}
+	pairs, err := PairExamples(
+		fixture.source,
+		fixture.contract,
+		fixture.task.OutputRelativePath,
+		candidates,
+		reordered,
+	)
+	if err != nil {
+		t.Fatalf("PairExamples rejected order-independent verifier records: %v", err)
+	}
+	for index, pair := range pairs {
+		if pair.Candidate.ID != candidates.Examples[index].ID ||
+			pair.Verifier.CandidateID != pair.Candidate.ID {
+			t.Fatalf("pair %d = %#v", index, pair)
+		}
+	}
+	binary := newImportFixture(t, TaskBinarySearch)
+	binaryCandidates, binaryVerifiers := importFixtureDataset(
+		t,
+		binary,
+		completeDataset(binary),
+		testImportLimits(),
+	)
+	if _, err := PairExamples(
+		fixture.source,
+		fixture.contract,
+		fixture.task.OutputRelativePath,
+		binaryCandidates,
+		binaryVerifiers,
+	); err == nil {
+		t.Fatal("PairExamples accepted another contract-selected task at the caller's expected path")
+	}
+
+	scope, err := newContractScope(fixture.source, fixture.contract, fixture.task.OutputRelativePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name   string
+		mutate func(*CandidateSet, *VerifierSet)
+	}{
+		{"candidate set authority", func(c *CandidateSet, _ *VerifierSet) { c.Authority = "RESULT" }},
+		{"candidate set source", func(c *CandidateSet, _ *VerifierSet) { c.Source[0] ^= 1 }},
+		{"candidate set contract", func(c *CandidateSet, _ *VerifierSet) { c.Contract[0] ^= 1 }},
+		{"candidate set path", func(c *CandidateSet, _ *VerifierSet) { c.OutputRelativePath = "./" + c.OutputRelativePath }},
+		{"candidate set name", func(c *CandidateSet, _ *VerifierSet) { c.DatasetName = datasetName(TaskBinarySearch) }},
+		{"candidate set task", func(c *CandidateSet, _ *VerifierSet) { c.Task = TaskBinarySearch }},
+		{"candidate set semantics", func(c *CandidateSet, _ *VerifierSet) { c.LengthSemantics = LengthFixedFourEndpoints }},
+		{"verifier set authority", func(_ *CandidateSet, v *VerifierSet) { v.Authority = "RESULT" }},
+		{"verifier set source", func(_ *CandidateSet, v *VerifierSet) { v.Source[0] ^= 1 }},
+		{"verifier set contract", func(_ *CandidateSet, v *VerifierSet) { v.Contract[0] ^= 1 }},
+		{"verifier set path", func(_ *CandidateSet, v *VerifierSet) { v.OutputRelativePath = "./" + v.OutputRelativePath }},
+		{"verifier set name", func(_ *CandidateSet, v *VerifierSet) { v.DatasetName = datasetName(TaskBinarySearch) }},
+		{"verifier set task", func(_ *CandidateSet, v *VerifierSet) { v.Task = TaskBinarySearch }},
+		{"verifier set semantics", func(_ *CandidateSet, v *VerifierSet) { v.LengthSemantics = LengthFixedFourEndpoints }},
+		{"candidate ID", func(c *CandidateSet, _ *VerifierSet) { c.Examples[0].ID[0] ^= 1 }},
+		{"candidate authority", func(c *CandidateSet, _ *VerifierSet) { c.Examples[0].Authority = "RESULT" }},
+		{"candidate source", func(c *CandidateSet, _ *VerifierSet) { c.Examples[0].Source[0] ^= 1 }},
+		{"candidate contract", func(c *CandidateSet, _ *VerifierSet) { c.Examples[0].Contract[0] ^= 1 }},
+		{"candidate path", func(c *CandidateSet, _ *VerifierSet) { c.Examples[0].OutputRelativePath = "foreign" }},
+		{"candidate task", func(c *CandidateSet, _ *VerifierSet) { c.Examples[0].Task = TaskBinarySearch }},
+		{"candidate ordinal", func(c *CandidateSet, _ *VerifierSet) { c.Examples[0].Ordinal++ }},
+		{"candidate prompt", func(c *CandidateSet, _ *VerifierSet) { c.Examples[0].Prompt += " mutation" }},
+		{"candidate semantics", func(c *CandidateSet, _ *VerifierSet) { c.Examples[0].LengthSemantics = LengthFixedFourEndpoints }},
+		{"candidate requested length", func(c *CandidateSet, _ *VerifierSet) { c.Examples[0].RequestedLength = 8 }},
+		{"candidate effective size", func(c *CandidateSet, _ *VerifierSet) { c.Examples[0].EffectiveInputSize++ }},
+		{"candidate seed", func(c *CandidateSet, _ *VerifierSet) { c.Examples[0].Seed = 14 }},
+		{"candidate hints", func(c *CandidateSet, _ *VerifierSet) { c.Examples[0].UseHints = true }},
+		{"verifier ID", func(_ *CandidateSet, v *VerifierSet) { v.Examples[0].ID[0] ^= 1 }},
+		{"verifier authority", func(_ *CandidateSet, v *VerifierSet) { v.Examples[0].Authority = "RESULT" }},
+		{"verifier source", func(_ *CandidateSet, v *VerifierSet) { v.Examples[0].Source[0] ^= 1 }},
+		{"verifier contract", func(_ *CandidateSet, v *VerifierSet) { v.Examples[0].Contract[0] ^= 1 }},
+		{"verifier candidate", func(_ *CandidateSet, v *VerifierSet) { v.Examples[0].CandidateID[0] ^= 1 }},
+		{"verifier reference", func(_ *CandidateSet, v *VerifierSet) { v.Examples[0].Reference += " mutation" }},
+		{"missing candidate", func(c *CandidateSet, _ *VerifierSet) { c.Examples = c.Examples[:len(c.Examples)-1] }},
+		{"extra candidate", func(c *CandidateSet, _ *VerifierSet) { c.Examples = append(c.Examples, c.Examples[0]) }},
+		{"duplicate candidate", func(c *CandidateSet, _ *VerifierSet) { c.Examples[len(c.Examples)-1] = c.Examples[0] }},
+		{"reordered candidate", func(c *CandidateSet, _ *VerifierSet) { c.Examples[0], c.Examples[1] = c.Examples[1], c.Examples[0] }},
+		{"missing verifier", func(_ *CandidateSet, v *VerifierSet) { v.Examples = v.Examples[:len(v.Examples)-1] }},
+		{"extra verifier", func(_ *CandidateSet, v *VerifierSet) { v.Examples = append(v.Examples, v.Examples[0]) }},
+		{"duplicate verifier", func(_ *CandidateSet, v *VerifierSet) { v.Examples[len(v.Examples)-1] = v.Examples[0] }},
+		{
+			"valid foreign verifier",
+			func(_ *CandidateSet, v *VerifierSet) {
+				v.Examples[len(v.Examples)-1] = makeVerifier(scope, CandidateID{1}, "foreign")
+			},
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			mutatedCandidates := cloneCandidateSet(candidates)
+			mutatedVerifiers := cloneVerifierSet(verifiers)
+			test.mutate(&mutatedCandidates, &mutatedVerifiers)
+			if _, err := PairExamples(
+				fixture.source,
+				fixture.contract,
+				fixture.task.OutputRelativePath,
+				mutatedCandidates,
+				mutatedVerifiers,
+			); err == nil {
+				t.Fatalf("PairExamples accepted %s", test.name)
+			}
+		})
+	}
+}
+
+func TestImportDatasetRejectsAmbiguousOrMalformedJSON(t *testing.T) {
+	t.Parallel()
+	fixture := newImportFixture(t, TaskInsertionSort)
+	dataset := completeDataset(fixture)
+	valid := string(marshalDataset(t, dataset))
+	firstLength := fmt.Sprintf(`"length":%d,`, fixture.task.Sizes[0].RequestedLength)
+	tests := map[string][]byte{
+		"unknown top level": []byte(strings.Replace(valid, `{"name":`, `{"unknown":true,"name":`, 1)),
+		"duplicate field":   []byte(strings.Replace(valid, `{"name":`, `{"name":"duplicate","name":`, 1)),
+		"trailing value":    []byte(valid + `{}`),
+		"missing length":    []byte(strings.Replace(valid, firstLength, "", 1)),
+		"fractional seed":   []byte(strings.Replace(valid, `"seed":3`, `"seed":3.5`, 1)),
+		"unknown auxiliary": []byte(strings.Replace(valid, `"use_hints":false`, `"use_hints":false,"extra":true`, 1)),
+		"multiple refs":     []byte(strings.Replace(valid, `"references":[`, `"references":["extra",`, 1)),
+		"empty refs":        []byte(strings.Replace(valid, dataset.Examples[0].References[0], "", 1)),
+		"invalid UTF-8":     {0xff, '{', '}'},
+	}
+	for name, body := range tests {
+		name, body := name, body
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if _, _, err := ImportDataset(
+				bytes.NewReader(body),
+				fixture.source,
+				fixture.contract,
+				fixture.task.OutputRelativePath,
+				testImportLimits(),
+			); err == nil {
+				t.Fatalf("ImportDataset accepted %s", name)
+			}
+		})
+	}
+	nulPrompt := completeDataset(fixture)
+	nulPrompt.Examples[0].Prompt = string(fixture.task.Task) + ":\n\x00"
+	if _, _, err := ImportDataset(
+		bytes.NewReader(marshalDataset(t, nulPrompt)),
+		fixture.source,
+		fixture.contract,
+		fixture.task.OutputRelativePath,
+		testImportLimits(),
+	); err == nil {
+		t.Fatal("ImportDataset accepted a NUL prompt")
+	}
+}
+
+type importFixture struct {
+	source   SourceRecord
+	contract GenerationContract
+	plan     GenerationPlan
+	task     TaskPlan
+}
+
+func newImportFixture(t *testing.T, task TaskKind) importFixture {
+	t.Helper()
+	source := trackedSourceRecord(t)
+	contract := trackedGenerationContract(t, source)
+	plan, err := contract.Plan(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, candidate := range plan.Tasks {
+		if candidate.Task == task {
+			return importFixture{
+				source:   source,
+				contract: contract,
+				plan:     plan,
+				task:     candidate,
+			}
+		}
+	}
+	t.Fatalf("task %q is not selected", task)
+	return importFixture{}
+}
+
+func completeDataset(fixture importFixture) upstreamDataset {
+	examples := make([]upstreamExample, 0, fixture.task.ExpectedExamples)
+	for _, size := range fixture.task.Sizes {
+		for _, seed := range fixture.plan.Seeds {
+			for sample := 0; sample < fixture.plan.SamplesPerCell; sample++ {
+				examples = append(examples, upstreamExample{
+					Prompt: fmt.Sprintf(
+						"%s:\ninput length=%d seed=%d sample=%d",
+						fixture.task.Task,
+						size.RequestedLength,
+						seed,
+						sample,
+					),
+					References: []string{fmt.Sprintf(
+						"reference length=%d seed=%d sample=%d",
+						size.RequestedLength,
+						seed,
+						sample,
+					)},
+					Auxiliary: upstreamAuxiliary{
+						Length:   int64Pointer(size.RequestedLength),
+						Seed:     int64Pointer(seed),
+						UseHints: boolPointer(fixture.plan.UseHints),
+					},
+				})
+			}
+		}
+	}
+	return upstreamDataset{
+		Name:     datasetName(fixture.task.Task),
+		Examples: examples,
+	}
+}
+
+func importFixtureDataset(
+	t *testing.T,
+	fixture importFixture,
+	dataset upstreamDataset,
+	limits ImportLimits,
+) (CandidateSet, VerifierSet) {
+	t.Helper()
+	candidates, verifiers, err := ImportDataset(
+		bytes.NewReader(marshalDataset(t, dataset)),
+		fixture.source,
+		fixture.contract,
+		fixture.task.OutputRelativePath,
+		limits,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return candidates, verifiers
+}
+
+func marshalDataset(t *testing.T, dataset upstreamDataset) []byte {
+	t.Helper()
+	body, err := json.Marshal(dataset)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return body
+}
+
+func int64Pointer(value int64) *int64 {
+	return &value
+}
+
+func boolPointer(value bool) *bool {
+	return &value
 }
 
 func testImportLimits() ImportLimits {
 	return ImportLimits{
-		MaxDatasetBytes:   16 << 10,
-		MaxExamples:       4,
-		MaxPromptBytes:    1024,
-		MaxReferenceBytes: 1024,
-		MaxDeclaredLength: 100,
+		MaxDatasetBytes:   8 << 20,
+		MaxExamples:       16,
+		MaxPromptBytes:    1 << 20,
+		MaxReferenceBytes: 1 << 20,
+		MaxDeclaredLength: 32,
 	}
 }
 
+func withImportLimits(change func(*ImportLimits)) ImportLimits {
+	limits := testImportLimits()
+	change(&limits)
+	return limits
+}
+
+func cloneCandidateSet(set CandidateSet) CandidateSet {
+	set.Examples = append([]CandidateExample(nil), set.Examples...)
+	return set
+}
+
+func cloneVerifierSet(set VerifierSet) VerifierSet {
+	set.Examples = append([]VerifierExample(nil), set.Examples...)
+	return set
+}
+
 func FuzzImportDataset(f *testing.F) {
-	f.Add(oneExampleDataset("task", "input", "answer", 7, 3, false))
-	f.Add(`{"name":"clrs_text_task","examples":[]}`)
-	f.Fuzz(func(t *testing.T, body string) {
-		if len(body) > 16<<10 {
+	f.Add([]byte(`{"name":"clrs_text_insertion_sort","examples":[{"prompt":"insertion_sort:\ninput","references":["reference"],"auxiliary":{"length":10,"seed":3,"use_hints":false}}]}`))
+	f.Add([]byte(`{"name":"clrs_text_insertion_sort","examples":[]}`))
+	f.Fuzz(func(t *testing.T, body []byte) {
+		if len(body) > 64<<10 {
 			return
 		}
-		_, _, _ = ImportDataset(strings.NewReader(body), trackedSourceRecord(t), LengthDeclaredInput, testImportLimits())
+		fixture := newImportFixture(t, TaskInsertionSort)
+		_, _, _ = ImportDataset(
+			bytes.NewReader(body),
+			fixture.source,
+			fixture.contract,
+			fixture.task.OutputRelativePath,
+			testImportLimits(),
+		)
 	})
 }


### PR DESCRIPTION
## Summary

- bind imported CLRS datasets to the pinned source identity, generation-contract identity, and contract-derived output path
- validate declared task semantics, requested and effective length-by-seed cells, record counts, caps, no-hint policy, and candidate/verifier separation
- reject mutated, duplicate, missing, cross-task, and foreign records during revalidation and pairing

## Validation

- `npm run check` — pass on the same patch before rebase: 723 workstation tests (722 pass, 1 explicit skip), 383-file Pages build; hashed local receipt retained
- `go test -race -count=20 -shuffle=on ./internal/clrsfixture` — pass after rebase
- `go vet ./internal/clrsfixture` — pass after rebase
- `npm run validate:policy` — pass after rebase
- `npm run check:code-shape` — baseline permits the change
- `npm run check:prose` — pass after rebase
- `git diff --check origin/main...HEAD` — pass

## Boundary

This is an import and pairing contract, not generator provenance, image reproducibility, specialist quality, energy evidence, or a scientific result. It advances #12; that issue remains open until the generator and end-to-end lanes are admitted.