### PR TITLE
fix(site): restore continuous-book fragment clearance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,11 @@ the exact diff; this file records why the project changed.
 
 ### Fixed
 
+- Continuous-book deep links now restore every chapter and heading below the
+  responsive action bar on cold load and later hash navigation. Internal book
+  links remain in the namespaced edition while preserving the current Pages
+  base path, query and route; a real-browser desktop/mobile regression guards
+  the observable clearance.
 - The page-27 biomimetic-transfer figure now uses a print-safe vertical flow.
   Print hides the screen-only overflow cue and resets the diagram caption from
   sticky positioning so the caption stays with the figure before the following

--- a/app/components/book-edition.tsx
+++ b/app/components/book-edition.tsx
@@ -41,6 +41,41 @@ function documentHeadingId(path: string, headingId: string) {
   return `${bookId(path)}--${headingId}`;
 }
 
+function useBookFragmentRestoration() {
+  useEffect(() => {
+    let frame = 0;
+    const restoreFragment = () => {
+      window.cancelAnimationFrame(frame);
+      frame = window.requestAnimationFrame(() => {
+        const target = window.location.hash.slice(1);
+        if (target) window.document.getElementById(target)?.scrollIntoView();
+      });
+    };
+
+    restoreFragment();
+    window.addEventListener("hashchange", restoreFragment);
+    return () => {
+      window.removeEventListener("hashchange", restoreFragment);
+      window.cancelAnimationFrame(frame);
+    };
+  }, []);
+}
+
+function navigateFromBook(
+  path: string,
+  hash: string,
+  bookDocumentPaths: Set<string>,
+  externalHref: (path: string, hash?: string) => string,
+) {
+  if (bookDocumentPaths.has(path)) {
+    window.location.assign(
+      hash ? `#${documentHeadingId(path, hash)}` : `#${bookId(path)}`,
+    );
+    return;
+  }
+  window.location.assign(externalHref(path, hash));
+}
+
 function BookDocumentArticle({
   document: researchDocument,
   navigate,
@@ -66,13 +101,6 @@ function BookDocumentArticle({
       heading.dataset.bookLegacyHeadingId = legacyId;
       heading.id = documentHeadingId(researchDocument.path, legacyId);
     }
-
-    const target = window.location.hash.slice(1);
-    if (!target.startsWith(`${bookId(researchDocument.path)}--`)) return;
-    const frame = window.requestAnimationFrame(() => {
-      window.document.getElementById(target)?.scrollIntoView();
-    });
-    return () => window.cancelAnimationFrame(frame);
   }, [researchDocument.body, researchDocument.path]);
 
   return (
@@ -150,9 +178,9 @@ export function BookEdition({
     (sum, document) => sum + document.words,
     0,
   );
-  const navigate = (path: string, hash = "") => {
-    window.location.assign(surfaceDocumentHref(path, hash));
-  };
+  useBookFragmentRestoration();
+  const navigate = (path: string, hash = "") =>
+    navigateFromBook(path, hash, bookDocumentPaths, surfaceDocumentHref);
   const bookHref = (path: string, hash: string) => {
     if (bookDocumentPaths.has(path)) {
       return hash ? `#${documentHeadingId(path, hash)}` : `#${bookId(path)}`;

--- a/app/globals.css
+++ b/app/globals.css
@@ -2016,10 +2016,13 @@ button {
   overflow-wrap: anywhere;
 }
 
+.book-shell-web .book-document,
 .book-prose h1,
 .book-prose h2,
 .book-prose h3,
-.book-prose h4 {
+.book-prose h4,
+.book-prose h5,
+.book-prose h6 {
   scroll-margin-top: 96px;
 }
 
@@ -2085,10 +2088,13 @@ button {
     flex-direction: column;
   }
 
+  .book-shell-web .book-document,
   .book-prose h1,
   .book-prose h2,
   .book-prose h3,
-  .book-prose h4 {
+  .book-prose h4,
+  .book-prose h5,
+  .book-prose h6 {
     scroll-margin-top: 28px;
   }
 }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "test:workstation": "node --test --experimental-test-isolation=none --test-concurrency=1 experiments/workstation/*.test.mjs experiments/workstation/**/*.test.mjs",
     "test:workstation:core": "node --test --experimental-test-isolation=none --test-concurrency=1 experiments/workstation/*.test.mjs experiments/workstation/lib/*.test.mjs",
     "test:readiness": "node --test --experimental-test-isolation=none scripts/readiness-summary.test.mjs",
-    "test:site": "node --test --experimental-test-isolation=none scripts/book-route.test.mjs scripts/book-edition-surface.test.mjs scripts/github-pages.test.mjs scripts/language-access.test.mjs scripts/mermaid-browser.test.mjs scripts/pages-base.test.mjs scripts/pages-seo.test.mjs scripts/prepare-reader-artifacts.test.mjs scripts/publication-unification.test.mjs",
+    "test:site": "node --test --experimental-test-isolation=none scripts/book-route.test.mjs scripts/book-edition-surface.test.mjs scripts/book-fragment-browser.test.mjs scripts/github-pages.test.mjs scripts/language-access.test.mjs scripts/mermaid-browser.test.mjs scripts/pages-base.test.mjs scripts/pages-seo.test.mjs scripts/prepare-reader-artifacts.test.mjs scripts/publication-unification.test.mjs",
     "validate:translations": "node scripts/validate-translations.mjs",
     "test:translations": "node --test --experimental-test-isolation=none scripts/translation-manifest.test.mjs scripts/translation-pages.test.mjs scripts/translation-vite-build.test.mjs",
     "validate:site-build": "node scripts/validate-github-pages-build.mjs",

--- a/public/downloads/book-manifest.json
+++ b/public/downloads/book-manifest.json
@@ -4,7 +4,7 @@
   "version": "0.3.0",
   "source_ref": "main",
   "pdf": "public/downloads/20-watts-was-enough-full-concept-book.pdf",
-  "source_digest": "dc9fbe445d11fbbc3313719c3bc7608a32a9d66fd58a182b25d1506240e11cfa",
+  "source_digest": "4a7b064f54febb59f07db837015e947db9e31bcdd646904027b12637db228368",
   "source_files": [
     "app/book-content.ts",
     "app/components/book-edition.tsx",

--- a/scripts/book-edition-surface.test.mjs
+++ b/scripts/book-edition-surface.test.mjs
@@ -138,14 +138,27 @@ test("the book manifest must carry the package version and explicit source ref",
   );
 });
 
-test("the book namespaces heading fragments while retaining document anchors", async () => {
-  const edition = await source("app/components/book-edition.tsx");
+test("the book namespaces and restores fragments while retaining document anchors", async () => {
+  const [edition, stylesheet] = await Promise.all([
+    source("app/components/book-edition.tsx"),
+    source("app/globals.css"),
+  ]);
 
   assert.match(edition, /function documentHeadingId\(path: string, headingId: string\)/);
   assert.match(edition, /heading\.dataset\.bookLegacyHeadingId \?\? heading\.id/);
   assert.match(edition, /heading\.id = documentHeadingId\(researchDocument\.path, legacyId\)/);
   assert.match(edition, /return hash \? `#\$\{documentHeadingId\(path, hash\)\}` : `#\$\{bookId\(path\)\}`/);
   assert.match(edition, /id=\{bookId\(document\.path\)\}/);
+  assert.match(edition, /window\.addEventListener\("hashchange", restoreFragment\)/);
+  assert.match(edition, /window\.removeEventListener\("hashchange", restoreFragment\)/);
+  assert.match(
+    edition,
+    /if \(bookDocumentPaths\.has\(path\)\) \{[\s\S]*window\.location\.assign\([\s\S]*documentHeadingId\(path, hash\)/,
+  );
+  assert.match(
+    stylesheet,
+    /\.book-shell-web \.book-document,[\s\S]*\.book-prose h6 \{\s*scroll-margin-top:\s*96px;/,
+  );
 });
 
 test("the web book defers media work while PDF rendering stays eager", async () => {

--- a/scripts/book-fragment-browser.test.mjs
+++ b/scripts/book-fragment-browser.test.mjs
@@ -1,0 +1,240 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { createServer as createTcpServer } from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { createServer as createViteServer } from "vite";
+import {
+  connectCdp,
+  devtoolsPage,
+  firstExistingChromium,
+  stopProcess,
+} from "./lib/chromium-cdp.mjs";
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const coldTarget =
+  "book-concept-07-cross-domain-convergence-md--candidate-production-is-not-acceptance";
+const navigationSource =
+  "book-math-visual-models-md--sparselocality-break-even-plane";
+const hashTarget = "book-concept-80-energy-model-md--data-movement-ledger";
+const pagesBasePath = "/20-watts-was-enough/";
+const viewports = Object.freeze([
+  { label: "desktop", width: 1440, height: 900, minimumClearance: 8 },
+  { label: "mobile", width: 375, height: 844, minimumClearance: 20 },
+]);
+
+async function reserveLocalPort() {
+  const server = createTcpServer();
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  assert.equal(typeof address, "object");
+  const port = address.port;
+  await new Promise((resolve, reject) => server.close((error) => (
+    error ? reject(error) : resolve()
+  )));
+  return port;
+}
+
+async function fragmentSnapshot(cdp, targetId) {
+  return (await cdp.send("Runtime.evaluate", {
+    expression: `(() => {
+      const target = document.getElementById(${JSON.stringify(targetId)});
+      const actions = document.querySelector(".book-actions");
+      const targetRect = target?.getBoundingClientRect();
+      const actionsRect = actions?.getBoundingClientRect();
+      const actionsPosition = actions ? getComputedStyle(actions).position : null;
+      const obstructionBottom = actionsPosition === "sticky"
+        ? Math.max(0, actionsRect?.bottom ?? 0)
+        : 0;
+      return {
+        actionsBottom: actionsRect?.bottom ?? null,
+        actionsPosition,
+        hash: location.hash,
+        readyState: document.readyState,
+        scrollMarginTop: target ? parseFloat(getComputedStyle(target).scrollMarginTop) : null,
+        scrollY,
+        tagName: target?.tagName ?? null,
+        targetBottom: targetRect?.bottom ?? null,
+        targetText: target?.textContent?.trim() ?? null,
+        targetTop: targetRect?.top ?? null,
+        obstructionBottom,
+        pathname: location.pathname,
+        search: location.search,
+        viewportHeight: innerHeight,
+        viewportWidth: innerWidth,
+      };
+    })()`,
+    returnByValue: true,
+  })).result?.value;
+}
+
+async function waitForVisibleFragment(cdp, targetId, timeoutMs = 30_000) {
+  const deadline = Date.now() + timeoutMs;
+  let previous;
+  let stableSamples = 0;
+  let snapshot;
+
+  while (Date.now() < deadline) {
+    snapshot = await fragmentSnapshot(cdp, targetId);
+    const visible =
+      snapshot?.readyState === "complete"
+      && snapshot.hash === `#${targetId}`
+      && /^H[1-6]$/u.test(snapshot.tagName ?? "")
+      && snapshot.targetBottom > 0
+      && snapshot.targetTop >= snapshot.obstructionBottom
+      && snapshot.targetTop < snapshot.viewportHeight;
+    const stable = visible
+      && previous
+      && Math.abs(snapshot.targetTop - previous.targetTop) < 0.5
+      && Math.abs(snapshot.scrollY - previous.scrollY) < 0.5;
+    stableSamples = stable ? stableSamples + 1 : 0;
+    if (stableSamples >= 5) return snapshot;
+    previous = snapshot;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+
+  assert.fail(`Fragment did not become stably visible: ${JSON.stringify(snapshot)}`);
+}
+
+function assertFragmentClearance(snapshot, viewport, mode) {
+  assert.equal(snapshot.viewportWidth, viewport.width, JSON.stringify(snapshot));
+  assert.ok(snapshot.targetText, `${mode}: missing target text`);
+  assert.ok(
+    snapshot.targetTop >= snapshot.obstructionBottom + viewport.minimumClearance,
+    `${mode}: heading is not clear of the action bar: ${JSON.stringify(snapshot)}`,
+  );
+  assert.ok(
+    snapshot.targetBottom > 0 && snapshot.targetTop < snapshot.viewportHeight,
+    `${mode}: heading is outside the viewport: ${JSON.stringify(snapshot)}`,
+  );
+  assert.ok(
+    snapshot.scrollMarginTop >= viewport.minimumClearance,
+    `${mode}: heading lacks fragment clearance: ${JSON.stringify(snapshot)}`,
+  );
+}
+
+function assertFragmentLocation(snapshot, viewport) {
+  assert.equal(snapshot.pathname, `${pagesBasePath}book/`, JSON.stringify(snapshot));
+  assert.equal(snapshot.search, `?fragment-test=${viewport.label}`, JSON.stringify(snapshot));
+}
+
+async function retainFragmentEvidence(cdp, label, snapshot) {
+  const outputRoot = process.env.BOOK_FRAGMENT_EVIDENCE_DIR?.trim();
+  if (!outputRoot) return;
+  await mkdir(outputRoot, { recursive: true });
+  const screenshot = await cdp.send("Page.captureScreenshot", {
+    captureBeyondViewport: false,
+    format: "png",
+    fromSurface: true,
+  });
+  await Promise.all([
+    writeFile(
+      path.join(outputRoot, `${label}.png`),
+      Buffer.from(screenshot.data, "base64"),
+      { flag: "wx" },
+    ),
+    writeFile(
+      path.join(outputRoot, `${label}.json`),
+      `${JSON.stringify(snapshot, null, 2)}\n`,
+      { flag: "wx" },
+    ),
+  ]);
+}
+
+async function navigate(cdp, url) {
+  const navigation = await cdp.send("Page.navigate", { url });
+  assert.equal(navigation.errorText, undefined);
+}
+
+test("book fragments restore below the action bar on cold load and hash navigation", {
+  timeout: 120_000,
+}, async () => {
+  const browser = await firstExistingChromium();
+  const debugPort = await reserveLocalPort();
+  const profile = await mkdtemp(path.join(os.tmpdir(), "20w-book-fragment-"));
+  const previousPagesBasePath = process.env.PAGES_BASE_PATH;
+  process.env.PAGES_BASE_PATH = pagesBasePath;
+  let vite;
+  let browserProcess;
+  let cdp;
+
+  try {
+    vite = await createViteServer({
+      configFile: path.join(repositoryRoot, "vite.pages.config.ts"),
+      logLevel: "silent",
+      server: { host: "127.0.0.1", port: 0 },
+    });
+    await vite.listen();
+    const address = vite.httpServer?.address();
+    assert.equal(typeof address, "object");
+    browserProcess = spawn(browser, [
+      "--headless=new",
+      "--disable-gpu",
+      "--disable-extensions",
+      "--disable-background-networking",
+      "--disable-dev-shm-usage",
+      "--disable-features=NetworkServiceSandbox",
+      "--no-sandbox",
+      "--no-proxy-server",
+      "--allow-insecure-localhost",
+      "--no-first-run",
+      "--no-default-browser-check",
+      "--hide-scrollbars",
+      "--window-size=1440,900",
+      `--remote-debugging-port=${debugPort}`,
+      `--user-data-dir=${profile}`,
+      "about:blank",
+    ], { stdio: "ignore", windowsHide: true });
+
+    cdp = await connectCdp(await devtoolsPage(browserProcess, debugPort));
+    await cdp.send("Page.enable");
+    await cdp.send("Runtime.enable");
+
+    for (const viewport of viewports) {
+      await cdp.send("Emulation.setDeviceMetricsOverride", {
+        width: viewport.width,
+        height: viewport.height,
+        deviceScaleFactor: 1,
+        mobile: viewport.width <= 760,
+      });
+
+      const bookUrl = `http://127.0.0.1:${address.port}${pagesBasePath}book/?fragment-test=${viewport.label}`;
+      await navigate(cdp, "about:blank");
+      await navigate(cdp, `${bookUrl}#${coldTarget}`);
+      const coldSnapshot = await waitForVisibleFragment(cdp, coldTarget);
+      assertFragmentClearance(coldSnapshot, viewport, `${viewport.label} cold load`);
+      assertFragmentLocation(coldSnapshot, viewport);
+      await retainFragmentEvidence(cdp, `${viewport.label}-cold`, coldSnapshot);
+
+      await navigate(cdp, `${bookUrl}#${navigationSource}`);
+      await waitForVisibleFragment(cdp, navigationSource);
+      const click = (await cdp.send("Runtime.evaluate", {
+        expression: `(() => {
+          const link = document.querySelector('a[href="#${hashTarget}"]');
+          const href = link?.getAttribute("href") ?? null;
+          link?.click();
+          return { found: Boolean(link), href };
+        })()`,
+        returnByValue: true,
+      })).result?.value;
+      assert.deepEqual(click, { found: true, href: `#${hashTarget}` });
+      const hashSnapshot = await waitForVisibleFragment(cdp, hashTarget);
+      assertFragmentClearance(hashSnapshot, viewport, `${viewport.label} hash navigation`);
+      assertFragmentLocation(hashSnapshot, viewport);
+      await retainFragmentEvidence(cdp, `${viewport.label}-hash`, hashSnapshot);
+    }
+  } finally {
+    cdp?.socket.close();
+    await stopProcess(browserProcess);
+    await vite?.close();
+    await rm(profile, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    if (previousPagesBasePath === undefined) delete process.env.PAGES_BASE_PATH;
+    else process.env.PAGES_BASE_PATH = previousPagesBasePath;
+  }
+});

--- a/scripts/book-pdf-semantic-baseline.json
+++ b/scripts/book-pdf-semantic-baseline.json
@@ -7,7 +7,7 @@
     "pdf": "public/downloads/20-watts-was-enough-full-concept-book.pdf",
     "manifest": "public/downloads/book-manifest.json",
     "pdf_sha256": "a3bd7e9fb4982e5fd63d07b301a3dfa7152b1d64dd7c744c9fcf4ceebaa422c8",
-    "manifest_sha256": "c3d050425ab7e41e187099e0cfbb37146aaf4c8921057a48091780b46277447f",
+    "manifest_sha256": "210fd565baaf8c0feb55575a93147e73fa3ea10092fd5a1994e9f8c37f1c55e0",
     "size_bytes": 12780003,
     "pages": 412,
     "page_size_name": "A4",
@@ -18,7 +18,7 @@
     "pdf_version": "1.4",
     "tagged": true,
     "source_ref": "main",
-    "source_digest": "dc9fbe445d11fbbc3313719c3bc7608a32a9d66fd58a182b25d1506240e11cfa",
+    "source_digest": "4a7b064f54febb59f07db837015e947db9e31bcdd646904027b12637db228368",
     "version": "0.3.0"
   },
   "tools": {


### PR DESCRIPTION
## Summary

- restore namespaced continuous-book fragments on both cold load and later hash navigation
- keep internal book links on the current Pages route while preserving the base path and query
- give every book chapter and heading responsive fragment clearance below the desktop action bar
- add a real Chrome regression at 1440 x 900 and 375 x 844
- refresh the source-bound PDF manifest and semantic-baseline identities; the PDF bytes are unchanged

## Validation

- `npm run check` under Node 26.8.1: 723 workstation tests, 722 passed, 1 explicit skip, 0 failed; complete Pages build and artifact validation passed
- final-base focused suite after rebasing onto `9cd3da1`: browser/book surface 19/19, semantic/release 35/35, PDF validation, policy, code shape, prose, typecheck, lint, and `git diff --check`
- pinned renderer produced two byte-identical renders; the PDF remains byte-identical to `main` at `a3bd7e9fb4982e5fd63d07b301a3dfa7152b1d64dd7c744c9fcf4ceebaa422c8`
- Poppler 26.08.0 semantic audit reproduced the exact existing five known-debt sentinel classes and all prior extraction hashes; this change does not claim to repair them
- four retained desktop/mobile cold-load/hash-navigation captures were opened and inspected

## Boundaries

This is a bounded fragment-navigation repair, not a general layout or accessibility pass. Keyboard focus transfer, 200% zoom, the medium-width breakpoint, forced colours, and equation-overflow quality remain unverified here.

Related to #10.