### PR TITLE
feat(experiment): add insertion-sort specialist vertical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@ the exact diff; this file records why the project changed.
   CI impact map now routes the importer and all six contract-named specialist
   packages through the Go lane instead of treating each new package as an
   unknown path.
+- The insertion-sort construction vertical now accepts only the validated
+  candidate and held-reference sets selected by that contract. Candidate IDs
+  become controller request IDs, prompt length and no-hint semantics are checked
+  against the parsed input, and the exact answer stays in a separate verifier.
+  Synthetic tests exercise the boundary; no dataset or scientific result is
+  added.
 - A versioned PDF semantic sentinel now binds the current source, book, A4 and
   tag metadata, Poppler tool identity, separate structure and text streams,
   exact diagnostics, and six nonlinear content anchors. Atomic evidence keeps

--- a/tooling/internal/clrsinsertion/adapter.go
+++ b/tooling/internal/clrsinsertion/adapter.go
@@ -1,0 +1,346 @@
+package clrsinsertion
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/lusoris/20-watts-was-enough/tooling/internal/clrsfixture"
+	"github.com/lusoris/20-watts-was-enough/tooling/internal/specialistcontrol"
+)
+
+const (
+	maximumIdentityBytes            = 128
+	maximumReferencesCeiling        = 4_096
+	maximumReferenceSetBytesCeiling = 64 << 20
+	// Four fixture identities, one prompt digest and the effective-size integer.
+	heldIdentityBytes = 5*sha256.Size + 8
+)
+
+var ErrReferenceLimit = errors.New("insertion-sort reference limit exceeded")
+
+// Specialist is the exact conventional insertion-sort implementation. It
+// owns no reference data and sees only specialistcontrol.Invocation.
+type Specialist struct {
+	id     string
+	limits Limits
+}
+
+// NewSpecialist closes the candidate-visible solver identity and bounds.
+func NewSpecialist(id string, limits Limits) (Specialist, error) {
+	if !validIdentity(id) {
+		return Specialist{}, errors.New("insertion-sort specialist identity is invalid")
+	}
+	if err := limits.Validate(); err != nil {
+		return Specialist{}, err
+	}
+	return Specialist{id: id, limits: limits}, nil
+}
+
+// Invoke implements specialistcontrol.Specialist.
+func (specialist Specialist) Invoke(
+	ctx context.Context,
+	invocation specialistcontrol.Invocation,
+) (specialistcontrol.SpecialistResult, error) {
+	refused := specialistcontrol.SpecialistResult{
+		Binding: invocation.Binding, SpecialistID: specialist.id, State: specialistcontrol.ResultRefused,
+	}
+	if ctx == nil {
+		return refused, errors.New("invoke insertion-sort specialist: nil context")
+	}
+	if err := ctx.Err(); err != nil {
+		return refused, err
+	}
+	if invocation.Task != specialistcontrol.TaskInsertionSort || invocation.Binding == (specialistcontrol.Binding{}) ||
+		invocation.MaxResultBytes <= 0 {
+		return refused, nil
+	}
+	answer, err := Solve(ctx, invocation.Payload, specialist.limits)
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return refused, err
+		}
+		if errors.Is(err, ErrInvalidLimits) || errors.Is(err, ErrMalformedPrompt) ||
+			errors.Is(err, ErrPromptLimit) || errors.Is(err, ErrAnswerLimit) {
+			return refused, nil
+		}
+		return refused, fmt.Errorf("solve insertion-sort invocation: %w", err)
+	}
+	if len(answer) > invocation.MaxResultBytes {
+		return refused, nil
+	}
+	return specialistcontrol.SpecialistResult{
+		Binding:      invocation.Binding,
+		SpecialistID: specialist.id,
+		State:        specialistcontrol.ResultCompleted,
+		Payload:      answer,
+	}, nil
+}
+
+// VerifierLimits bound the separately held reference index. They are safety
+// caps, not fixture counts or an experiment sampling decision.
+type VerifierLimits struct {
+	MaxReferences     int
+	MaxReferenceBytes int64
+}
+
+// Validate rejects an open or impractically large verifier index.
+func (limits VerifierLimits) Validate() error {
+	if limits.MaxReferences <= 0 || limits.MaxReferences > maximumReferencesCeiling ||
+		limits.MaxReferenceBytes <= 0 || limits.MaxReferenceBytes > maximumReferenceSetBytesCeiling {
+		return ErrReferenceLimit
+	}
+	return nil
+}
+
+type referenceKey struct {
+	runID     string
+	requestID string
+}
+
+type heldReference struct {
+	source             clrsfixture.SourceID
+	contract           clrsfixture.ContractID
+	candidateID        clrsfixture.CandidateID
+	verifierID         clrsfixture.VerifierID
+	promptSHA256       [sha256.Size]byte
+	effectiveInputSize int64
+	answer             []byte
+}
+
+type boundCandidate struct {
+	id     clrsfixture.CandidateID
+	prompt []byte
+}
+
+// RequestSet is the candidate-only projection of one validated insertion-sort
+// dataset run. It cannot be constructed from a raw prompt or held answer.
+type RequestSet struct {
+	runID      string
+	candidates []boundCandidate
+}
+
+// Verifier independently exact-scores against separately held references.
+type Verifier struct {
+	specialistID string
+	limits       Limits
+	references   map[referenceKey]heldReference
+}
+
+// BindDataset validates the exact contract-selected insertion-sort candidate
+// and verifier sets, then returns separate candidate-only and held-reference
+// views. Every value remains NO_RESULT.
+func BindDataset(
+	runID string,
+	specialistID string,
+	source clrsfixture.SourceRecord,
+	contract clrsfixture.GenerationContract,
+	candidates clrsfixture.CandidateSet,
+	verifiers clrsfixture.VerifierSet,
+	limits Limits,
+	verifierLimits VerifierLimits,
+) (RequestSet, Verifier, error) {
+	if !validIdentity(runID) || !validIdentity(specialistID) {
+		return RequestSet{}, Verifier{}, errors.New("insertion-sort run or specialist identity is invalid")
+	}
+	if err := limits.Validate(); err != nil {
+		return RequestSet{}, Verifier{}, err
+	}
+	if err := verifierLimits.Validate(); err != nil {
+		return RequestSet{}, Verifier{}, err
+	}
+	if err := PinnedSourceEvidence().ValidateSource(source); err != nil {
+		return RequestSet{}, Verifier{}, err
+	}
+	task, err := insertionTaskPlan(source, contract)
+	if err != nil {
+		return RequestSet{}, Verifier{}, err
+	}
+	pairs, err := clrsfixture.PairExamples(
+		source,
+		contract,
+		task.OutputRelativePath,
+		candidates,
+		verifiers,
+	)
+	if err != nil {
+		return RequestSet{}, Verifier{}, fmt.Errorf("pair insertion-sort dataset: %w", err)
+	}
+	if len(pairs) == 0 || len(pairs) > verifierLimits.MaxReferences {
+		return RequestSet{}, Verifier{}, fmt.Errorf("%w: reference count is %d", ErrReferenceLimit, len(pairs))
+	}
+
+	requestSet := RequestSet{runID: runID, candidates: make([]boundCandidate, 0, len(pairs))}
+	validated := make(map[referenceKey]heldReference, len(pairs))
+	var retainedBytes int64
+	for index, pair := range pairs {
+		candidate, held, bindErr := bindPair(pair, limits)
+		if bindErr != nil {
+			return RequestSet{}, Verifier{}, fmt.Errorf("bind insertion-sort pair %d: %w", index, bindErr)
+		}
+		requestID := candidate.id.String()
+		retainedBytes += int64(len(runID)+len(requestID)+len(held.answer)) + heldIdentityBytes
+		if retainedBytes > verifierLimits.MaxReferenceBytes {
+			return RequestSet{}, Verifier{}, fmt.Errorf("%w: retained bytes exceed %d", ErrReferenceLimit, verifierLimits.MaxReferenceBytes)
+		}
+		key := referenceKey{runID: runID, requestID: requestID}
+		if _, duplicate := validated[key]; duplicate {
+			return RequestSet{}, Verifier{}, fmt.Errorf("duplicate insertion-sort reference %s/%s", key.runID, key.requestID)
+		}
+		requestSet.candidates = append(requestSet.candidates, candidate)
+		validated[key] = held
+	}
+	return requestSet, Verifier{specialistID: specialistID, limits: limits, references: validated}, nil
+}
+
+// Requests returns fresh candidate-only controller packets for one closed run
+// window. RequestID is the source-and-contract-bound CandidateID.
+func (set RequestSet) Requests(issuedAt, deadline time.Time) ([]specialistcontrol.Request, error) {
+	if !validIdentity(set.runID) || len(set.candidates) == 0 {
+		return nil, errors.New("insertion-sort request set is unbound")
+	}
+	if issuedAt.IsZero() || deadline.IsZero() || !deadline.After(issuedAt) {
+		return nil, errors.New("insertion-sort request window is invalid")
+	}
+	requests := make([]specialistcontrol.Request, 0, len(set.candidates))
+	for _, candidate := range set.candidates {
+		requestID := candidate.id.String()
+		if !validIdentity(requestID) || len(candidate.prompt) == 0 {
+			return nil, errors.New("insertion-sort bound candidate is invalid")
+		}
+		requests = append(requests, specialistcontrol.Request{
+			RunID:     set.runID,
+			RequestID: requestID,
+			Task:      specialistcontrol.TaskInsertionSort,
+			Payload:   append([]byte(nil), candidate.prompt...),
+			IssuedAt:  issuedAt,
+			Deadline:  deadline,
+		})
+	}
+	return requests, nil
+}
+
+// Verify implements specialistcontrol.ExactVerifier.
+func (verifier Verifier) Verify(
+	ctx context.Context,
+	invocation specialistcontrol.Invocation,
+	candidate specialistcontrol.Candidate,
+) (specialistcontrol.Verification, error) {
+	verification := specialistcontrol.Verification{
+		Binding: candidate.Binding, CandidateBinding: candidate.CandidateBinding,
+		Verdict: specialistcontrol.VerificationAbstain,
+	}
+	if ctx == nil {
+		return verification, errors.New("verify insertion-sort candidate: nil context")
+	}
+	if err := ctx.Err(); err != nil {
+		return verification, err
+	}
+	if invocation.Task != specialistcontrol.TaskInsertionSort || invocation.Binding != candidate.Binding ||
+		candidate.Binding == (specialistcontrol.Binding{}) ||
+		candidate.CandidateBinding == (specialistcontrol.CandidateBinding{}) ||
+		candidate.SpecialistID != verifier.specialistID || candidate.State != specialistcontrol.ResultCompleted {
+		return verification, errors.New("verify insertion-sort candidate: invalid invocation binding")
+	}
+	held, present := verifier.references[referenceKey{runID: invocation.RunID, requestID: invocation.RequestID}]
+	if !present || held.candidateID.String() != invocation.RequestID ||
+		held.promptSHA256 != sha256.Sum256(invocation.Payload) {
+		return verification, errors.New("verify insertion-sort candidate: no exact prompt-bound reference")
+	}
+	values, err := parsePrompt(ctx, invocation.Payload, verifier.limits)
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return verification, err
+		}
+		return verification, errors.New("verify insertion-sort candidate: prompt semantics differ from the held candidate")
+	}
+	if int64(len(values)) != held.effectiveInputSize {
+		return verification, errors.New("verify insertion-sort candidate: prompt semantics differ from the held candidate")
+	}
+	if len(candidate.Payload) == 0 || len(candidate.Payload) > verifier.limits.MaxAnswerBytes {
+		return verification, errors.New("verify insertion-sort candidate: answer crosses verifier bounds")
+	}
+	if bytes.Equal(candidate.Payload, held.answer) {
+		verification.Verdict = specialistcontrol.VerificationExact
+	} else {
+		verification.Verdict = specialistcontrol.VerificationMismatch
+	}
+	return verification, nil
+}
+
+func insertionTaskPlan(
+	source clrsfixture.SourceRecord,
+	contract clrsfixture.GenerationContract,
+) (clrsfixture.TaskPlan, error) {
+	plan, err := contract.Plan(source)
+	if err != nil {
+		return clrsfixture.TaskPlan{}, fmt.Errorf("plan insertion-sort dataset: %w", err)
+	}
+	for _, task := range plan.Tasks {
+		if task.Task == clrsfixture.TaskInsertionSort {
+			return task, nil
+		}
+	}
+	return clrsfixture.TaskPlan{}, errors.New("generation contract has no insertion-sort task")
+}
+
+func bindPair(pair clrsfixture.PairedExample, limits Limits) (boundCandidate, heldReference, error) {
+	candidate := pair.Candidate
+	verifier := pair.Verifier
+	if candidate.Task != clrsfixture.TaskInsertionSort ||
+		candidate.LengthSemantics != clrsfixture.LengthDeclaredInput || candidate.UseHints ||
+		candidate.RequestedLength != candidate.EffectiveInputSize ||
+		verifier.CandidateID != candidate.ID {
+		return boundCandidate{}, heldReference{}, errors.New("pair differs from insertion-sort no-hint length semantics")
+	}
+	if candidate.EffectiveInputSize <= 0 || candidate.EffectiveInputSize > int64(limits.MaxValues) {
+		return boundCandidate{}, heldReference{}, fmt.Errorf(
+			"%w: effective input size %d exceeds 1..%d",
+			ErrPromptLimit,
+			candidate.EffectiveInputSize,
+			limits.MaxValues,
+		)
+	}
+	prompt := []byte(candidate.Prompt)
+	values, err := parsePrompt(context.Background(), prompt, limits)
+	if err != nil {
+		return boundCandidate{}, heldReference{}, fmt.Errorf("validate candidate prompt: %w", err)
+	}
+	if int64(len(values)) != candidate.EffectiveInputSize {
+		return boundCandidate{}, heldReference{}, fmt.Errorf(
+			"prompt value count = %d, want effective input size %d",
+			len(values), candidate.EffectiveInputSize,
+		)
+	}
+	answer := []byte(verifier.Reference)
+	if err := validateReference(context.Background(), answer, limits, values); err != nil {
+		return boundCandidate{}, heldReference{}, err
+	}
+	return boundCandidate{id: candidate.ID, prompt: append([]byte(nil), prompt...)}, heldReference{
+		source:             candidate.Source,
+		contract:           candidate.Contract,
+		candidateID:        candidate.ID,
+		verifierID:         verifier.ID,
+		promptSHA256:       sha256.Sum256(prompt),
+		effectiveInputSize: candidate.EffectiveInputSize,
+		answer:             append([]byte(nil), answer...),
+	}, nil
+}
+
+func validIdentity(value string) bool {
+	if len(value) == 0 || len(value) > maximumIdentityBytes {
+		return false
+	}
+	for index := range len(value) {
+		character := value[index]
+		if (character < 'a' || character > 'z') && (character < 'A' || character > 'Z') &&
+			(character < '0' || character > '9') && character != '.' && character != '_' &&
+			character != ':' && character != '-' {
+			return false
+		}
+	}
+	return true
+}

--- a/tooling/internal/clrsinsertion/adapter_test.go
+++ b/tooling/internal/clrsinsertion/adapter_test.go
@@ -1,0 +1,878 @@
+package clrsinsertion
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lusoris/20-watts-was-enough/tooling/internal/clrsfixture"
+	"github.com/lusoris/20-watts-was-enough/tooling/internal/specialistcontrol"
+)
+
+const (
+	testRunID        = "run-001"
+	testSpecialistID = "exact-insertion-sort-v1"
+)
+
+var verticalNow = time.Date(2026, time.August, 31, 12, 0, 0, 0, time.UTC)
+
+type recorderFunc func(context.Context, specialistcontrol.Decision) error
+
+func (function recorderFunc) RecordDecision(ctx context.Context, decision specialistcontrol.Decision) error {
+	return function(ctx, decision)
+}
+
+type specialistFunc func(context.Context, specialistcontrol.Invocation) (specialistcontrol.SpecialistResult, error)
+
+func (function specialistFunc) Invoke(ctx context.Context, invocation specialistcontrol.Invocation) (specialistcontrol.SpecialistResult, error) {
+	return function(ctx, invocation)
+}
+
+type verifierFunc func(context.Context, specialistcontrol.Invocation, specialistcontrol.Candidate) (specialistcontrol.Verification, error)
+
+func (function verifierFunc) Verify(ctx context.Context, invocation specialistcontrol.Invocation, candidate specialistcontrol.Candidate) (specialistcontrol.Verification, error) {
+	return function(ctx, invocation, candidate)
+}
+
+func TestBindDatasetBuildsContractBoundRequestsAndIsolatesReferences(t *testing.T) {
+	t.Parallel()
+	fixture := newImportFixture(t, clrsfixture.TaskInsertionSort)
+	reorderedVerifiers := cloneVerifierSet(fixture.verifiers)
+	for left, right := 0, len(reorderedVerifiers.Examples)-1; left < right; left, right = left+1, right-1 {
+		reorderedVerifiers.Examples[left], reorderedVerifiers.Examples[right] =
+			reorderedVerifiers.Examples[right], reorderedVerifiers.Examples[left]
+	}
+	requestSet, verifier, err := BindDataset(
+		testRunID,
+		testSpecialistID,
+		fixture.source,
+		fixture.contract,
+		fixture.candidates,
+		reorderedVerifiers,
+		testLimits(),
+		testVerifierLimits(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requests, err := requestSet.Requests(verticalNow.Add(-time.Second), verticalNow.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(requests) != fixture.task.ExpectedExamples {
+		t.Fatalf("request count = %d, want %d", len(requests), fixture.task.ExpectedExamples)
+	}
+	for index, request := range requests {
+		candidate := fixture.candidates.Examples[index]
+		if request.RunID != testRunID || request.RequestID != candidate.ID.String() ||
+			request.Task != specialistcontrol.TaskInsertionSort ||
+			!bytes.Equal(request.Payload, []byte(candidate.Prompt)) {
+			t.Fatalf("request %d = %#v, candidate %#v", index, request, candidate)
+		}
+		key := referenceKey{runID: testRunID, requestID: request.RequestID}
+		held, present := verifier.references[key]
+		expectedVerifier := fixture.verifiers.Examples[index]
+		if !present || held.source != candidate.Source || held.contract != candidate.Contract ||
+			held.candidateID != candidate.ID || held.verifierID != expectedVerifier.ID ||
+			held.effectiveInputSize != candidate.EffectiveInputSize ||
+			!bytes.Equal(held.answer, []byte(expectedVerifier.Reference)) {
+			t.Fatalf("held reference %d = %#v", index, held)
+		}
+	}
+	for _, candidateType := range []reflect.Type{
+		reflect.TypeOf(RequestSet{}),
+		reflect.TypeOf(boundCandidate{}),
+		reflect.TypeOf(specialistcontrol.Invocation{}),
+	} {
+		for index := 0; index < candidateType.NumField(); index++ {
+			name := strings.ToLower(candidateType.Field(index).Name)
+			if strings.Contains(name, "answer") || strings.Contains(name, "reference") {
+				t.Fatalf("candidate-visible type %s exposes verifier field %q", candidateType, name)
+			}
+		}
+	}
+}
+
+func TestBindDatasetRejectsForeignAndTamperedContractRecords(t *testing.T) {
+	t.Parallel()
+	insertion := newImportFixture(t, clrsfixture.TaskInsertionSort)
+	binary := newImportFixture(t, clrsfixture.TaskBinarySearch)
+	if _, _, err := BindDataset(
+		testRunID,
+		testSpecialistID,
+		binary.source,
+		binary.contract,
+		binary.candidates,
+		binary.verifiers,
+		testLimits(),
+		testVerifierLimits(),
+	); err == nil {
+		t.Fatal("BindDataset accepted a valid foreign task set")
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*clrsfixture.CandidateSet, *clrsfixture.VerifierSet)
+	}{
+		{"candidate identity", func(c *clrsfixture.CandidateSet, _ *clrsfixture.VerifierSet) { c.Examples[0].ID[0] ^= 1 }},
+		{"candidate prompt", func(c *clrsfixture.CandidateSet, _ *clrsfixture.VerifierSet) { c.Examples[0].Prompt += " mutation" }},
+		{"candidate task", func(c *clrsfixture.CandidateSet, _ *clrsfixture.VerifierSet) {
+			c.Examples[0].Task = clrsfixture.TaskBinarySearch
+		}},
+		{"candidate effective size", func(c *clrsfixture.CandidateSet, _ *clrsfixture.VerifierSet) { c.Examples[0].EffectiveInputSize++ }},
+		{"candidate hints", func(c *clrsfixture.CandidateSet, _ *clrsfixture.VerifierSet) { c.Examples[0].UseHints = true }},
+		{"verifier identity", func(_ *clrsfixture.CandidateSet, v *clrsfixture.VerifierSet) { v.Examples[0].ID[0] ^= 1 }},
+		{"verifier answer", func(_ *clrsfixture.CandidateSet, v *clrsfixture.VerifierSet) { v.Examples[0].Reference += " mutation" }},
+		{"missing candidate", func(c *clrsfixture.CandidateSet, _ *clrsfixture.VerifierSet) { c.Examples = c.Examples[1:] }},
+		{"missing verifier", func(_ *clrsfixture.CandidateSet, v *clrsfixture.VerifierSet) { v.Examples = v.Examples[1:] }},
+		{"reordered candidates", func(c *clrsfixture.CandidateSet, _ *clrsfixture.VerifierSet) {
+			c.Examples[0], c.Examples[1] = c.Examples[1], c.Examples[0]
+		}},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			candidates := cloneCandidateSet(insertion.candidates)
+			verifiers := cloneVerifierSet(insertion.verifiers)
+			test.mutate(&candidates, &verifiers)
+			if _, _, err := BindDataset(
+				testRunID,
+				testSpecialistID,
+				insertion.source,
+				insertion.contract,
+				candidates,
+				verifiers,
+				testLimits(),
+				testVerifierLimits(),
+			); err == nil {
+				t.Fatalf("BindDataset accepted %s", test.name)
+			}
+		})
+	}
+
+	foreignSource := insertion.source
+	foreignSource.Commit = "a" + foreignSource.Commit[1:]
+	if _, _, err := BindDataset(
+		testRunID,
+		testSpecialistID,
+		foreignSource,
+		insertion.contract,
+		insertion.candidates,
+		insertion.verifiers,
+		testLimits(),
+		testVerifierLimits(),
+	); err == nil {
+		t.Fatal("BindDataset accepted a source record outside the pinned insertion evidence")
+	}
+	foreignContract := insertion.contract
+	foreignContract.Seeds = append([]int64(nil), insertion.contract.Seeds...)
+	foreignContract.Seeds[0]++
+	if _, _, err := BindDataset(
+		testRunID,
+		testSpecialistID,
+		insertion.source,
+		foreignContract,
+		insertion.candidates,
+		insertion.verifiers,
+		testLimits(),
+		testVerifierLimits(),
+	); err == nil {
+		t.Fatal("BindDataset accepted a mutated generation contract")
+	}
+}
+
+func TestBindDatasetRejectsPromptSemanticsMissingFromTheGenericImporter(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		mutate func(*testExample)
+	}{
+		{
+			name: "effective input size mismatch",
+			mutate: func(example *testExample) {
+				example.prompt, example.reference = insertionExample(3)
+			},
+		},
+		{
+			name: "hint-bearing prompt",
+			mutate: func(example *testExample) {
+				example.prompt += "hint:\n"
+			},
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			fixture := newImportFixture(t, clrsfixture.TaskInsertionSort)
+			test.mutate(&fixture.dataset.examples[0])
+			fixture.importDataset(t)
+			if _, _, err := BindDataset(
+				testRunID,
+				testSpecialistID,
+				fixture.source,
+				fixture.contract,
+				fixture.candidates,
+				fixture.verifiers,
+				testLimits(),
+				testVerifierLimits(),
+			); err == nil {
+				t.Fatalf("BindDataset accepted %s", test.name)
+			}
+		})
+	}
+}
+
+func TestBindDatasetRejectsSemanticallyWrongHeldAnswers(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		mutate func(*testExample)
+	}{
+		{
+			name: "unsorted",
+			mutate: func(example *testExample) {
+				descending, _ := insertionTokens(example.length)
+				example.reference = formatTestAnswer(descending)
+			},
+		},
+		{
+			name: "foreign value",
+			mutate: func(example *testExample) {
+				_, ascending := insertionTokens(example.length)
+				ascending[len(ascending)-1] = "0.999999"
+				example.reference = formatTestAnswer(ascending)
+			},
+		},
+		{
+			name: "duplicate and missing",
+			mutate: func(example *testExample) {
+				_, ascending := insertionTokens(example.length)
+				ascending[len(ascending)-1] = ascending[len(ascending)-2]
+				example.reference = formatTestAnswer(ascending)
+			},
+		},
+		{
+			name: "alternate spelling",
+			mutate: func(example *testExample) {
+				_, ascending := insertionTokens(example.length)
+				ascending[0] += "0"
+				example.reference = formatTestAnswer(ascending)
+			},
+		},
+		{
+			name: "equal value reordered",
+			mutate: func(example *testExample) {
+				example.prompt = "insertion_sort:\nkey: [0.2 0.10 0.1 0.100 0.3 0.4 0.5 0.6 0.7 0.8]\npred:\n"
+				example.reference = "[0.1 0.10 0.100 0.2 0.3 0.4 0.5 0.6 0.7 0.8]\n\n"
+			},
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			fixture := newImportFixture(t, clrsfixture.TaskInsertionSort)
+			test.mutate(&fixture.dataset.examples[0])
+			fixture.importDataset(t)
+			if _, _, err := BindDataset(
+				testRunID,
+				testSpecialistID,
+				fixture.source,
+				fixture.contract,
+				fixture.candidates,
+				fixture.verifiers,
+				testLimits(),
+				testVerifierLimits(),
+			); err == nil {
+				t.Fatalf("BindDataset accepted %s held answer", test.name)
+			}
+		})
+	}
+}
+
+func TestRequestSetAndVerifierSnapshotTheirSeparateInputs(t *testing.T) {
+	t.Parallel()
+	fixture := newImportFixture(t, clrsfixture.TaskInsertionSort)
+	originalPrompt := fixture.candidates.Examples[0].Prompt
+	originalAnswer := fixture.verifiers.Examples[0].Reference
+	requestSet, verifier, err := BindDataset(
+		testRunID,
+		testSpecialistID,
+		fixture.source,
+		fixture.contract,
+		fixture.candidates,
+		fixture.verifiers,
+		testLimits(),
+		testVerifierLimits(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixture.candidates.Examples[0].Prompt = "mutated"
+	fixture.verifiers.Examples[0].Reference = "mutated"
+
+	requests, err := requestSet.Requests(verticalNow.Add(-time.Second), verticalNow.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	requests[0].Payload[0] = 'X'
+	fresh, err := requestSet.Requests(verticalNow.Add(-time.Second), verticalNow.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(fresh[0].Payload) != originalPrompt {
+		t.Fatalf("fresh request payload = %q, want original prompt", fresh[0].Payload)
+	}
+	invocation, candidate := verificationInputs(fresh[0], []byte(originalAnswer))
+	verification, err := verifier.Verify(context.Background(), invocation, candidate)
+	if err != nil || verification.Verdict != specialistcontrol.VerificationExact {
+		t.Fatalf("Verify(snapshot) = %#v, error %v", verification, err)
+	}
+
+	for name, window := range map[string][2]time.Time{
+		"zero issued":   {{}, verticalNow},
+		"zero deadline": {verticalNow, {}},
+		"equal":         {verticalNow, verticalNow},
+		"reverse":       {verticalNow, verticalNow.Add(-time.Second)},
+	} {
+		if _, err := requestSet.Requests(window[0], window[1]); err == nil {
+			t.Fatalf("Requests accepted %s window", name)
+		}
+	}
+	if _, err := (RequestSet{}).Requests(verticalNow, verticalNow.Add(time.Second)); err == nil {
+		t.Fatal("zero RequestSet produced requests")
+	}
+}
+
+func TestVerifierRejectsRunCandidateAndPromptSubstitution(t *testing.T) {
+	t.Parallel()
+	fixture := newImportFixture(t, clrsfixture.TaskInsertionSort)
+	requestSet, verifier := bindFixture(t, fixture, testLimits(), testVerifierLimits())
+	requests, err := requestSet.Requests(verticalNow.Add(-time.Second), verticalNow.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	answer := []byte(fixture.verifiers.Examples[0].Reference)
+	invocation, candidate := verificationInputs(requests[0], answer)
+	if verification, err := verifier.Verify(context.Background(), invocation, candidate); err != nil ||
+		verification.Verdict != specialistcontrol.VerificationExact {
+		t.Fatalf("baseline verification = %#v, error %v", verification, err)
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*specialistcontrol.Invocation)
+	}{
+		{"run", func(value *specialistcontrol.Invocation) { value.RunID = "run-foreign" }},
+		{"candidate identity", func(value *specialistcontrol.Invocation) { value.RequestID = requests[3].RequestID }},
+		{"prompt", func(value *specialistcontrol.Invocation) { value.Payload[0] = 'X' }},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			changed := invocation
+			changed.Payload = append([]byte(nil), invocation.Payload...)
+			test.mutate(&changed)
+			if _, err := verifier.Verify(context.Background(), changed, candidate); err == nil {
+				t.Fatalf("Verify accepted %s substitution", test.name)
+			}
+		})
+	}
+	cancelled := &cancelAfterChecksContext{Context: context.Background(), cancelAt: 3}
+	if _, err := verifier.Verify(cancelled, invocation, candidate); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Verify(mid-parse cancellation) error = %v, want context.Canceled", err)
+	}
+}
+
+func TestBindDatasetClosesRunAndReferenceBounds(t *testing.T) {
+	t.Parallel()
+	fixture := newImportFixture(t, clrsfixture.TaskInsertionSort)
+	tests := []struct {
+		name             string
+		runID            string
+		specialistID     string
+		limits           Limits
+		verifierLimits   VerifierLimits
+		wantReferenceErr bool
+	}{
+		{"empty run", "", testSpecialistID, testLimits(), testVerifierLimits(), false},
+		{"bad specialist", testRunID, "bad specialist", testLimits(), testVerifierLimits(), false},
+		{"open reference count", testRunID, testSpecialistID, testLimits(), VerifierLimits{MaxReferenceBytes: 1024}, true},
+		{"small reference count", testRunID, testSpecialistID, testLimits(), VerifierLimits{MaxReferences: 8, MaxReferenceBytes: 16 << 10}, true},
+		{"small reference bytes", testRunID, testSpecialistID, testLimits(), VerifierLimits{MaxReferences: 16, MaxReferenceBytes: 1}, true},
+		{"small value count", testRunID, testSpecialistID, withLimits(func(value *Limits) { value.MaxValues = 8 }), testVerifierLimits(), false},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			_, _, err := BindDataset(
+				test.runID,
+				test.specialistID,
+				fixture.source,
+				fixture.contract,
+				fixture.candidates,
+				fixture.verifiers,
+				test.limits,
+				test.verifierLimits,
+			)
+			if err == nil {
+				t.Fatalf("BindDataset accepted %s", test.name)
+			}
+			if test.wantReferenceErr && !errors.Is(err, ErrReferenceLimit) {
+				t.Fatalf("BindDataset(%s) error = %v, want ErrReferenceLimit", test.name, err)
+			}
+		})
+	}
+}
+
+func TestInsertionSortVerticalRecordsBeforeEffectAndKeepsReferenceOutOfSpecialist(t *testing.T) {
+	t.Parallel()
+	runner, events, request, reference := verticalRunner(t, nil)
+	run, err := runner.Run(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.Decision.State != specialistcontrol.DecisionInvoke ||
+		run.Outcome.State != specialistcontrol.OutcomeVerified ||
+		run.Outcome.Authority != specialistcontrol.ResultAuthority ||
+		!bytes.Equal(run.Outcome.Payload, reference) {
+		t.Fatalf("vertical outcome = %#v", run)
+	}
+	if !reflect.DeepEqual(*events, []string{"record", "invoke", "verify"}) {
+		t.Fatalf("effect order = %v, want record/invoke/verify", *events)
+	}
+}
+
+func TestInsertionSortVerticalRefusesMalformedAndOversizedInputBeforeVerification(t *testing.T) {
+	t.Parallel()
+	fixture := newImportFixture(t, clrsfixture.TaskInsertionSort)
+	requestSet, verifier := bindFixture(t, fixture, testLimits(), testVerifierLimits())
+	requests, err := requestSet.Requests(verticalNow.Add(-time.Second), verticalNow.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, prompt := range map[string][]byte{
+		"malformed": []byte("insertion_sort:\nkey: [0.3, 0.1 0.2]\npred:\n"),
+		"oversized": []byte("insertion_sort:\nkey: [0.3 0.1 0.2 0.4]\npred:\n"),
+	} {
+		name, prompt := name, prompt
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			limits := testLimits()
+			limits.MaxValues = 3
+			specialist, err := NewSpecialist(testSpecialistID, limits)
+			if err != nil {
+				t.Fatal(err)
+			}
+			verifierCalled := false
+			observedVerifier := verifierFunc(func(ctx context.Context, invocation specialistcontrol.Invocation, candidate specialistcontrol.Candidate) (specialistcontrol.Verification, error) {
+				verifierCalled = true
+				return verifier.Verify(ctx, invocation, candidate)
+			})
+			runner := newVerticalRunner(
+				t,
+				specialist,
+				recorderFunc(func(context.Context, specialistcontrol.Decision) error { return nil }),
+				observedVerifier,
+				func() time.Time { return verticalNow },
+			)
+			request := requests[0]
+			request.Payload = prompt
+			run, runErr := runner.Run(context.Background(), request)
+			if runErr != nil || verifierCalled || run.Outcome.State != specialistcontrol.OutcomeRefused ||
+				run.Outcome.Reason != specialistcontrol.ReasonSpecialistRefused ||
+				run.Outcome.Authority != specialistcontrol.ResultAuthority {
+				t.Fatalf("Run(%s) error/verifier/outcome = %v/%t/%#v", name, runErr, verifierCalled, run.Outcome)
+			}
+		})
+	}
+}
+
+func TestInsertionSortVerticalTypesCancellationAndDeadlineAsNoResult(t *testing.T) {
+	t.Parallel()
+	t.Run("cancelled", func(t *testing.T) {
+		t.Parallel()
+		runner, _, request, _ := verticalRunner(t, nil)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		run, err := runner.Run(ctx, request)
+		if !errors.Is(err, context.Canceled) || run.Outcome.State != specialistcontrol.OutcomeAbstained ||
+			run.Outcome.Reason != specialistcontrol.ReasonCancelled ||
+			run.Outcome.Authority != specialistcontrol.ResultAuthority {
+			t.Fatalf("cancelled outcome/error = %#v/%v", run.Outcome, err)
+		}
+	})
+
+	t.Run("deadline", func(t *testing.T) {
+		t.Parallel()
+		fixture := newImportFixture(t, clrsfixture.TaskInsertionSort)
+		requestSet, verifier := bindFixture(t, fixture, testLimits(), testVerifierLimits())
+		requests, err := requestSet.Requests(verticalNow.Add(-time.Second), verticalNow.Add(time.Second))
+		if err != nil {
+			t.Fatal(err)
+		}
+		specialist, err := NewSpecialist(testSpecialistID, testLimits())
+		if err != nil {
+			t.Fatal(err)
+		}
+		calls := 0
+		clock := func() time.Time {
+			calls++
+			if calls == 2 {
+				return requests[0].Deadline
+			}
+			return verticalNow
+		}
+		invoked := false
+		runner := newVerticalRunner(
+			t,
+			specialistFunc(func(ctx context.Context, invocation specialistcontrol.Invocation) (specialistcontrol.SpecialistResult, error) {
+				invoked = true
+				return specialist.Invoke(ctx, invocation)
+			}),
+			recorderFunc(func(context.Context, specialistcontrol.Decision) error { return nil }),
+			verifier,
+			clock,
+		)
+		run, runErr := runner.Run(context.Background(), requests[0])
+		if runErr != nil || invoked || run.Outcome.State != specialistcontrol.OutcomeAbstained ||
+			run.Outcome.Reason != specialistcontrol.ReasonDeadlineElapsed ||
+			run.Outcome.Authority != specialistcontrol.ResultAuthority {
+			t.Fatalf("deadline outcome/error/invoked = %#v/%v/%t", run.Outcome, runErr, invoked)
+		}
+	})
+}
+
+func TestInsertionSortVerticalAbstainsOnWrongAnswer(t *testing.T) {
+	t.Parallel()
+	fixture := newImportFixture(t, clrsfixture.TaskInsertionSort)
+	requestSet, verifier := bindFixture(t, fixture, testLimits(), testVerifierLimits())
+	requests, err := requestSet.Requests(verticalNow.Add(-time.Second), verticalNow.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrong := specialistFunc(func(_ context.Context, invocation specialistcontrol.Invocation) (specialistcontrol.SpecialistResult, error) {
+		return specialistcontrol.SpecialistResult{
+			Binding: invocation.Binding, SpecialistID: testSpecialistID,
+			State: specialistcontrol.ResultCompleted, Payload: []byte("[0.3 0.2 0.1]\n\n"),
+		}, nil
+	})
+	runner := newVerticalRunner(
+		t,
+		wrong,
+		recorderFunc(func(context.Context, specialistcontrol.Decision) error { return nil }),
+		verifier,
+		func() time.Time { return verticalNow },
+	)
+	run, runErr := runner.Run(context.Background(), requests[0])
+	if runErr != nil || run.Outcome.State != specialistcontrol.OutcomeAbstained ||
+		run.Outcome.Reason != specialistcontrol.ReasonVerificationMismatch ||
+		run.Outcome.Authority != specialistcontrol.ResultAuthority || len(run.Outcome.Payload) != 0 {
+		t.Fatalf("wrong-answer outcome/error = %#v/%v", run.Outcome, runErr)
+	}
+}
+
+func verticalRunner(
+	t *testing.T,
+	clock func() time.Time,
+) (specialistcontrol.Runner, *[]string, specialistcontrol.Request, []byte) {
+	t.Helper()
+	if clock == nil {
+		clock = func() time.Time { return verticalNow }
+	}
+	fixture := newImportFixture(t, clrsfixture.TaskInsertionSort)
+	requestSet, verifier := bindFixture(t, fixture, testLimits(), testVerifierLimits())
+	requests, err := requestSet.Requests(verticalNow.Add(-time.Second), verticalNow.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	reference := []byte(fixture.verifiers.Examples[0].Reference)
+	specialist, err := NewSpecialist(testSpecialistID, testLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	events := make([]string, 0, 3)
+	observedSpecialist := specialistFunc(func(ctx context.Context, invocation specialistcontrol.Invocation) (specialistcontrol.SpecialistResult, error) {
+		events = append(events, "invoke")
+		if bytes.Contains(invocation.Payload, reference) {
+			t.Fatal("verifier-only reference bytes leaked into the specialist request")
+		}
+		return specialist.Invoke(ctx, invocation)
+	})
+	observedVerifier := verifierFunc(func(ctx context.Context, invocation specialistcontrol.Invocation, candidate specialistcontrol.Candidate) (specialistcontrol.Verification, error) {
+		events = append(events, "verify")
+		return verifier.Verify(ctx, invocation, candidate)
+	})
+	runner := newVerticalRunner(
+		t,
+		observedSpecialist,
+		recorderFunc(func(context.Context, specialistcontrol.Decision) error {
+			events = append(events, "record")
+			return nil
+		}),
+		observedVerifier,
+		clock,
+	)
+	return runner, &events, requests[0], reference
+}
+
+func newVerticalRunner(
+	t *testing.T,
+	target specialistcontrol.Specialist,
+	recorder specialistcontrol.DecisionRecorder,
+	verifier specialistcontrol.ExactVerifier,
+	clock func() time.Time,
+) specialistcontrol.Runner {
+	t.Helper()
+	routes := make([]specialistcontrol.Route, 0, len(specialistcontrol.Tasks()))
+	specialists := make(map[string]specialistcontrol.Specialist, len(specialistcontrol.Tasks()))
+	for _, task := range specialistcontrol.Tasks() {
+		id := "unavailable-" + string(task)
+		if task == specialistcontrol.TaskInsertionSort {
+			id = testSpecialistID
+			specialists[id] = target
+		} else {
+			specialists[id] = specialistFunc(func(_ context.Context, invocation specialistcontrol.Invocation) (specialistcontrol.SpecialistResult, error) {
+				return specialistcontrol.SpecialistResult{
+					Binding: invocation.Binding, SpecialistID: "unavailable-" + string(invocation.Task),
+					State: specialistcontrol.ResultAbstained,
+				}, nil
+			})
+		}
+		routes = append(routes, specialistcontrol.Route{Task: task, SpecialistID: id})
+	}
+	policy, err := specialistcontrol.NewPolicy(specialistcontrol.Limits{
+		MaxRequestBytes: 1024,
+		MaxResultBytes:  1024,
+		MaxRequestAge:   2 * time.Second,
+		MaxExecution:    2 * time.Second,
+	}, routes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner, err := specialistcontrol.NewRunner(policy, recorder, specialists, verifier, clock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return runner
+}
+
+type testExample struct {
+	prompt    string
+	reference string
+	length    int64
+	seed      int64
+	useHints  bool
+}
+
+type testDataset struct {
+	name     string
+	examples []testExample
+}
+
+type importFixture struct {
+	source     clrsfixture.SourceRecord
+	contract   clrsfixture.GenerationContract
+	task       clrsfixture.TaskPlan
+	dataset    testDataset
+	candidates clrsfixture.CandidateSet
+	verifiers  clrsfixture.VerifierSet
+}
+
+func newImportFixture(t *testing.T, task clrsfixture.TaskKind) importFixture {
+	t.Helper()
+	sourceBody := readGeneratorFile(t, "upstream.json")
+	source, err := clrsfixture.ParseSourceRecord(sourceBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	contractBody := readGeneratorFile(t, "contract.json")
+	contract, err := clrsfixture.ParseGenerationContract(contractBody, source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := contract.Plan(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var selected clrsfixture.TaskPlan
+	for _, candidate := range plan.Tasks {
+		if candidate.Task == task {
+			selected = candidate
+			break
+		}
+	}
+	if selected.Task == "" {
+		t.Fatalf("task %s is absent from tracked contract", task)
+	}
+	fixture := importFixture{
+		source: source, contract: contract, task: selected,
+		dataset: makeTestDataset(plan, selected),
+	}
+	fixture.importDataset(t)
+	return fixture
+}
+
+func (fixture *importFixture) importDataset(t *testing.T) {
+	t.Helper()
+	body, err := json.Marshal(fixture.dataset.jsonValue())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixture.candidates, fixture.verifiers, err = clrsfixture.ImportDataset(
+		bytes.NewReader(body),
+		fixture.source,
+		fixture.contract,
+		fixture.task.OutputRelativePath,
+		testImportLimits(),
+	)
+	if err != nil {
+		t.Fatalf("import synthetic contract-bound %s dataset: %v", fixture.task.Task, err)
+	}
+}
+
+func makeTestDataset(plan clrsfixture.GenerationPlan, task clrsfixture.TaskPlan) testDataset {
+	dataset := testDataset{name: "clrs_text_" + string(task.Task)}
+	for _, size := range task.Sizes {
+		for _, seed := range plan.Seeds {
+			for sample := 0; sample < plan.SamplesPerCell; sample++ {
+				prompt := fmt.Sprintf("%s:\ninput: %d/%d/%d", task.Task, size.RequestedLength, seed, sample)
+				reference := fmt.Sprintf("reference-%d-%d-%d", size.RequestedLength, seed, sample)
+				if task.Task == clrsfixture.TaskInsertionSort {
+					prompt, reference = insertionExample(size.RequestedLength)
+				}
+				dataset.examples = append(dataset.examples, testExample{
+					prompt: prompt, reference: reference,
+					length: size.RequestedLength, seed: seed, useHints: plan.UseHints,
+				})
+			}
+		}
+	}
+	return dataset
+}
+
+func (dataset testDataset) jsonValue() map[string]any {
+	examples := make([]any, 0, len(dataset.examples))
+	for _, example := range dataset.examples {
+		examples = append(examples, map[string]any{
+			"prompt":     example.prompt,
+			"references": []string{example.reference},
+			"auxiliary": map[string]any{
+				"length": example.length, "seed": example.seed, "use_hints": example.useHints,
+			},
+		})
+	}
+	return map[string]any{"name": dataset.name, "examples": examples}
+}
+
+func insertionExample(length int64) (string, string) {
+	descending, ascending := insertionTokens(length)
+	return "insertion_sort:\nkey: [" + strings.Join(descending, " ") + "]\npred:\n", formatTestAnswer(ascending)
+}
+
+func insertionTokens(length int64) ([]string, []string) {
+	ascending := make([]string, 0, length)
+	for value := int64(1); value <= length; value++ {
+		ascending = append(ascending, fmt.Sprintf("0.%06d", value))
+	}
+	descending := append([]string(nil), ascending...)
+	for left, right := 0, len(descending)-1; left < right; left, right = left+1, right-1 {
+		descending[left], descending[right] = descending[right], descending[left]
+	}
+	return descending, ascending
+}
+
+func formatTestAnswer(tokens []string) string {
+	return "[" + strings.Join(tokens, " ") + "]\n\n"
+}
+
+func readGeneratorFile(t *testing.T, name string) []byte {
+	t.Helper()
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("locate insertion-sort adapter test")
+	}
+	body, err := os.ReadFile(filepath.Join(filepath.Dir(filename), "..", "..", "clrs-generator", name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return body
+}
+
+func bindFixture(
+	t *testing.T,
+	fixture importFixture,
+	limits Limits,
+	verifierLimits VerifierLimits,
+) (RequestSet, Verifier) {
+	t.Helper()
+	requestSet, verifier, err := BindDataset(
+		testRunID,
+		testSpecialistID,
+		fixture.source,
+		fixture.contract,
+		fixture.candidates,
+		fixture.verifiers,
+		limits,
+		verifierLimits,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return requestSet, verifier
+}
+
+func verificationInputs(
+	request specialistcontrol.Request,
+	answer []byte,
+) (specialistcontrol.Invocation, specialistcontrol.Candidate) {
+	invocation := specialistcontrol.Invocation{
+		RunID: request.RunID, RequestID: request.RequestID, Task: request.Task,
+		Payload: append([]byte(nil), request.Payload...), Binding: specialistcontrol.Binding{1},
+		Deadline: request.Deadline, MaxResultBytes: 1024,
+	}
+	candidate := specialistcontrol.Candidate{
+		Binding: invocation.Binding, CandidateBinding: specialistcontrol.CandidateBinding{1},
+		SpecialistID: testSpecialistID, State: specialistcontrol.ResultCompleted,
+		Payload: append([]byte(nil), answer...),
+	}
+	return invocation, candidate
+}
+
+func cloneCandidateSet(set clrsfixture.CandidateSet) clrsfixture.CandidateSet {
+	set.Examples = append([]clrsfixture.CandidateExample(nil), set.Examples...)
+	return set
+}
+
+func cloneVerifierSet(set clrsfixture.VerifierSet) clrsfixture.VerifierSet {
+	set.Examples = append([]clrsfixture.VerifierExample(nil), set.Examples...)
+	return set
+}
+
+func testImportLimits() clrsfixture.ImportLimits {
+	return clrsfixture.ImportLimits{
+		MaxDatasetBytes: 1 << 20, MaxExamples: 16,
+		MaxPromptBytes: 512, MaxReferenceBytes: 512, MaxDeclaredLength: 64,
+	}
+}
+
+func testVerifierLimits() VerifierLimits {
+	return VerifierLimits{MaxReferences: 16, MaxReferenceBytes: 16 << 10}
+}
+
+func withLimits(change func(*Limits)) Limits {
+	limits := testLimits()
+	change(&limits)
+	return limits
+}

--- a/tooling/internal/clrsinsertion/prompt.go
+++ b/tooling/internal/clrsinsertion/prompt.go
@@ -1,0 +1,275 @@
+package clrsinsertion
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+)
+
+const (
+	promptPrefix = "insertion_sort:\nkey: ["
+	promptSuffix = "]\npred:\n"
+	answerPrefix = "["
+	answerSuffix = "]\n\n"
+
+	maximumPromptBytesCeiling = 1 << 20
+	maximumValuesCeiling      = 4_096
+	maximumTokenBytesCeiling  = 128
+	maximumAnswerBytesCeiling = 1 << 20
+)
+
+var (
+	// ErrInvalidLimits means a caller did not close every parser/output bound.
+	ErrInvalidLimits = errors.New("invalid insertion-sort limits")
+	// ErrMalformedPrompt means bytes do not match the bounded no-hint grammar.
+	ErrMalformedPrompt = errors.New("malformed insertion-sort prompt")
+	// ErrPromptLimit means candidate-visible input crossed a configured bound.
+	ErrPromptLimit = errors.New("insertion-sort prompt limit exceeded")
+	// ErrAnswerLimit means the exact answer crossed a configured output bound.
+	ErrAnswerLimit = errors.New("insertion-sort answer limit exceeded")
+)
+
+// Limits are parser safety caps, not selected experiment sizes.
+type Limits struct {
+	MaxPromptBytes int
+	MaxValues      int
+	MaxTokenBytes  int
+	MaxAnswerBytes int
+}
+
+// Validate rejects open or impractically large bounds.
+func (limits Limits) Validate() error {
+	if limits.MaxPromptBytes <= 0 || limits.MaxPromptBytes > maximumPromptBytesCeiling ||
+		limits.MaxValues <= 0 || limits.MaxValues > maximumValuesCeiling ||
+		limits.MaxTokenBytes <= 0 || limits.MaxTokenBytes > maximumTokenBytesCeiling ||
+		limits.MaxAnswerBytes <= 0 || limits.MaxAnswerBytes > maximumAnswerBytesCeiling {
+		return ErrInvalidLimits
+	}
+	return nil
+}
+
+type scalar struct {
+	text  string
+	value float64
+}
+
+// Solve returns the exact conventional insertion-sort answer for the bounded
+// no-hint structural grammar derived from the pinned CLRS-Text source. It
+// preserves scalar spellings and checks cancellation while performing stable
+// insertion sort. A successful answer is still NO_RESULT.
+func Solve(ctx context.Context, prompt []byte, limits Limits) ([]byte, error) {
+	if ctx == nil {
+		return nil, errors.New("solve insertion sort: nil context")
+	}
+	if err := limits.Validate(); err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	values, err := parsePrompt(ctx, prompt, limits)
+	if err != nil {
+		return nil, err
+	}
+	if err := insertionSort(ctx, values); err != nil {
+		return nil, err
+	}
+	answer := formatAnswer(values)
+	if len(answer) > limits.MaxAnswerBytes {
+		return nil, fmt.Errorf("%w: %d bytes exceeds %d", ErrAnswerLimit, len(answer), limits.MaxAnswerBytes)
+	}
+	return answer, nil
+}
+
+func parsePrompt(ctx context.Context, prompt []byte, limits Limits) ([]scalar, error) {
+	if len(prompt) > limits.MaxPromptBytes {
+		return nil, fmt.Errorf("%w: %d bytes exceeds %d", ErrPromptLimit, len(prompt), limits.MaxPromptBytes)
+	}
+	if !utf8.Valid(prompt) || len(prompt) == 0 {
+		return nil, ErrMalformedPrompt
+	}
+	body, found := strings.CutPrefix(string(prompt), promptPrefix)
+	if !found {
+		return nil, fmt.Errorf("%w: wrong task or input marker", ErrMalformedPrompt)
+	}
+	body, found = strings.CutSuffix(body, promptSuffix)
+	if !found || body == "" {
+		return nil, fmt.Errorf("%w: wrong output marker or empty key", ErrMalformedPrompt)
+	}
+	tokens := strings.Split(body, " ")
+	if len(tokens) > limits.MaxValues {
+		return nil, fmt.Errorf("%w: %d values exceeds %d", ErrPromptLimit, len(tokens), limits.MaxValues)
+	}
+	values := make([]scalar, 0, len(tokens))
+	for index, token := range tokens {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if token == "" {
+			return nil, fmt.Errorf("%w: empty scalar at position %d", ErrMalformedPrompt, index)
+		}
+		if len(token) > limits.MaxTokenBytes {
+			return nil, fmt.Errorf("%w: scalar %d exceeds %d bytes", ErrPromptLimit, index, limits.MaxTokenBytes)
+		}
+		value, err := parseUpstreamScalar(token)
+		if err != nil {
+			return nil, fmt.Errorf("%w at position %d: %v", ErrMalformedPrompt, index, err)
+		}
+		values = append(values, scalar{text: token, value: value})
+	}
+	return values, nil
+}
+
+func parseUpstreamScalar(token string) (float64, error) {
+	if !decimalGrammar(token) {
+		return 0, errors.New("scalar is outside the finite decimal grammar")
+	}
+	value, err := strconv.ParseFloat(token, 64)
+	if err != nil || math.IsInf(value, 0) || math.IsNaN(value) {
+		return 0, errors.New("scalar is not finite float64")
+	}
+	// The pinned generator calls SortingSampler with its default U[0,1) range.
+	if value < 0 || value >= 1 {
+		return 0, errors.New("scalar is outside the pinned sampler range [0,1)")
+	}
+	return value, nil
+}
+
+func decimalGrammar(token string) bool {
+	index := 0
+	if index >= len(token) || token[index] < '0' || token[index] > '9' {
+		return false
+	}
+	for index < len(token) && token[index] >= '0' && token[index] <= '9' {
+		index++
+	}
+	if index < len(token) && token[index] == '.' {
+		index++
+		start := index
+		for index < len(token) && token[index] >= '0' && token[index] <= '9' {
+			index++
+		}
+		if start == index {
+			return false
+		}
+	}
+	if index < len(token) && token[index] == 'e' {
+		index++
+		if index < len(token) && (token[index] == '+' || token[index] == '-') {
+			index++
+		}
+		start := index
+		for index < len(token) && token[index] >= '0' && token[index] <= '9' {
+			index++
+		}
+		if start == index {
+			return false
+		}
+	}
+	return index == len(token)
+}
+
+func insertionSort(ctx context.Context, values []scalar) error {
+	for outer := 1; outer < len(values); outer++ {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		item := values[outer]
+		inner := outer
+		for inner > 0 && values[inner-1].value > item.value {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			values[inner] = values[inner-1]
+			inner--
+		}
+		values[inner] = item
+	}
+	return nil
+}
+
+func formatAnswer(values []scalar) []byte {
+	var builder strings.Builder
+	builder.Grow(len(answerPrefix) + len(answerSuffix) + len(values)*4)
+	builder.WriteString(answerPrefix)
+	for index, value := range values {
+		if index > 0 {
+			builder.WriteByte(' ')
+		}
+		builder.WriteString(value.text)
+	}
+	builder.WriteString(answerSuffix)
+	return []byte(builder.String())
+}
+
+type stableTokenQueue struct {
+	tokens   []string
+	consumed int
+}
+
+// validateReference independently proves that a held answer is the stable,
+// sorted permutation of the prompt. It deliberately does not call Solve or
+// insertionSort, so verifier construction cannot merely repeat the candidate
+// implementation.
+func validateReference(ctx context.Context, reference []byte, limits Limits, promptValues []scalar) error {
+	if len(reference) > limits.MaxAnswerBytes {
+		return fmt.Errorf("%w: reference is %d bytes", ErrAnswerLimit, len(reference))
+	}
+	body, found := strings.CutPrefix(string(reference), answerPrefix)
+	if !found {
+		return errors.New("reference lacks answer prefix")
+	}
+	body, found = strings.CutSuffix(body, answerSuffix)
+	if !found || body == "" || !utf8.Valid(reference) {
+		return errors.New("reference lacks exact answer suffix or values")
+	}
+	tokens := strings.Split(body, " ")
+	if len(tokens) != len(promptValues) {
+		return fmt.Errorf("reference value count = %d, want %d", len(tokens), len(promptValues))
+	}
+	stableGroups := make(map[uint64]*stableTokenQueue, len(promptValues))
+	for _, value := range promptValues {
+		key := math.Float64bits(value.value)
+		group := stableGroups[key]
+		if group == nil {
+			group = &stableTokenQueue{}
+			stableGroups[key] = group
+		}
+		group.tokens = append(group.tokens, value.text)
+	}
+	var previous float64
+	for index, token := range tokens {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if len(token) == 0 || len(token) > limits.MaxTokenBytes {
+			return errors.New("reference scalar crosses token bounds")
+		}
+		value, err := parseUpstreamScalar(token)
+		if err != nil {
+			return fmt.Errorf("reference scalar %q: %w", token, err)
+		}
+		if index > 0 && value < previous {
+			return errors.New("reference values are not nondecreasing")
+		}
+		previous = value
+		group := stableGroups[math.Float64bits(value)]
+		if group == nil || group.consumed >= len(group.tokens) {
+			return fmt.Errorf("reference scalar %q is absent from the prompt multiplicity", token)
+		}
+		if token != group.tokens[group.consumed] {
+			return fmt.Errorf("reference scalar %q changes prompt spelling or equal-value order", token)
+		}
+		group.consumed++
+	}
+	for _, group := range stableGroups {
+		if group.consumed != len(group.tokens) {
+			return errors.New("reference omits one or more prompt scalar occurrences")
+		}
+	}
+	return nil
+}

--- a/tooling/internal/clrsinsertion/prompt_test.go
+++ b/tooling/internal/clrsinsertion/prompt_test.go
@@ -1,0 +1,166 @@
+package clrsinsertion
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/lusoris/20-watts-was-enough/tooling/internal/clrsfixture"
+)
+
+type cancelAfterChecksContext struct {
+	context.Context
+	cancelAt int
+	checks   int
+}
+
+func (ctx *cancelAfterChecksContext) Err() error {
+	ctx.checks++
+	if ctx.checks >= ctx.cancelAt {
+		return context.Canceled
+	}
+	return nil
+}
+
+func TestSolveMatchesPinnedNoHintPromptAndReferenceGrammar(t *testing.T) {
+	t.Parallel()
+	prompt := []byte("insertion_sort:\nkey: [0.549 0.715 0.603 0.545 0.424]\npred:\n")
+	want := "[0.424 0.545 0.549 0.603 0.715]\n\n"
+	first, err := Solve(context.Background(), prompt, testLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := Solve(context.Background(), prompt, testLimits())
+	if err != nil || string(first) != want || string(second) != want {
+		t.Fatalf("Solve() = %q/%q, error %v, want exact %q", first, second, err, want)
+	}
+}
+
+func TestSolveUsesStableInsertionSortAndPreservesScalarSpellings(t *testing.T) {
+	t.Parallel()
+	prompt := []byte("insertion_sort:\nkey: [0.5 1e-07 0.50 0.0 0.25]\npred:\n")
+	want := "[0.0 1e-07 0.25 0.5 0.50]\n\n"
+	answer, err := Solve(context.Background(), prompt, testLimits())
+	if err != nil || string(answer) != want {
+		t.Fatalf("Solve() = %q, error %v, want %q", answer, err, want)
+	}
+}
+
+func TestSolveRejectsMalformedAndOversizedPrompts(t *testing.T) {
+	t.Parallel()
+	valid := "insertion_sort:\nkey: [0.3 0.1 0.2]\npred:\n"
+	tests := map[string]struct {
+		prompt string
+		mutate func(*Limits)
+		want   error
+	}{
+		"wrong task":       {prompt: strings.Replace(valid, "insertion_sort", "quicksort", 1), want: ErrMalformedPrompt},
+		"hinted trace":     {prompt: "insertion_sort:\nkey: [0.3 0.1], initial_trace: [0.3 0.1]\ntrace | pred:\n", want: ErrMalformedPrompt},
+		"missing newline":  {prompt: strings.TrimSuffix(valid, "\n"), want: ErrMalformedPrompt},
+		"comma separator":  {prompt: strings.Replace(valid, "0.3 0.1", "0.3, 0.1", 1), want: ErrMalformedPrompt},
+		"double space":     {prompt: strings.Replace(valid, "0.3 0.1", "0.3  0.1", 1), want: ErrMalformedPrompt},
+		"non-finite":       {prompt: strings.Replace(valid, "0.3", "NaN", 1), want: ErrMalformedPrompt},
+		"sampler range":    {prompt: strings.Replace(valid, "0.3", "1.0", 1), want: ErrMalformedPrompt},
+		"too many values":  {prompt: valid, mutate: func(limits *Limits) { limits.MaxValues = 2 }, want: ErrPromptLimit},
+		"oversized token":  {prompt: valid, mutate: func(limits *Limits) { limits.MaxTokenBytes = 2 }, want: ErrPromptLimit},
+		"oversized prompt": {prompt: valid, mutate: func(limits *Limits) { limits.MaxPromptBytes = len(valid) - 1 }, want: ErrPromptLimit},
+		"oversized answer": {prompt: valid, mutate: func(limits *Limits) { limits.MaxAnswerBytes = 4 }, want: ErrAnswerLimit},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			limits := testLimits()
+			if test.mutate != nil {
+				test.mutate(&limits)
+			}
+			if _, err := Solve(context.Background(), []byte(test.prompt), limits); !errors.Is(err, test.want) {
+				t.Fatalf("Solve() error = %v, want %v", err, test.want)
+			}
+		})
+	}
+}
+
+func TestSolveHonoursCancellationAndClosedLimits(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := Solve(ctx, []byte("insertion_sort:\nkey: [0.2 0.1]\npred:\n"), testLimits()); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Solve(cancelled) error = %v, want context.Canceled", err)
+	}
+	limits := testLimits()
+	limits.MaxValues = 0
+	if _, err := Solve(context.Background(), []byte("insertion_sort:\nkey: [0.2 0.1]\npred:\n"), limits); !errors.Is(err, ErrInvalidLimits) {
+		t.Fatalf("Solve(open limits) error = %v, want ErrInvalidLimits", err)
+	}
+}
+
+func TestSolveChecksCancellationInsideInsertionShift(t *testing.T) {
+	t.Parallel()
+	ctx := &cancelAfterChecksContext{Context: context.Background(), cancelAt: 11}
+	prompt := []byte("insertion_sort:\nkey: [0.8 0.7 0.6 0.5 0.4 0.3 0.2 0.1]\npred:\n")
+	if _, err := Solve(ctx, prompt, testLimits()); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Solve(inner-loop cancellation) error = %v, want context.Canceled", err)
+	}
+	if ctx.checks != ctx.cancelAt {
+		t.Fatalf("context checks = %d, want cancellation at check %d", ctx.checks, ctx.cancelAt)
+	}
+}
+
+func TestPinnedSourceEvidenceIsExact(t *testing.T) {
+	t.Parallel()
+	evidence := PinnedSourceEvidence()
+	if evidence.SourceRecordPath != "tooling/clrs-generator/upstream.json" ||
+		evidence.SourceID != "sha256:7ec3b6b7528d04f517c4e9b7c3e0cd0f7034a775d225d469d1aca5c00fec10d1" {
+		t.Fatalf("source identity = %#v", evidence)
+	}
+	if evidence.Formatter.Path != "clrs/_src/clrs_text/clrs_utils.py" ||
+		evidence.Formatter.SHA256 != "d6d320eb1536be8fbdb512315d55eada2db3ff87afd613762f125d38a9e7a53c" ||
+		evidence.Spec.SHA256 != "51f1cc936b28189c7b2e3b2030c30e224fb448f3d2846181983329448f1ed018" ||
+		evidence.Algorithm.SHA256 != "f38d82a93c1e4b987c5f68d9ad72eb4205a3572bdec490c9317cff573fb59ca4" ||
+		evidence.Sampler.SHA256 != "01921e9ca7fa0cc81a8ce82dd76869820f1e9ad8863d5b76b088b0610a2e0473" {
+		t.Fatalf("source file identities = %#v", evidence)
+	}
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("locate insertion-sort source test")
+	}
+	body, err := os.ReadFile(filepath.Join(filepath.Dir(filename), "..", "..", "clrs-generator", "upstream.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	source, err := clrsfixture.ParseSourceRecord(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := evidence.ValidateSource(source); err != nil {
+		t.Fatal(err)
+	}
+	mutations := []func(*SourceEvidence){
+		func(value *SourceEvidence) { value.SourceRecordPath = "other.json" },
+		func(value *SourceEvidence) { value.Formatter.SHA256 = strings.Repeat("0", 64) },
+		func(value *SourceEvidence) { value.Spec.GitBlob = strings.Repeat("0", 40) },
+		func(value *SourceEvidence) { value.Algorithm.Path = "sorting-other.py" },
+		func(value *SourceEvidence) { value.Sampler.SHA256 = strings.Repeat("f", 64) },
+	}
+	for index, mutate := range mutations {
+		changed := evidence
+		mutate(&changed)
+		if err := changed.ValidateSource(source); err == nil {
+			t.Fatalf("ValidateSource accepted supporting-evidence mutation %d", index)
+		}
+	}
+}
+
+func testLimits() Limits {
+	return Limits{
+		MaxPromptBytes: 512,
+		MaxValues:      64,
+		MaxTokenBytes:  32,
+		MaxAnswerBytes: 512,
+	}
+}

--- a/tooling/internal/clrsinsertion/source.go
+++ b/tooling/internal/clrsinsertion/source.go
@@ -1,0 +1,74 @@
+// Package clrsinsertion implements the exact-program insertion-sort vertical
+// for the CLRS-Text development shakedown. Every value remains NO_RESULT.
+package clrsinsertion
+
+import (
+	"fmt"
+
+	"github.com/lusoris/20-watts-was-enough/tooling/internal/clrsfixture"
+)
+
+// SourceFile binds one upstream file used to derive this vertical's grammar or
+// exact conventional operation. SHA256 is over the file bytes at Commit.
+type SourceFile struct {
+	Path    string
+	GitBlob string
+	SHA256  string
+}
+
+// SourceEvidence extends the canonical source record with the supporting files
+// used to derive this vertical. It references rather than repeats repository,
+// commit, tree, generator, requirements, and licence metadata.
+type SourceEvidence struct {
+	SourceRecordPath string
+	SourceID         string
+	Formatter        SourceFile
+	Spec             SourceFile
+	Algorithm        SourceFile
+	Sampler          SourceFile
+}
+
+// PinnedSourceEvidence returns the exact official source inspected for the
+// no-hint prompt/reference grammar and insertion-sort operation.
+func PinnedSourceEvidence() SourceEvidence {
+	return SourceEvidence{
+		SourceRecordPath: "tooling/clrs-generator/upstream.json",
+		SourceID:         "sha256:7ec3b6b7528d04f517c4e9b7c3e0cd0f7034a775d225d469d1aca5c00fec10d1",
+		Formatter: SourceFile{
+			Path:    "clrs/_src/clrs_text/clrs_utils.py",
+			GitBlob: "64a2714ca879cd62a4c1d1db0a80e6c23bf61541",
+			SHA256:  "d6d320eb1536be8fbdb512315d55eada2db3ff87afd613762f125d38a9e7a53c",
+		},
+		Spec: SourceFile{
+			Path:    "clrs/_src/specs.py",
+			GitBlob: "db3b02e14072152df590a8df518ef058fd167930",
+			SHA256:  "51f1cc936b28189c7b2e3b2030c30e224fb448f3d2846181983329448f1ed018",
+		},
+		Algorithm: SourceFile{
+			Path:    "clrs/_src/algorithms/sorting.py",
+			GitBlob: "cdc78ebfdc98e650b5fa67dfe259ff1e3b317fc2",
+			SHA256:  "f38d82a93c1e4b987c5f68d9ad72eb4205a3572bdec490c9317cff573fb59ca4",
+		},
+		Sampler: SourceFile{
+			Path:    "clrs/_src/samplers.py",
+			GitBlob: "442a5c6d1da86c2956d8dcc78c9339ded296e1a8",
+			SHA256:  "01921e9ca7fa0cc81a8ce82dd76869820f1e9ad8863d5b76b088b0610a2e0473",
+		},
+	}
+}
+
+// ValidateSource checks that this grammar evidence points to the supplied
+// canonical source record.
+func (evidence SourceEvidence) ValidateSource(source clrsfixture.SourceRecord) error {
+	if evidence != PinnedSourceEvidence() {
+		return fmt.Errorf("insertion-sort supporting source evidence differs from the pinned record")
+	}
+	identity, err := source.Identity()
+	if err != nil {
+		return fmt.Errorf("validate insertion-sort source record: %w", err)
+	}
+	if identity.String() != evidence.SourceID {
+		return fmt.Errorf("insertion-sort source identity = %s, want %s", identity, evidence.SourceID)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

- add the first pure-Go CLRS specialist vertical for insertion sort
- derive controller request IDs and bounded prompts from validated candidate and held-reference records
- keep exact answers in an independent verifier and preserve `NO_RESULT`
- cover malformed, oversized, stale, mismatched, deterministic-order, and refusal boundaries

## Validation

- `go test -race ./internal/clrsinsertion`
- `go test ./... && go vet ./...`
- impact-common gate in the digest-pinned official Node 26.8.1 container with npm 12.0.2
- `npm run check:prose`

## Authority boundary

This is construction plumbing only. It does not generate a dataset, run a model, or establish a scientific result.

Refs #12