### PR TITLE
feat(experiment): add matrix-chain specialist vertical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,11 @@ the exact diff; this file records why the project changed.
   the target, clamped to the final index. A separate linear verifier checks the
   contract-selected references while candidate requests retain only source-bound
   prompts and IDs. Synthetic tests add no dataset or scientific result.
+- The matrix-chain construction vertical now reproduces the pinned synchronous
+  split-cost operation and the generator's full split-pointer probe matrix in
+  Go. A separate interval-order verifier proves each held split is cost-minimal
+  without calling the specialist solver; source-bound requests remain isolated
+  from held answers, and all construction output remains `NO_RESULT`.
 - A versioned PDF semantic sentinel now binds the current source, book, A4 and
   tag metadata, Poppler tool identity, separate structure and text streams,
   exact diagnostics, and six nonlinear content anchors. Atomic evidence keeps

--- a/tooling/internal/clrsmatrixchain/adapter.go
+++ b/tooling/internal/clrsmatrixchain/adapter.go
@@ -1,0 +1,346 @@
+package clrsmatrixchain
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/lusoris/20-watts-was-enough/tooling/internal/clrsfixture"
+	"github.com/lusoris/20-watts-was-enough/tooling/internal/specialistcontrol"
+)
+
+const (
+	maximumIdentityBytes            = 128
+	maximumReferencesCeiling        = 4_096
+	maximumReferenceSetBytesCeiling = 64 << 20
+	// Four fixture identities, one prompt digest and the effective-size integer.
+	heldIdentityBytes = 5*sha256.Size + 8
+)
+
+var ErrReferenceLimit = errors.New("matrix-chain reference limit exceeded")
+
+// Specialist is the exact pinned CLRS matrix-chain implementation. It
+// owns no reference data and sees only specialistcontrol.Invocation.
+type Specialist struct {
+	id     string
+	limits Limits
+}
+
+// NewSpecialist closes the candidate-visible solver identity and bounds.
+func NewSpecialist(id string, limits Limits) (Specialist, error) {
+	if !validIdentity(id) {
+		return Specialist{}, errors.New("matrix-chain specialist identity is invalid")
+	}
+	if err := limits.Validate(); err != nil {
+		return Specialist{}, err
+	}
+	return Specialist{id: id, limits: limits}, nil
+}
+
+// Invoke implements specialistcontrol.Specialist.
+func (specialist Specialist) Invoke(
+	ctx context.Context,
+	invocation specialistcontrol.Invocation,
+) (specialistcontrol.SpecialistResult, error) {
+	refused := specialistcontrol.SpecialistResult{
+		Binding: invocation.Binding, SpecialistID: specialist.id, State: specialistcontrol.ResultRefused,
+	}
+	if ctx == nil {
+		return refused, errors.New("invoke matrix-chain specialist: nil context")
+	}
+	if err := ctx.Err(); err != nil {
+		return refused, err
+	}
+	if invocation.Task != specialistcontrol.TaskMatrixChainOrder || invocation.Binding == (specialistcontrol.Binding{}) ||
+		invocation.MaxResultBytes <= 0 {
+		return refused, nil
+	}
+	answer, err := Solve(ctx, invocation.Payload, specialist.limits)
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return refused, err
+		}
+		if errors.Is(err, ErrInvalidLimits) || errors.Is(err, ErrMalformedPrompt) ||
+			errors.Is(err, ErrPromptLimit) || errors.Is(err, ErrAnswerLimit) {
+			return refused, nil
+		}
+		return refused, fmt.Errorf("solve matrix-chain invocation: %w", err)
+	}
+	if len(answer) > invocation.MaxResultBytes {
+		return refused, nil
+	}
+	return specialistcontrol.SpecialistResult{
+		Binding:      invocation.Binding,
+		SpecialistID: specialist.id,
+		State:        specialistcontrol.ResultCompleted,
+		Payload:      answer,
+	}, nil
+}
+
+// VerifierLimits bound the separately held reference index. They are safety
+// caps, not fixture counts or an experiment sampling decision.
+type VerifierLimits struct {
+	MaxReferences     int
+	MaxReferenceBytes int64
+}
+
+// Validate rejects an open or impractically large verifier index.
+func (limits VerifierLimits) Validate() error {
+	if limits.MaxReferences <= 0 || limits.MaxReferences > maximumReferencesCeiling ||
+		limits.MaxReferenceBytes <= 0 || limits.MaxReferenceBytes > maximumReferenceSetBytesCeiling {
+		return ErrReferenceLimit
+	}
+	return nil
+}
+
+type referenceKey struct {
+	runID     string
+	requestID string
+}
+
+type heldReference struct {
+	source             clrsfixture.SourceID
+	contract           clrsfixture.ContractID
+	candidateID        clrsfixture.CandidateID
+	verifierID         clrsfixture.VerifierID
+	promptSHA256       [sha256.Size]byte
+	effectiveInputSize int64
+	answer             []byte
+}
+
+type boundCandidate struct {
+	id     clrsfixture.CandidateID
+	prompt []byte
+}
+
+// RequestSet is the candidate-only projection of one validated matrix-chain
+// dataset run. It cannot be constructed from a raw prompt or held answer.
+type RequestSet struct {
+	runID      string
+	candidates []boundCandidate
+}
+
+// Verifier independently exact-scores against separately held references.
+type Verifier struct {
+	specialistID string
+	limits       Limits
+	references   map[referenceKey]heldReference
+}
+
+// BindDataset validates the exact contract-selected matrix-chain candidate
+// and verifier sets, then returns separate candidate-only and held-reference
+// views. Every value remains NO_RESULT.
+func BindDataset(
+	runID string,
+	specialistID string,
+	source clrsfixture.SourceRecord,
+	contract clrsfixture.GenerationContract,
+	candidates clrsfixture.CandidateSet,
+	verifiers clrsfixture.VerifierSet,
+	limits Limits,
+	verifierLimits VerifierLimits,
+) (RequestSet, Verifier, error) {
+	if !validIdentity(runID) || !validIdentity(specialistID) {
+		return RequestSet{}, Verifier{}, errors.New("matrix-chain run or specialist identity is invalid")
+	}
+	if err := limits.Validate(); err != nil {
+		return RequestSet{}, Verifier{}, err
+	}
+	if err := verifierLimits.Validate(); err != nil {
+		return RequestSet{}, Verifier{}, err
+	}
+	if err := PinnedSourceEvidence().ValidateSource(source); err != nil {
+		return RequestSet{}, Verifier{}, err
+	}
+	task, err := matrixChainTaskPlan(source, contract)
+	if err != nil {
+		return RequestSet{}, Verifier{}, err
+	}
+	pairs, err := clrsfixture.PairExamples(
+		source,
+		contract,
+		task.OutputRelativePath,
+		candidates,
+		verifiers,
+	)
+	if err != nil {
+		return RequestSet{}, Verifier{}, fmt.Errorf("pair matrix-chain dataset: %w", err)
+	}
+	if len(pairs) == 0 || len(pairs) > verifierLimits.MaxReferences {
+		return RequestSet{}, Verifier{}, fmt.Errorf("%w: reference count is %d", ErrReferenceLimit, len(pairs))
+	}
+
+	requestSet := RequestSet{runID: runID, candidates: make([]boundCandidate, 0, len(pairs))}
+	validated := make(map[referenceKey]heldReference, len(pairs))
+	var retainedBytes int64
+	for index, pair := range pairs {
+		candidate, held, bindErr := bindPair(pair, limits)
+		if bindErr != nil {
+			return RequestSet{}, Verifier{}, fmt.Errorf("bind matrix-chain pair %d: %w", index, bindErr)
+		}
+		requestID := candidate.id.String()
+		retainedBytes += int64(len(runID)+len(requestID)+len(held.answer)) + heldIdentityBytes
+		if retainedBytes > verifierLimits.MaxReferenceBytes {
+			return RequestSet{}, Verifier{}, fmt.Errorf("%w: retained bytes exceed %d", ErrReferenceLimit, verifierLimits.MaxReferenceBytes)
+		}
+		key := referenceKey{runID: runID, requestID: requestID}
+		if _, duplicate := validated[key]; duplicate {
+			return RequestSet{}, Verifier{}, fmt.Errorf("duplicate matrix-chain reference %s/%s", key.runID, key.requestID)
+		}
+		requestSet.candidates = append(requestSet.candidates, candidate)
+		validated[key] = held
+	}
+	return requestSet, Verifier{specialistID: specialistID, limits: limits, references: validated}, nil
+}
+
+// Requests returns fresh candidate-only controller packets for one closed run
+// window. RequestID is the source-and-contract-bound CandidateID.
+func (set RequestSet) Requests(issuedAt, deadline time.Time) ([]specialistcontrol.Request, error) {
+	if !validIdentity(set.runID) || len(set.candidates) == 0 {
+		return nil, errors.New("matrix-chain request set is unbound")
+	}
+	if issuedAt.IsZero() || deadline.IsZero() || !deadline.After(issuedAt) {
+		return nil, errors.New("matrix-chain request window is invalid")
+	}
+	requests := make([]specialistcontrol.Request, 0, len(set.candidates))
+	for _, candidate := range set.candidates {
+		requestID := candidate.id.String()
+		if !validIdentity(requestID) || len(candidate.prompt) == 0 {
+			return nil, errors.New("matrix-chain bound candidate is invalid")
+		}
+		requests = append(requests, specialistcontrol.Request{
+			RunID:     set.runID,
+			RequestID: requestID,
+			Task:      specialistcontrol.TaskMatrixChainOrder,
+			Payload:   append([]byte(nil), candidate.prompt...),
+			IssuedAt:  issuedAt,
+			Deadline:  deadline,
+		})
+	}
+	return requests, nil
+}
+
+// Verify implements specialistcontrol.ExactVerifier.
+func (verifier Verifier) Verify(
+	ctx context.Context,
+	invocation specialistcontrol.Invocation,
+	candidate specialistcontrol.Candidate,
+) (specialistcontrol.Verification, error) {
+	verification := specialistcontrol.Verification{
+		Binding: candidate.Binding, CandidateBinding: candidate.CandidateBinding,
+		Verdict: specialistcontrol.VerificationAbstain,
+	}
+	if ctx == nil {
+		return verification, errors.New("verify matrix-chain candidate: nil context")
+	}
+	if err := ctx.Err(); err != nil {
+		return verification, err
+	}
+	if invocation.Task != specialistcontrol.TaskMatrixChainOrder || invocation.Binding != candidate.Binding ||
+		candidate.Binding == (specialistcontrol.Binding{}) ||
+		candidate.CandidateBinding == (specialistcontrol.CandidateBinding{}) ||
+		candidate.SpecialistID != verifier.specialistID || candidate.State != specialistcontrol.ResultCompleted {
+		return verification, errors.New("verify matrix-chain candidate: invalid invocation binding")
+	}
+	held, present := verifier.references[referenceKey{runID: invocation.RunID, requestID: invocation.RequestID}]
+	if !present || held.candidateID.String() != invocation.RequestID ||
+		held.promptSHA256 != sha256.Sum256(invocation.Payload) {
+		return verification, errors.New("verify matrix-chain candidate: no exact prompt-bound reference")
+	}
+	input, err := parsePrompt(ctx, invocation.Payload, verifier.limits)
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return verification, err
+		}
+		return verification, errors.New("verify matrix-chain candidate: prompt semantics differ from the held candidate")
+	}
+	if int64(len(input.dimensions)) != held.effectiveInputSize {
+		return verification, errors.New("verify matrix-chain candidate: prompt semantics differ from the held candidate")
+	}
+	if len(candidate.Payload) == 0 || len(candidate.Payload) > verifier.limits.MaxAnswerBytes {
+		return verification, errors.New("verify matrix-chain candidate: answer crosses verifier bounds")
+	}
+	if bytes.Equal(candidate.Payload, held.answer) {
+		verification.Verdict = specialistcontrol.VerificationExact
+	} else {
+		verification.Verdict = specialistcontrol.VerificationMismatch
+	}
+	return verification, nil
+}
+
+func matrixChainTaskPlan(
+	source clrsfixture.SourceRecord,
+	contract clrsfixture.GenerationContract,
+) (clrsfixture.TaskPlan, error) {
+	plan, err := contract.Plan(source)
+	if err != nil {
+		return clrsfixture.TaskPlan{}, fmt.Errorf("plan matrix-chain dataset: %w", err)
+	}
+	for _, task := range plan.Tasks {
+		if task.Task == clrsfixture.TaskMatrixChainOrder {
+			return task, nil
+		}
+	}
+	return clrsfixture.TaskPlan{}, errors.New("generation contract has no matrix-chain task")
+}
+
+func bindPair(pair clrsfixture.PairedExample, limits Limits) (boundCandidate, heldReference, error) {
+	candidate := pair.Candidate
+	verifier := pair.Verifier
+	if candidate.Task != clrsfixture.TaskMatrixChainOrder ||
+		candidate.LengthSemantics != clrsfixture.LengthDeclaredInput || candidate.UseHints ||
+		candidate.RequestedLength != candidate.EffectiveInputSize ||
+		verifier.CandidateID != candidate.ID {
+		return boundCandidate{}, heldReference{}, errors.New("pair differs from matrix-chain no-hint length semantics")
+	}
+	if candidate.EffectiveInputSize < 2 || candidate.EffectiveInputSize > int64(limits.MaxDimensions) {
+		return boundCandidate{}, heldReference{}, fmt.Errorf(
+			"%w: effective input size %d exceeds 2..%d",
+			ErrPromptLimit,
+			candidate.EffectiveInputSize,
+			limits.MaxDimensions,
+		)
+	}
+	prompt := []byte(candidate.Prompt)
+	input, err := parsePrompt(context.Background(), prompt, limits)
+	if err != nil {
+		return boundCandidate{}, heldReference{}, fmt.Errorf("validate candidate prompt: %w", err)
+	}
+	if int64(len(input.dimensions)) != candidate.EffectiveInputSize {
+		return boundCandidate{}, heldReference{}, fmt.Errorf(
+			"prompt value count = %d, want effective input size %d",
+			len(input.dimensions), candidate.EffectiveInputSize,
+		)
+	}
+	answer := []byte(verifier.Reference)
+	if err := validateReference(context.Background(), answer, limits, input); err != nil {
+		return boundCandidate{}, heldReference{}, err
+	}
+	return boundCandidate{id: candidate.ID, prompt: append([]byte(nil), prompt...)}, heldReference{
+		source:             candidate.Source,
+		contract:           candidate.Contract,
+		candidateID:        candidate.ID,
+		verifierID:         verifier.ID,
+		promptSHA256:       sha256.Sum256(prompt),
+		effectiveInputSize: candidate.EffectiveInputSize,
+		answer:             append([]byte(nil), answer...),
+	}, nil
+}
+
+func validIdentity(value string) bool {
+	if len(value) == 0 || len(value) > maximumIdentityBytes {
+		return false
+	}
+	for index := range len(value) {
+		character := value[index]
+		if (character < 'a' || character > 'z') && (character < 'A' || character > 'Z') &&
+			(character < '0' || character > '9') && character != '.' && character != '_' &&
+			character != ':' && character != '-' {
+			return false
+		}
+	}
+	return true
+}

--- a/tooling/internal/clrsmatrixchain/adapter_test.go
+++ b/tooling/internal/clrsmatrixchain/adapter_test.go
@@ -1,0 +1,852 @@
+package clrsmatrixchain
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lusoris/20-watts-was-enough/tooling/internal/clrsfixture"
+	"github.com/lusoris/20-watts-was-enough/tooling/internal/specialistcontrol"
+)
+
+const (
+	testRunID        = "run-001"
+	testSpecialistID = "exact-matrix-chain-v1"
+)
+
+var verticalNow = time.Date(2026, time.August, 31, 12, 0, 0, 0, time.UTC)
+
+type recorderFunc func(context.Context, specialistcontrol.Decision) error
+
+func (function recorderFunc) RecordDecision(ctx context.Context, decision specialistcontrol.Decision) error {
+	return function(ctx, decision)
+}
+
+type specialistFunc func(context.Context, specialistcontrol.Invocation) (specialistcontrol.SpecialistResult, error)
+
+func (function specialistFunc) Invoke(ctx context.Context, invocation specialistcontrol.Invocation) (specialistcontrol.SpecialistResult, error) {
+	return function(ctx, invocation)
+}
+
+type verifierFunc func(context.Context, specialistcontrol.Invocation, specialistcontrol.Candidate) (specialistcontrol.Verification, error)
+
+func (function verifierFunc) Verify(ctx context.Context, invocation specialistcontrol.Invocation, candidate specialistcontrol.Candidate) (specialistcontrol.Verification, error) {
+	return function(ctx, invocation, candidate)
+}
+
+func TestBindDatasetBuildsContractBoundRequestsAndIsolatesReferences(t *testing.T) {
+	t.Parallel()
+	fixture := newImportFixture(t, clrsfixture.TaskMatrixChainOrder)
+	reorderedVerifiers := cloneVerifierSet(fixture.verifiers)
+	for left, right := 0, len(reorderedVerifiers.Examples)-1; left < right; left, right = left+1, right-1 {
+		reorderedVerifiers.Examples[left], reorderedVerifiers.Examples[right] =
+			reorderedVerifiers.Examples[right], reorderedVerifiers.Examples[left]
+	}
+	requestSet, verifier, err := BindDataset(
+		testRunID,
+		testSpecialistID,
+		fixture.source,
+		fixture.contract,
+		fixture.candidates,
+		reorderedVerifiers,
+		testLimits(),
+		testVerifierLimits(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requests, err := requestSet.Requests(verticalNow.Add(-time.Second), verticalNow.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(requests) != fixture.task.ExpectedExamples {
+		t.Fatalf("request count = %d, want %d", len(requests), fixture.task.ExpectedExamples)
+	}
+	for index, request := range requests {
+		candidate := fixture.candidates.Examples[index]
+		if request.RunID != testRunID || request.RequestID != candidate.ID.String() ||
+			request.Task != specialistcontrol.TaskMatrixChainOrder ||
+			!bytes.Equal(request.Payload, []byte(candidate.Prompt)) {
+			t.Fatalf("request %d = %#v, candidate %#v", index, request, candidate)
+		}
+		key := referenceKey{runID: testRunID, requestID: request.RequestID}
+		held, present := verifier.references[key]
+		expectedVerifier := fixture.verifiers.Examples[index]
+		if !present || held.source != candidate.Source || held.contract != candidate.Contract ||
+			held.candidateID != candidate.ID || held.verifierID != expectedVerifier.ID ||
+			held.effectiveInputSize != candidate.EffectiveInputSize ||
+			!bytes.Equal(held.answer, []byte(expectedVerifier.Reference)) {
+			t.Fatalf("held reference %d = %#v", index, held)
+		}
+	}
+	for _, candidateType := range []reflect.Type{
+		reflect.TypeOf(RequestSet{}),
+		reflect.TypeOf(boundCandidate{}),
+		reflect.TypeOf(specialistcontrol.Invocation{}),
+	} {
+		for index := 0; index < candidateType.NumField(); index++ {
+			name := strings.ToLower(candidateType.Field(index).Name)
+			if strings.Contains(name, "answer") || strings.Contains(name, "reference") {
+				t.Fatalf("candidate-visible type %s exposes verifier field %q", candidateType, name)
+			}
+		}
+	}
+}
+
+func TestSpecialistMatchesEveryContractBoundSyntheticCell(t *testing.T) {
+	t.Parallel()
+	fixture := newImportFixture(t, clrsfixture.TaskMatrixChainOrder)
+	requestSet, _ := bindFixture(t, fixture, testLimits(), testVerifierLimits())
+	requests, err := requestSet.Requests(verticalNow.Add(-time.Second), verticalNow.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	specialist, err := NewSpecialist(testSpecialistID, testLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for index, request := range requests {
+		invocation, _ := verificationInputs(request, nil)
+		result, invokeErr := specialist.Invoke(context.Background(), invocation)
+		want := []byte(fixture.verifiers.Examples[index].Reference)
+		if invokeErr != nil || result.State != specialistcontrol.ResultCompleted ||
+			result.SpecialistID != testSpecialistID || result.Binding != invocation.Binding ||
+			!bytes.Equal(result.Payload, want) {
+			t.Fatalf("cell %d result/error = %#v/%v, want %q", index, result, invokeErr, want)
+		}
+	}
+}
+
+func TestBindDatasetRejectsForeignAndTamperedContractRecords(t *testing.T) {
+	t.Parallel()
+	matrix := newImportFixture(t, clrsfixture.TaskMatrixChainOrder)
+	insertion := newImportFixture(t, clrsfixture.TaskInsertionSort)
+	if _, _, err := BindDataset(
+		testRunID,
+		testSpecialistID,
+		insertion.source,
+		insertion.contract,
+		insertion.candidates,
+		insertion.verifiers,
+		testLimits(),
+		testVerifierLimits(),
+	); err == nil {
+		t.Fatal("BindDataset accepted a valid foreign task set")
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*clrsfixture.CandidateSet, *clrsfixture.VerifierSet)
+	}{
+		{"candidate identity", func(c *clrsfixture.CandidateSet, _ *clrsfixture.VerifierSet) { c.Examples[0].ID[0] ^= 1 }},
+		{"candidate prompt", func(c *clrsfixture.CandidateSet, _ *clrsfixture.VerifierSet) { c.Examples[0].Prompt += " mutation" }},
+		{"candidate task", func(c *clrsfixture.CandidateSet, _ *clrsfixture.VerifierSet) {
+			c.Examples[0].Task = clrsfixture.TaskInsertionSort
+		}},
+		{"candidate effective size", func(c *clrsfixture.CandidateSet, _ *clrsfixture.VerifierSet) { c.Examples[0].EffectiveInputSize++ }},
+		{"candidate hints", func(c *clrsfixture.CandidateSet, _ *clrsfixture.VerifierSet) { c.Examples[0].UseHints = true }},
+		{"verifier identity", func(_ *clrsfixture.CandidateSet, v *clrsfixture.VerifierSet) { v.Examples[0].ID[0] ^= 1 }},
+		{"verifier answer", func(_ *clrsfixture.CandidateSet, v *clrsfixture.VerifierSet) { v.Examples[0].Reference += " mutation" }},
+		{"missing candidate", func(c *clrsfixture.CandidateSet, _ *clrsfixture.VerifierSet) { c.Examples = c.Examples[1:] }},
+		{"missing verifier", func(_ *clrsfixture.CandidateSet, v *clrsfixture.VerifierSet) { v.Examples = v.Examples[1:] }},
+		{"reordered candidates", func(c *clrsfixture.CandidateSet, _ *clrsfixture.VerifierSet) {
+			c.Examples[0], c.Examples[1] = c.Examples[1], c.Examples[0]
+		}},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			candidates := cloneCandidateSet(matrix.candidates)
+			verifiers := cloneVerifierSet(matrix.verifiers)
+			test.mutate(&candidates, &verifiers)
+			if _, _, err := BindDataset(
+				testRunID,
+				testSpecialistID,
+				matrix.source,
+				matrix.contract,
+				candidates,
+				verifiers,
+				testLimits(),
+				testVerifierLimits(),
+			); err == nil {
+				t.Fatalf("BindDataset accepted %s", test.name)
+			}
+		})
+	}
+
+	foreignSource := matrix.source
+	foreignSource.Commit = "a" + foreignSource.Commit[1:]
+	if _, _, err := BindDataset(
+		testRunID, testSpecialistID, foreignSource, matrix.contract,
+		matrix.candidates, matrix.verifiers, testLimits(), testVerifierLimits(),
+	); err == nil {
+		t.Fatal("BindDataset accepted a source record outside the pinned matrix-chain evidence")
+	}
+	foreignContract := matrix.contract
+	foreignContract.Seeds = append([]int64(nil), matrix.contract.Seeds...)
+	foreignContract.Seeds[0]++
+	if _, _, err := BindDataset(
+		testRunID, testSpecialistID, matrix.source, foreignContract,
+		matrix.candidates, matrix.verifiers, testLimits(), testVerifierLimits(),
+	); err == nil {
+		t.Fatal("BindDataset accepted a mutated generation contract")
+	}
+}
+
+func TestBindDatasetRejectsPromptSemanticsMissingFromTheGenericImporter(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		mutate func(*testExample)
+	}{
+		{"effective input size mismatch", func(example *testExample) {
+			example.prompt, example.reference = matrixExample(3, example.seed)
+		}},
+		{"hint-bearing prompt", func(example *testExample) { example.prompt += "hint:\n" }},
+		{"wrong input marker", func(example *testExample) {
+			example.prompt = strings.Replace(example.prompt, "\np: [", "\nkey: [", 1)
+		}},
+		{"wrong output marker", func(example *testExample) {
+			example.prompt = strings.Replace(example.prompt, "\ns:\n", "\nm:\n", 1)
+		}},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			fixture := newImportFixture(t, clrsfixture.TaskMatrixChainOrder)
+			test.mutate(&fixture.dataset.examples[0])
+			fixture.importDataset(t)
+			if _, _, err := BindDataset(
+				testRunID, testSpecialistID, fixture.source, fixture.contract,
+				fixture.candidates, fixture.verifiers, testLimits(), testVerifierLimits(),
+			); err == nil {
+				t.Fatalf("BindDataset accepted %s", test.name)
+			}
+		})
+	}
+}
+
+func TestBindDatasetRejectsSemanticallyWrongHeldAnswers(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		mutate func(*testExample)
+	}{
+		{"wrong shape", func(example *testExample) { example.reference = "1\n\n" }},
+		{"leading zero", func(example *testExample) { example.reference = "00\n\n" }},
+		{"out of range", func(example *testExample) { example.reference = "99\n\n" }},
+		{"foreign syntax", func(example *testExample) { example.reference = "[0]\n\n" }},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			fixture := newImportFixture(t, clrsfixture.TaskMatrixChainOrder)
+			test.mutate(&fixture.dataset.examples[0])
+			fixture.importDataset(t)
+			if _, _, err := BindDataset(
+				testRunID, testSpecialistID, fixture.source, fixture.contract,
+				fixture.candidates, fixture.verifiers, testLimits(), testVerifierLimits(),
+			); err == nil {
+				t.Fatalf("BindDataset accepted %s held answer", test.name)
+			}
+		})
+	}
+}
+
+func TestRequestSetAndVerifierSnapshotTheirSeparateInputs(t *testing.T) {
+	t.Parallel()
+	fixture := newImportFixture(t, clrsfixture.TaskMatrixChainOrder)
+	originalPrompt := fixture.candidates.Examples[0].Prompt
+	originalAnswer := fixture.verifiers.Examples[0].Reference
+	requestSet, verifier := bindFixture(t, fixture, testLimits(), testVerifierLimits())
+	fixture.candidates.Examples[0].Prompt = "mutated"
+	fixture.verifiers.Examples[0].Reference = "mutated"
+
+	requests, err := requestSet.Requests(verticalNow.Add(-time.Second), verticalNow.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	requests[0].Payload[0] = 'X'
+	fresh, err := requestSet.Requests(verticalNow.Add(-time.Second), verticalNow.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(fresh[0].Payload) != originalPrompt {
+		t.Fatalf("fresh request payload = %q, want original prompt", fresh[0].Payload)
+	}
+	invocation, candidate := verificationInputs(fresh[0], []byte(originalAnswer))
+	verification, err := verifier.Verify(context.Background(), invocation, candidate)
+	if err != nil || verification.Verdict != specialistcontrol.VerificationExact {
+		t.Fatalf("Verify(snapshot) = %#v, error %v", verification, err)
+	}
+
+	for name, window := range map[string][2]time.Time{
+		"zero issued":   {{}, verticalNow},
+		"zero deadline": {verticalNow, {}},
+		"equal":         {verticalNow, verticalNow},
+		"reverse":       {verticalNow, verticalNow.Add(-time.Second)},
+	} {
+		if _, err := requestSet.Requests(window[0], window[1]); err == nil {
+			t.Fatalf("Requests accepted %s window", name)
+		}
+	}
+	if _, err := (RequestSet{}).Requests(verticalNow, verticalNow.Add(time.Second)); err == nil {
+		t.Fatal("zero RequestSet produced requests")
+	}
+}
+
+func TestVerifierRejectsRunCandidateAndPromptSubstitution(t *testing.T) {
+	t.Parallel()
+	fixture := newImportFixture(t, clrsfixture.TaskMatrixChainOrder)
+	requestSet, verifier := bindFixture(t, fixture, testLimits(), testVerifierLimits())
+	requests, err := requestSet.Requests(verticalNow.Add(-time.Second), verticalNow.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	answer := []byte(fixture.verifiers.Examples[0].Reference)
+	invocation, candidate := verificationInputs(requests[0], answer)
+	if verification, err := verifier.Verify(context.Background(), invocation, candidate); err != nil ||
+		verification.Verdict != specialistcontrol.VerificationExact {
+		t.Fatalf("baseline verification = %#v, error %v", verification, err)
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*specialistcontrol.Invocation)
+	}{
+		{"run", func(value *specialistcontrol.Invocation) { value.RunID = "run-foreign" }},
+		{"candidate identity", func(value *specialistcontrol.Invocation) { value.RequestID = requests[3].RequestID }},
+		{"prompt", func(value *specialistcontrol.Invocation) { value.Payload[0] = 'X' }},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			changed := invocation
+			changed.Payload = append([]byte(nil), invocation.Payload...)
+			test.mutate(&changed)
+			if _, err := verifier.Verify(context.Background(), changed, candidate); err == nil {
+				t.Fatalf("Verify accepted %s substitution", test.name)
+			}
+		})
+	}
+	cancelled := &cancelAfterChecksContext{Context: context.Background(), cancelAt: 3}
+	if _, err := verifier.Verify(cancelled, invocation, candidate); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Verify(mid-parse cancellation) error = %v, want context.Canceled", err)
+	}
+}
+
+func TestBindDatasetClosesRunAndReferenceBounds(t *testing.T) {
+	t.Parallel()
+	fixture := newImportFixture(t, clrsfixture.TaskMatrixChainOrder)
+	tests := []struct {
+		name             string
+		runID            string
+		specialistID     string
+		limits           Limits
+		verifierLimits   VerifierLimits
+		wantReferenceErr bool
+	}{
+		{"empty run", "", testSpecialistID, testLimits(), testVerifierLimits(), false},
+		{"bad specialist", testRunID, "bad specialist", testLimits(), testVerifierLimits(), false},
+		{"open reference count", testRunID, testSpecialistID, testLimits(), VerifierLimits{MaxReferenceBytes: 1024}, true},
+		{"small reference count", testRunID, testSpecialistID, testLimits(), VerifierLimits{MaxReferences: 8, MaxReferenceBytes: 16 << 10}, true},
+		{"small reference bytes", testRunID, testSpecialistID, testLimits(), VerifierLimits{MaxReferences: 16, MaxReferenceBytes: 1}, true},
+		{"small value count", testRunID, testSpecialistID, withLimits(func(value *Limits) { value.MaxDimensions = 8 }), testVerifierLimits(), false},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			_, _, err := BindDataset(
+				test.runID, test.specialistID, fixture.source, fixture.contract,
+				fixture.candidates, fixture.verifiers, test.limits, test.verifierLimits,
+			)
+			if err == nil {
+				t.Fatalf("BindDataset accepted %s", test.name)
+			}
+			if test.wantReferenceErr && !errors.Is(err, ErrReferenceLimit) {
+				t.Fatalf("BindDataset(%s) error = %v, want ErrReferenceLimit", test.name, err)
+			}
+		})
+	}
+}
+
+func TestMatrixChainOrderVerticalRecordsBeforeEffectAndKeepsReferenceOutOfSpecialist(t *testing.T) {
+	t.Parallel()
+	runner, events, request, reference := verticalRunner(t, nil)
+	run, err := runner.Run(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.Decision.State != specialistcontrol.DecisionInvoke ||
+		run.Outcome.State != specialistcontrol.OutcomeVerified ||
+		run.Outcome.Authority != specialistcontrol.ResultAuthority ||
+		!bytes.Equal(run.Outcome.Payload, reference) {
+		t.Fatalf("vertical outcome = %#v", run)
+	}
+	if !reflect.DeepEqual(*events, []string{"record", "invoke", "verify"}) {
+		t.Fatalf("effect order = %v, want record/invoke/verify", *events)
+	}
+}
+
+func TestMatrixChainOrderVerticalRefusesMalformedAndOversizedInputBeforeVerification(t *testing.T) {
+	t.Parallel()
+	fixture := newImportFixture(t, clrsfixture.TaskMatrixChainOrder)
+	requestSet, verifier := bindFixture(t, fixture, testLimits(), testVerifierLimits())
+	requests, err := requestSet.Requests(verticalNow.Add(-time.Second), verticalNow.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, prompt := range map[string][]byte{
+		"malformed": []byte("matrix_chain_order:\nkey: [0.3 0.1 0.2]\ns:\n"),
+		"oversized": []byte("matrix_chain_order:\np: [0.1 0.2 0.3 0.4]\ns:\n"),
+	} {
+		name, prompt := name, prompt
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			limits := testLimits()
+			limits.MaxDimensions = 3
+			specialist, err := NewSpecialist(testSpecialistID, limits)
+			if err != nil {
+				t.Fatal(err)
+			}
+			verifierCalled := false
+			observedVerifier := verifierFunc(func(ctx context.Context, invocation specialistcontrol.Invocation, candidate specialistcontrol.Candidate) (specialistcontrol.Verification, error) {
+				verifierCalled = true
+				return verifier.Verify(ctx, invocation, candidate)
+			})
+			runner := newVerticalRunner(
+				t, specialist,
+				recorderFunc(func(context.Context, specialistcontrol.Decision) error { return nil }),
+				observedVerifier, func() time.Time { return verticalNow },
+			)
+			request := requests[0]
+			request.Payload = prompt
+			run, runErr := runner.Run(context.Background(), request)
+			if runErr != nil || verifierCalled || run.Outcome.State != specialistcontrol.OutcomeRefused ||
+				run.Outcome.Reason != specialistcontrol.ReasonSpecialistRefused ||
+				run.Outcome.Authority != specialistcontrol.ResultAuthority {
+				t.Fatalf("Run(%s) error/verifier/outcome = %v/%t/%#v", name, runErr, verifierCalled, run.Outcome)
+			}
+		})
+	}
+}
+
+func TestMatrixChainOrderVerticalTypesCancellationAndDeadlineAsNoResult(t *testing.T) {
+	t.Parallel()
+	t.Run("cancelled", func(t *testing.T) {
+		t.Parallel()
+		runner, _, request, _ := verticalRunner(t, nil)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		run, err := runner.Run(ctx, request)
+		if !errors.Is(err, context.Canceled) || run.Outcome.State != specialistcontrol.OutcomeAbstained ||
+			run.Outcome.Reason != specialistcontrol.ReasonCancelled ||
+			run.Outcome.Authority != specialistcontrol.ResultAuthority {
+			t.Fatalf("cancelled outcome/error = %#v/%v", run.Outcome, err)
+		}
+	})
+
+	t.Run("deadline", func(t *testing.T) {
+		t.Parallel()
+		fixture := newImportFixture(t, clrsfixture.TaskMatrixChainOrder)
+		requestSet, verifier := bindFixture(t, fixture, testLimits(), testVerifierLimits())
+		requests, err := requestSet.Requests(verticalNow.Add(-time.Second), verticalNow.Add(time.Second))
+		if err != nil {
+			t.Fatal(err)
+		}
+		specialist, err := NewSpecialist(testSpecialistID, testLimits())
+		if err != nil {
+			t.Fatal(err)
+		}
+		calls := 0
+		clock := func() time.Time {
+			calls++
+			if calls == 2 {
+				return requests[0].Deadline
+			}
+			return verticalNow
+		}
+		invoked := false
+		runner := newVerticalRunner(
+			t,
+			specialistFunc(func(ctx context.Context, invocation specialistcontrol.Invocation) (specialistcontrol.SpecialistResult, error) {
+				invoked = true
+				return specialist.Invoke(ctx, invocation)
+			}),
+			recorderFunc(func(context.Context, specialistcontrol.Decision) error { return nil }),
+			verifier, clock,
+		)
+		run, runErr := runner.Run(context.Background(), requests[0])
+		if runErr != nil || invoked || run.Outcome.State != specialistcontrol.OutcomeAbstained ||
+			run.Outcome.Reason != specialistcontrol.ReasonDeadlineElapsed ||
+			run.Outcome.Authority != specialistcontrol.ResultAuthority {
+			t.Fatalf("deadline outcome/error/invoked = %#v/%v/%t", run.Outcome, runErr, invoked)
+		}
+	})
+}
+
+func TestMatrixChainOrderVerticalAbstainsOnWrongAnswer(t *testing.T) {
+	t.Parallel()
+	fixture := newImportFixture(t, clrsfixture.TaskMatrixChainOrder)
+	requestSet, verifier := bindFixture(t, fixture, testLimits(), testVerifierLimits())
+	requests, err := requestSet.Requests(verticalNow.Add(-time.Second), verticalNow.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrong := specialistFunc(func(_ context.Context, invocation specialistcontrol.Invocation) (specialistcontrol.SpecialistResult, error) {
+		return specialistcontrol.SpecialistResult{
+			Binding: invocation.Binding, SpecialistID: testSpecialistID,
+			State: specialistcontrol.ResultCompleted, Payload: []byte("99\n\n"),
+		}, nil
+	})
+	runner := newVerticalRunner(
+		t, wrong,
+		recorderFunc(func(context.Context, specialistcontrol.Decision) error { return nil }),
+		verifier, func() time.Time { return verticalNow },
+	)
+	run, runErr := runner.Run(context.Background(), requests[0])
+	if runErr != nil || run.Outcome.State != specialistcontrol.OutcomeAbstained ||
+		run.Outcome.Reason != specialistcontrol.ReasonVerificationMismatch ||
+		run.Outcome.Authority != specialistcontrol.ResultAuthority || len(run.Outcome.Payload) != 0 {
+		t.Fatalf("wrong-answer outcome/error = %#v/%v", run.Outcome, runErr)
+	}
+}
+
+func verticalRunner(
+	t *testing.T,
+	clock func() time.Time,
+) (specialistcontrol.Runner, *[]string, specialistcontrol.Request, []byte) {
+	t.Helper()
+	if clock == nil {
+		clock = func() time.Time { return verticalNow }
+	}
+	fixture := newImportFixture(t, clrsfixture.TaskMatrixChainOrder)
+	requestSet, verifier := bindFixture(t, fixture, testLimits(), testVerifierLimits())
+	requests, err := requestSet.Requests(verticalNow.Add(-time.Second), verticalNow.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	reference := []byte(fixture.verifiers.Examples[0].Reference)
+	specialist, err := NewSpecialist(testSpecialistID, testLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	events := make([]string, 0, 3)
+	observedSpecialist := specialistFunc(func(ctx context.Context, invocation specialistcontrol.Invocation) (specialistcontrol.SpecialistResult, error) {
+		events = append(events, "invoke")
+		if bytes.Contains(invocation.Payload, reference) {
+			t.Fatal("verifier-only reference bytes leaked into the specialist request")
+		}
+		return specialist.Invoke(ctx, invocation)
+	})
+	observedVerifier := verifierFunc(func(ctx context.Context, invocation specialistcontrol.Invocation, candidate specialistcontrol.Candidate) (specialistcontrol.Verification, error) {
+		events = append(events, "verify")
+		return verifier.Verify(ctx, invocation, candidate)
+	})
+	runner := newVerticalRunner(
+		t, observedSpecialist,
+		recorderFunc(func(context.Context, specialistcontrol.Decision) error {
+			events = append(events, "record")
+			return nil
+		}),
+		observedVerifier, clock,
+	)
+	return runner, &events, requests[0], reference
+}
+
+func newVerticalRunner(
+	t *testing.T,
+	target specialistcontrol.Specialist,
+	recorder specialistcontrol.DecisionRecorder,
+	verifier specialistcontrol.ExactVerifier,
+	clock func() time.Time,
+) specialistcontrol.Runner {
+	t.Helper()
+	routes := make([]specialistcontrol.Route, 0, len(specialistcontrol.Tasks()))
+	specialists := make(map[string]specialistcontrol.Specialist, len(specialistcontrol.Tasks()))
+	for _, task := range specialistcontrol.Tasks() {
+		id := "unavailable-" + string(task)
+		if task == specialistcontrol.TaskMatrixChainOrder {
+			id = testSpecialistID
+			specialists[id] = target
+		} else {
+			specialists[id] = specialistFunc(func(_ context.Context, invocation specialistcontrol.Invocation) (specialistcontrol.SpecialistResult, error) {
+				return specialistcontrol.SpecialistResult{
+					Binding: invocation.Binding, SpecialistID: "unavailable-" + string(invocation.Task),
+					State: specialistcontrol.ResultAbstained,
+				}, nil
+			})
+		}
+		routes = append(routes, specialistcontrol.Route{Task: task, SpecialistID: id})
+	}
+	policy, err := specialistcontrol.NewPolicy(specialistcontrol.Limits{
+		MaxRequestBytes: 1024,
+		MaxResultBytes:  1024,
+		MaxRequestAge:   2 * time.Second,
+		MaxExecution:    2 * time.Second,
+	}, routes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner, err := specialistcontrol.NewRunner(policy, recorder, specialists, verifier, clock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return runner
+}
+
+type testExample struct {
+	prompt    string
+	reference string
+	length    int64
+	seed      int64
+	useHints  bool
+}
+
+type testDataset struct {
+	name     string
+	examples []testExample
+}
+
+type importFixture struct {
+	source     clrsfixture.SourceRecord
+	contract   clrsfixture.GenerationContract
+	task       clrsfixture.TaskPlan
+	dataset    testDataset
+	candidates clrsfixture.CandidateSet
+	verifiers  clrsfixture.VerifierSet
+}
+
+func newImportFixture(t *testing.T, task clrsfixture.TaskKind) importFixture {
+	t.Helper()
+	sourceBody := readGeneratorFile(t, "upstream.json")
+	source, err := clrsfixture.ParseSourceRecord(sourceBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	contractBody := readGeneratorFile(t, "contract.json")
+	contract, err := clrsfixture.ParseGenerationContract(contractBody, source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := contract.Plan(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var selected clrsfixture.TaskPlan
+	for _, candidate := range plan.Tasks {
+		if candidate.Task == task {
+			selected = candidate
+			break
+		}
+	}
+	if selected.Task == "" {
+		t.Fatalf("task %s is absent from tracked contract", task)
+	}
+	fixture := importFixture{
+		source: source, contract: contract, task: selected,
+		dataset: makeTestDataset(plan, selected),
+	}
+	fixture.importDataset(t)
+	return fixture
+}
+
+func (fixture *importFixture) importDataset(t *testing.T) {
+	t.Helper()
+	body, err := json.Marshal(fixture.dataset.jsonValue())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixture.candidates, fixture.verifiers, err = clrsfixture.ImportDataset(
+		bytes.NewReader(body),
+		fixture.source,
+		fixture.contract,
+		fixture.task.OutputRelativePath,
+		testImportLimits(),
+	)
+	if err != nil {
+		t.Fatalf("import synthetic contract-bound %s dataset: %v", fixture.task.Task, err)
+	}
+}
+
+func makeTestDataset(plan clrsfixture.GenerationPlan, task clrsfixture.TaskPlan) testDataset {
+	dataset := testDataset{name: "clrs_text_" + string(task.Task)}
+	for _, size := range task.Sizes {
+		for _, seed := range plan.Seeds {
+			for sample := 0; sample < plan.SamplesPerCell; sample++ {
+				prompt := fmt.Sprintf("%s:\ninput: %d/%d/%d", task.Task, size.RequestedLength, seed, sample)
+				reference := fmt.Sprintf("reference-%d-%d-%d", size.RequestedLength, seed, sample)
+				if task.Task == clrsfixture.TaskMatrixChainOrder {
+					prompt, reference = matrixExample(size.RequestedLength, seed)
+				}
+				dataset.examples = append(dataset.examples, testExample{
+					prompt: prompt, reference: reference,
+					length: size.RequestedLength, seed: seed, useHints: plan.UseHints,
+				})
+			}
+		}
+	}
+	return dataset
+}
+
+func (dataset testDataset) jsonValue() map[string]any {
+	examples := make([]any, 0, len(dataset.examples))
+	for _, example := range dataset.examples {
+		examples = append(examples, map[string]any{
+			"prompt":     example.prompt,
+			"references": []string{example.reference},
+			"auxiliary": map[string]any{
+				"length": example.length, "seed": example.seed, "use_hints": example.useHints,
+			},
+		})
+	}
+	return map[string]any{"name": dataset.name, "examples": examples}
+}
+
+func matrixExample(length, seed int64) (string, string) {
+	values := make([]string, 0, length)
+	dimensions := make([]float64, 0, length)
+	for index := int64(0); index < length; index++ {
+		raw := (seed*104729+(index+1)*(index+3)*7919)%900000 + 50000
+		values = append(values, fmt.Sprintf("0.%06d", raw))
+		dimensions = append(dimensions, float64(raw)/1_000_000)
+	}
+	prompt := "matrix_chain_order:\np: [" + strings.Join(values, " ") + "]\ns:\n"
+	return prompt, independentMatrixReference(dimensions)
+}
+
+func independentMatrixReference(dimensions []float64) string {
+	size := len(dimensions)
+	costs := make([][]float64, size)
+	splits := make([][]int, size)
+	for row := 0; row < size; row++ {
+		costs[row] = make([]float64, size)
+		splits[row] = make([]int, size)
+	}
+	for width := 2; width < size; width++ {
+		for left := 1; left+width-1 < size; left++ {
+			right := left + width - 1
+			best := math.Inf(1)
+			for split := left; split < right; split++ {
+				candidate := costs[left][split] + costs[split+1][right] +
+					dimensions[left-1]*dimensions[split]*dimensions[right]
+				if candidate < best {
+					best = candidate
+					splits[left][right] = split
+				}
+			}
+			costs[left][right] = best
+		}
+	}
+	var answer strings.Builder
+	answer.WriteByte('[')
+	for row := range splits {
+		if row > 0 {
+			answer.WriteString(", ")
+		}
+		answer.WriteByte('[')
+		for column, split := range splits[row] {
+			if column > 0 {
+				answer.WriteByte(' ')
+			}
+			answer.WriteString(strconv.Itoa(split))
+		}
+		answer.WriteByte(']')
+	}
+	answer.WriteString("]\n\n")
+	return answer.String()
+}
+
+func readGeneratorFile(t *testing.T, name string) []byte {
+	t.Helper()
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("locate matrix-chain adapter test")
+	}
+	body, err := os.ReadFile(filepath.Join(filepath.Dir(filename), "..", "..", "clrs-generator", name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return body
+}
+
+func bindFixture(
+	t *testing.T,
+	fixture importFixture,
+	limits Limits,
+	verifierLimits VerifierLimits,
+) (RequestSet, Verifier) {
+	t.Helper()
+	requestSet, verifier, err := BindDataset(
+		testRunID,
+		testSpecialistID,
+		fixture.source,
+		fixture.contract,
+		fixture.candidates,
+		fixture.verifiers,
+		limits,
+		verifierLimits,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return requestSet, verifier
+}
+
+func verificationInputs(
+	request specialistcontrol.Request,
+	answer []byte,
+) (specialistcontrol.Invocation, specialistcontrol.Candidate) {
+	invocation := specialistcontrol.Invocation{
+		RunID: request.RunID, RequestID: request.RequestID, Task: request.Task,
+		Payload: append([]byte(nil), request.Payload...), Binding: specialistcontrol.Binding{1},
+		Deadline: request.Deadline, MaxResultBytes: 1024,
+	}
+	candidate := specialistcontrol.Candidate{
+		Binding: invocation.Binding, CandidateBinding: specialistcontrol.CandidateBinding{1},
+		SpecialistID: testSpecialistID, State: specialistcontrol.ResultCompleted,
+		Payload: append([]byte(nil), answer...),
+	}
+	return invocation, candidate
+}
+
+func cloneCandidateSet(set clrsfixture.CandidateSet) clrsfixture.CandidateSet {
+	set.Examples = append([]clrsfixture.CandidateExample(nil), set.Examples...)
+	return set
+}
+
+func cloneVerifierSet(set clrsfixture.VerifierSet) clrsfixture.VerifierSet {
+	set.Examples = append([]clrsfixture.VerifierExample(nil), set.Examples...)
+	return set
+}
+
+func testImportLimits() clrsfixture.ImportLimits {
+	return clrsfixture.ImportLimits{
+		MaxDatasetBytes: 1 << 20, MaxExamples: 16,
+		MaxPromptBytes: 512, MaxReferenceBytes: 512, MaxDeclaredLength: 64,
+	}
+}
+
+func testVerifierLimits() VerifierLimits {
+	return VerifierLimits{MaxReferences: 16, MaxReferenceBytes: 16 << 10}
+}
+
+func withLimits(change func(*Limits)) Limits {
+	limits := testLimits()
+	change(&limits)
+	return limits
+}

--- a/tooling/internal/clrsmatrixchain/prompt.go
+++ b/tooling/internal/clrsmatrixchain/prompt.go
@@ -1,0 +1,412 @@
+package clrsmatrixchain
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+)
+
+const (
+	promptPrefix = "matrix_chain_order:\np: ["
+	promptSuffix = "]\ns:\n"
+	answerSuffix = "\n\n"
+
+	maximumPromptBytesCeiling = 1 << 20
+	maximumDimensionsCeiling  = 128
+	maximumTokenBytesCeiling  = 128
+	maximumAnswerBytesCeiling = 1 << 20
+)
+
+var (
+	// ErrInvalidLimits means a caller did not close every parser/output bound.
+	ErrInvalidLimits = errors.New("invalid matrix-chain limits")
+	// ErrMalformedPrompt means bytes do not match the bounded no-hint grammar.
+	ErrMalformedPrompt = errors.New("malformed matrix-chain prompt")
+	// ErrPromptLimit means candidate-visible input crossed a configured bound.
+	ErrPromptLimit = errors.New("matrix-chain prompt limit exceeded")
+	// ErrAnswerLimit means the exact answer crossed a configured output bound.
+	ErrAnswerLimit = errors.New("matrix-chain answer limit exceeded")
+)
+
+// Limits are parser and bounded-work safety caps, not selected experiment sizes.
+type Limits struct {
+	MaxPromptBytes int
+	MaxDimensions  int
+	MaxTokenBytes  int
+	MaxAnswerBytes int
+}
+
+// Validate rejects open or impractically large bounds.
+func (limits Limits) Validate() error {
+	if limits.MaxPromptBytes <= 0 || limits.MaxPromptBytes > maximumPromptBytesCeiling ||
+		limits.MaxDimensions < 2 || limits.MaxDimensions > maximumDimensionsCeiling ||
+		limits.MaxTokenBytes <= 0 || limits.MaxTokenBytes > maximumTokenBytesCeiling ||
+		limits.MaxAnswerBytes <= 0 || limits.MaxAnswerBytes > maximumAnswerBytesCeiling {
+		return ErrInvalidLimits
+	}
+	return nil
+}
+
+type scalar struct {
+	value float64
+}
+
+type chainInput struct {
+	dimensions []scalar
+}
+
+// Solve returns the pinned CLRS matrix-chain split-pointer matrix for the
+// bounded no-hint structural grammar. A successful answer is NO_RESULT.
+func Solve(ctx context.Context, prompt []byte, limits Limits) ([]byte, error) {
+	if ctx == nil {
+		return nil, errors.New("solve matrix chain: nil context")
+	}
+	if err := limits.Validate(); err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	input, err := parsePrompt(ctx, prompt, limits)
+	if err != nil {
+		return nil, err
+	}
+	splits, err := matrixChainOrder(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+	return formatAnswer(splits, limits.MaxAnswerBytes)
+}
+
+func parsePrompt(ctx context.Context, prompt []byte, limits Limits) (chainInput, error) {
+	if len(prompt) > limits.MaxPromptBytes {
+		return chainInput{}, fmt.Errorf("%w: %d bytes exceeds %d", ErrPromptLimit, len(prompt), limits.MaxPromptBytes)
+	}
+	if len(prompt) == 0 || !utf8.Valid(prompt) {
+		return chainInput{}, ErrMalformedPrompt
+	}
+	body, found := strings.CutPrefix(string(prompt), promptPrefix)
+	if !found {
+		return chainInput{}, fmt.Errorf("%w: wrong task or dimension marker", ErrMalformedPrompt)
+	}
+	body, found = strings.CutSuffix(body, promptSuffix)
+	if !found || body == "" {
+		return chainInput{}, fmt.Errorf("%w: wrong output marker or empty dimensions", ErrMalformedPrompt)
+	}
+	tokens := strings.Split(body, " ")
+	if len(tokens) < 2 {
+		return chainInput{}, fmt.Errorf("%w: matrix chain needs at least two dimensions", ErrMalformedPrompt)
+	}
+	if len(tokens) > limits.MaxDimensions {
+		return chainInput{}, fmt.Errorf("%w: %d dimensions exceeds %d", ErrPromptLimit, len(tokens), limits.MaxDimensions)
+	}
+	dimensions := make([]scalar, 0, len(tokens))
+	for index, token := range tokens {
+		if err := ctx.Err(); err != nil {
+			return chainInput{}, err
+		}
+		value, err := parseBoundedScalar(token, limits.MaxTokenBytes)
+		if err != nil {
+			if errors.Is(err, ErrPromptLimit) {
+				return chainInput{}, fmt.Errorf("%w at dimension %d: %v", ErrPromptLimit, index, err)
+			}
+			return chainInput{}, fmt.Errorf("%w at dimension %d: %v", ErrMalformedPrompt, index, err)
+		}
+		dimensions = append(dimensions, value)
+	}
+	return chainInput{dimensions: dimensions}, nil
+}
+
+func parseBoundedScalar(token string, maximumBytes int) (scalar, error) {
+	if token == "" {
+		return scalar{}, errors.New("empty scalar")
+	}
+	if len(token) > maximumBytes {
+		return scalar{}, fmt.Errorf("%w: scalar exceeds %d bytes", ErrPromptLimit, maximumBytes)
+	}
+	if !decimalGrammar(token) {
+		return scalar{}, errors.New("scalar is outside the finite decimal grammar")
+	}
+	value, err := strconv.ParseFloat(token, 64)
+	if err != nil || math.IsInf(value, 0) || math.IsNaN(value) {
+		return scalar{}, errors.New("scalar is not finite float64")
+	}
+	// The pinned SortingSampler draws matrix dimensions from U[0,1).
+	if value < 0 || value >= 1 {
+		return scalar{}, errors.New("scalar is outside the pinned sampler range [0,1)")
+	}
+	return scalar{value: value}, nil
+}
+
+func decimalGrammar(token string) bool {
+	index := 0
+	if index >= len(token) || token[index] < '0' || token[index] > '9' {
+		return false
+	}
+	for index < len(token) && token[index] >= '0' && token[index] <= '9' {
+		index++
+	}
+	if index < len(token) && token[index] == '.' {
+		index++
+		start := index
+		for index < len(token) && token[index] >= '0' && token[index] <= '9' {
+			index++
+		}
+		if start == index {
+			return false
+		}
+	}
+	if index < len(token) && token[index] == 'e' {
+		index++
+		if index < len(token) && (token[index] == '+' || token[index] == '-') {
+			index++
+		}
+		start := index
+		for index < len(token) && token[index] >= '0' && token[index] <= '9' {
+			index++
+		}
+		if start == index {
+			return false
+		}
+	}
+	return index == len(token)
+}
+
+// matrixChainOrder mirrors the pinned synchronous relaxation, including its
+// first-discovered tie rule. The interval graph has depth below n, so n sweeps
+// close the otherwise open upstream while loop.
+func matrixChainOrder(ctx context.Context, input chainInput) ([][]int, error) {
+	size := len(input.dimensions)
+	costs := makeFloatMatrix(size)
+	splits := makeIntMatrix(size)
+	known := makeBoolMatrix(size)
+	for index := 1; index < size; index++ {
+		known[index][index] = true
+	}
+	for sweep := 0; sweep < size; sweep++ {
+		previousCosts := cloneFloatMatrix(costs)
+		previousKnown := cloneBoolMatrix(known)
+		for left := 1; left < size; left++ {
+			for right := left + 1; right < size; right++ {
+				if err := ctx.Err(); err != nil {
+					return nil, err
+				}
+				found := previousKnown[left][right]
+				for split := left; split < right; split++ {
+					if !previousKnown[left][split] || !previousKnown[split+1][right] {
+						continue
+					}
+					known[left][right] = true
+					candidate := previousCosts[left][split] + previousCosts[split+1][right] +
+						input.dimensions[left-1].value*input.dimensions[split].value*input.dimensions[right].value
+					if !found || candidate < costs[left][right] {
+						costs[left][right] = candidate
+						splits[left][right] = split
+						found = true
+					}
+				}
+			}
+		}
+		if equalFloatMatrices(previousCosts, costs) {
+			return splits, nil
+		}
+	}
+	return nil, errors.New("matrix-chain relaxation did not converge within the dimension bound")
+}
+
+func formatAnswer(matrix [][]int, maximumBytes int) ([]byte, error) {
+	answer := make([]byte, 0, len(matrix)*len(matrix)*3)
+	answer = append(answer, '[')
+	for row := range matrix {
+		if row > 0 {
+			answer = append(answer, ',', ' ')
+		}
+		answer = append(answer, '[')
+		for column, value := range matrix[row] {
+			if column > 0 {
+				answer = append(answer, ' ')
+			}
+			answer = strconv.AppendInt(answer, int64(value), 10)
+			if len(answer) > maximumBytes {
+				return nil, fmt.Errorf("%w: output exceeds %d bytes", ErrAnswerLimit, maximumBytes)
+			}
+		}
+		answer = append(answer, ']')
+	}
+	answer = append(answer, ']', '\n', '\n')
+	if len(answer) > maximumBytes {
+		return nil, fmt.Errorf("%w: %d bytes exceeds %d", ErrAnswerLimit, len(answer), maximumBytes)
+	}
+	return answer, nil
+}
+
+func parseAnswer(reference []byte, limits Limits, size int) ([][]int, error) {
+	if len(reference) == 0 || len(reference) > limits.MaxAnswerBytes || !utf8.Valid(reference) {
+		return nil, fmt.Errorf("%w: reference must contain 1..%d UTF-8 bytes", ErrAnswerLimit, limits.MaxAnswerBytes)
+	}
+	body, found := strings.CutSuffix(string(reference), answerSuffix)
+	if !found {
+		return nil, errors.New("reference is not one canonical split matrix")
+	}
+	position := 0
+	expect := func(literal string) bool {
+		if !strings.HasPrefix(body[position:], literal) {
+			return false
+		}
+		position += len(literal)
+		return true
+	}
+	if !expect("[") {
+		return nil, errors.New("reference is not one canonical split matrix")
+	}
+	matrix := makeIntMatrix(size)
+	for row := 0; row < size; row++ {
+		if row > 0 && !expect(", ") {
+			return nil, errors.New("reference row separator is not canonical")
+		}
+		if !expect("[") {
+			return nil, errors.New("reference row is not bracketed")
+		}
+		for column := 0; column < size; column++ {
+			if column > 0 && !expect(" ") {
+				return nil, errors.New("reference column separator is not canonical")
+			}
+			value, next, err := parseCanonicalIndex(body, position, size)
+			if err != nil {
+				return nil, err
+			}
+			matrix[row][column] = value
+			position = next
+		}
+		if !expect("]") {
+			return nil, errors.New("reference row has extra or missing columns")
+		}
+	}
+	if !expect("]") || position != len(body) {
+		return nil, errors.New("reference has extra or missing rows")
+	}
+	return matrix, nil
+}
+
+func parseCanonicalIndex(body string, position, size int) (int, int, error) {
+	if position >= len(body) || body[position] < '0' || body[position] > '9' {
+		return 0, position, errors.New("reference split is not a non-negative integer")
+	}
+	start := position
+	for position < len(body) && body[position] >= '0' && body[position] <= '9' {
+		position++
+	}
+	if position-start > 1 && body[start] == '0' {
+		return 0, position, errors.New("reference split has a leading zero")
+	}
+	parsed, err := strconv.ParseUint(body[start:position], 10, 31)
+	if err != nil || parsed >= uint64(size) {
+		return 0, position, fmt.Errorf("reference split is outside 0..%d", size-1)
+	}
+	return int(parsed), position, nil
+}
+
+// validateReference proves every held split independently with conventional
+// interval-order dynamic programming; it never calls Solve or its relaxation.
+func validateReference(ctx context.Context, reference []byte, limits Limits, input chainInput) error {
+	size := len(input.dimensions)
+	matrix, err := parseAnswer(reference, limits, size)
+	if err != nil {
+		return err
+	}
+	for row := 0; row < size; row++ {
+		for column := 0; column <= row; column++ {
+			if matrix[row][column] != 0 {
+				return fmt.Errorf("reference split[%d][%d] = %d, want structural zero", row, column, matrix[row][column])
+			}
+		}
+		if matrix[0][row] != 0 {
+			return fmt.Errorf("reference split[0][%d] = %d, want structural zero", row, matrix[0][row])
+		}
+	}
+	costs := makeFloatMatrix(size)
+	for width := 2; width < size; width++ {
+		for left := 1; left+width-1 < size; left++ {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			right := left + width - 1
+			selected := matrix[left][right]
+			if selected < left || selected >= right {
+				return fmt.Errorf("reference split[%d][%d] = %d, want %d..%d", left, right, selected, left, right-1)
+			}
+			best := math.Inf(1)
+			selectedCost := math.Inf(1)
+			for split := left; split < right; split++ {
+				candidate := costs[left][split] + costs[split+1][right] +
+					input.dimensions[left-1].value*input.dimensions[split].value*input.dimensions[right].value
+				if candidate < best {
+					best = candidate
+				}
+				if split == selected {
+					selectedCost = candidate
+				}
+			}
+			if selectedCost != best {
+				return fmt.Errorf("reference split[%d][%d] = %d is not cost-minimal", left, right, selected)
+			}
+			costs[left][right] = best
+		}
+	}
+	return nil
+}
+
+func makeFloatMatrix(size int) [][]float64 {
+	matrix := make([][]float64, size)
+	for row := range matrix {
+		matrix[row] = make([]float64, size)
+	}
+	return matrix
+}
+
+func makeIntMatrix(size int) [][]int {
+	matrix := make([][]int, size)
+	for row := range matrix {
+		matrix[row] = make([]int, size)
+	}
+	return matrix
+}
+
+func makeBoolMatrix(size int) [][]bool {
+	matrix := make([][]bool, size)
+	for row := range matrix {
+		matrix[row] = make([]bool, size)
+	}
+	return matrix
+}
+
+func cloneFloatMatrix(matrix [][]float64) [][]float64 {
+	clone := make([][]float64, len(matrix))
+	for row := range matrix {
+		clone[row] = append([]float64(nil), matrix[row]...)
+	}
+	return clone
+}
+
+func cloneBoolMatrix(matrix [][]bool) [][]bool {
+	clone := make([][]bool, len(matrix))
+	for row := range matrix {
+		clone[row] = append([]bool(nil), matrix[row]...)
+	}
+	return clone
+}
+
+func equalFloatMatrices(left, right [][]float64) bool {
+	for row := range left {
+		for column := range left[row] {
+			if left[row][column] != right[row][column] {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/tooling/internal/clrsmatrixchain/prompt_test.go
+++ b/tooling/internal/clrsmatrixchain/prompt_test.go
@@ -1,0 +1,195 @@
+package clrsmatrixchain
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/lusoris/20-watts-was-enough/tooling/internal/clrsfixture"
+)
+
+type cancelAfterChecksContext struct {
+	context.Context
+	cancelAt int
+	checks   int
+}
+
+func (ctx *cancelAfterChecksContext) Err() error {
+	ctx.checks++
+	if ctx.checks >= ctx.cancelAt {
+		return context.Canceled
+	}
+	return nil
+}
+
+func TestSolveMatchesPinnedNoHintProbeGrammar(t *testing.T) {
+	t.Parallel()
+	prompt := []byte("matrix_chain_order:\np: [0.30 0.35 0.15 0.05 0.10 0.20 0.25]\ns:\n")
+	want := "[[0 0 0 0 0 0 0], [0 0 1 1 3 3 3], [0 0 0 2 3 3 3], [0 0 0 0 3 3 3], [0 0 0 0 0 4 5], [0 0 0 0 0 0 5], [0 0 0 0 0 0 0]]\n\n"
+	first, err := Solve(context.Background(), prompt, testLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := Solve(context.Background(), prompt, testLimits())
+	if err != nil || string(first) != want || string(second) != want {
+		t.Fatalf("Solve() = %q/%q, error %v, want exact %q", first, second, err, want)
+	}
+}
+
+func TestSolvePreservesPinnedFirstDiscoveredTie(t *testing.T) {
+	t.Parallel()
+	prompt := []byte("matrix_chain_order:\np: [0.2 0.2 0.2 0.2 0.2]\ns:\n")
+	want := "[[0 0 0 0 0], [0 0 1 1 2], [0 0 0 2 2], [0 0 0 0 3], [0 0 0 0 0]]\n\n"
+	answer, err := Solve(context.Background(), prompt, testLimits())
+	if err != nil || string(answer) != want {
+		t.Fatalf("Solve(tie) = %q, error %v, want %q", answer, err, want)
+	}
+
+	input, err := parsePrompt(context.Background(), prompt, testLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	alternativeOptimal := []byte("[[0 0 0 0 0], [0 0 1 1 1], [0 0 0 2 2], [0 0 0 0 3], [0 0 0 0 0]]\n\n")
+	if err := validateReference(context.Background(), alternativeOptimal, testLimits(), input); err != nil {
+		t.Fatalf("independent verifier rejected an alternative cost-optimal tie: %v", err)
+	}
+}
+
+func TestValidateReferenceRejectsCanonicalButSuboptimalSplit(t *testing.T) {
+	t.Parallel()
+	prompt := []byte("matrix_chain_order:\np: [0.30 0.35 0.15 0.05 0.10 0.20 0.25]\ns:\n")
+	input, err := parsePrompt(context.Background(), prompt, testLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrong := []byte("[[0 0 0 0 0 0 0], [0 0 1 1 3 3 1], [0 0 0 2 3 3 3], [0 0 0 0 3 3 3], [0 0 0 0 0 4 5], [0 0 0 0 0 0 5], [0 0 0 0 0 0 0]]\n\n")
+	if err := validateReference(context.Background(), wrong, testLimits(), input); err == nil {
+		t.Fatal("validateReference accepted a canonical but suboptimal split matrix")
+	}
+}
+
+func TestSolveRejectsMalformedAndOversizedPrompts(t *testing.T) {
+	t.Parallel()
+	valid := "matrix_chain_order:\np: [0.1 0.3 0.5]\ns:\n"
+	tests := map[string]struct {
+		prompt string
+		mutate func(*Limits)
+		want   error
+	}{
+		"wrong task":       {prompt: strings.Replace(valid, "matrix_chain_order", "optimal_bst", 1), want: ErrMalformedPrompt},
+		"hinted trace":     {prompt: "matrix_chain_order:\np: [0.1 0.3], initial_trace: [[0 0], [0 0]]\ntrace | s:\n", want: ErrMalformedPrompt},
+		"one dimension":    {prompt: "matrix_chain_order:\np: [0.1]\ns:\n", want: ErrMalformedPrompt},
+		"wrong output":     {prompt: strings.Replace(valid, "\ns:\n", "\nm:\n", 1), want: ErrMalformedPrompt},
+		"missing newline":  {prompt: strings.TrimSuffix(valid, "\n"), want: ErrMalformedPrompt},
+		"comma separator":  {prompt: strings.Replace(valid, "0.1 0.3", "0.1, 0.3", 1), want: ErrMalformedPrompt},
+		"double space":     {prompt: strings.Replace(valid, "0.1 0.3", "0.1  0.3", 1), want: ErrMalformedPrompt},
+		"non-finite":       {prompt: strings.Replace(valid, "0.3", "NaN", 1), want: ErrMalformedPrompt},
+		"negative":         {prompt: strings.Replace(valid, "0.3", "-0.3", 1), want: ErrMalformedPrompt},
+		"sampler range":    {prompt: strings.Replace(valid, "0.3", "1.0", 1), want: ErrMalformedPrompt},
+		"too many values":  {prompt: valid, mutate: func(limits *Limits) { limits.MaxDimensions = 2 }, want: ErrPromptLimit},
+		"oversized token":  {prompt: valid, mutate: func(limits *Limits) { limits.MaxTokenBytes = 2 }, want: ErrPromptLimit},
+		"oversized prompt": {prompt: valid, mutate: func(limits *Limits) { limits.MaxPromptBytes = len(valid) - 1 }, want: ErrPromptLimit},
+		"oversized answer": {prompt: valid, mutate: func(limits *Limits) { limits.MaxAnswerBytes = 2 }, want: ErrAnswerLimit},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			limits := testLimits()
+			if test.mutate != nil {
+				test.mutate(&limits)
+			}
+			if _, err := Solve(context.Background(), []byte(test.prompt), limits); !errors.Is(err, test.want) {
+				t.Fatalf("Solve() error = %v, want %v", err, test.want)
+			}
+		})
+	}
+}
+
+func TestSolveHonoursCancellationAndClosedLimits(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	prompt := []byte("matrix_chain_order:\np: [0.1 0.3 0.5]\ns:\n")
+	if _, err := Solve(ctx, prompt, testLimits()); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Solve(cancelled) error = %v, want context.Canceled", err)
+	}
+	limits := testLimits()
+	limits.MaxDimensions = 0
+	if _, err := Solve(context.Background(), prompt, limits); !errors.Is(err, ErrInvalidLimits) {
+		t.Fatalf("Solve(open limits) error = %v, want ErrInvalidLimits", err)
+	}
+}
+
+func TestSolveChecksCancellationInsideMatrixChainOrder(t *testing.T) {
+	t.Parallel()
+	ctx := &cancelAfterChecksContext{Context: context.Background(), cancelAt: 14}
+	prompt := []byte("matrix_chain_order:\np: [0.1 0.2 0.3 0.4 0.5 0.6 0.7 0.8]\ns:\n")
+	if _, err := Solve(ctx, prompt, testLimits()); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Solve(matrix cancellation) error = %v, want context.Canceled", err)
+	}
+	if ctx.checks != ctx.cancelAt {
+		t.Fatalf("context checks = %d, want cancellation at check %d", ctx.checks, ctx.cancelAt)
+	}
+}
+
+func TestPinnedSourceEvidenceIsExact(t *testing.T) {
+	t.Parallel()
+	evidence := PinnedSourceEvidence()
+	if evidence.SourceRecordPath != "tooling/clrs-generator/upstream.json" ||
+		evidence.SourceID != "sha256:7ec3b6b7528d04f517c4e9b7c3e0cd0f7034a775d225d469d1aca5c00fec10d1" {
+		t.Fatalf("source identity = %#v", evidence)
+	}
+	if evidence.Formatter.SHA256 != "d6d320eb1536be8fbdb512315d55eada2db3ff87afd613762f125d38a9e7a53c" ||
+		evidence.Spec.SHA256 != "51f1cc936b28189c7b2e3b2030c30e224fb448f3d2846181983329448f1ed018" ||
+		evidence.Algorithm.Path != "clrs/_src/algorithms/dynamic_programming.py" ||
+		evidence.Algorithm.GitBlob != "b8f814ba8cf59a6d0fb508509999ccccdfed4e54" ||
+		evidence.Algorithm.SHA256 != "d966b8cfc3867e06daa2c9352e0371b3364cdf35272f11efe084c1a88460b0f9" ||
+		evidence.Sampler.SHA256 != "01921e9ca7fa0cc81a8ce82dd76869820f1e9ad8863d5b76b088b0610a2e0473" ||
+		evidence.Probing.SHA256 != "6ee8bea717c6a820fec0457c8be01a4459d5b2daab9c2c883ab8db333478f064" {
+		t.Fatalf("source file identities = %#v", evidence)
+	}
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("locate matrix-chain source test")
+	}
+	body, err := os.ReadFile(filepath.Join(filepath.Dir(filename), "..", "..", "clrs-generator", "upstream.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	source, err := clrsfixture.ParseSourceRecord(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := evidence.ValidateSource(source); err != nil {
+		t.Fatal(err)
+	}
+	mutations := []func(*SourceEvidence){
+		func(value *SourceEvidence) { value.SourceRecordPath = "other.json" },
+		func(value *SourceEvidence) { value.Formatter.SHA256 = strings.Repeat("0", 64) },
+		func(value *SourceEvidence) { value.Spec.GitBlob = strings.Repeat("0", 40) },
+		func(value *SourceEvidence) { value.Algorithm.Path = "dynamic-programming-other.py" },
+		func(value *SourceEvidence) { value.Sampler.SHA256 = strings.Repeat("f", 64) },
+		func(value *SourceEvidence) { value.Probing.GitBlob = strings.Repeat("a", 40) },
+	}
+	for index, mutate := range mutations {
+		changed := evidence
+		mutate(&changed)
+		if err := changed.ValidateSource(source); err == nil {
+			t.Fatalf("ValidateSource accepted supporting-evidence mutation %d", index)
+		}
+	}
+}
+
+func testLimits() Limits {
+	return Limits{
+		MaxPromptBytes: 512,
+		MaxDimensions:  64,
+		MaxTokenBytes:  32,
+		MaxAnswerBytes: 8 << 10,
+	}
+}

--- a/tooling/internal/clrsmatrixchain/source.go
+++ b/tooling/internal/clrsmatrixchain/source.go
@@ -1,0 +1,81 @@
+// Package clrsmatrixchain implements the exact-program matrix-chain-order
+// vertical for the CLRS-Text development shakedown. Every value remains
+// NO_RESULT.
+package clrsmatrixchain
+
+import (
+	"fmt"
+
+	"github.com/lusoris/20-watts-was-enough/tooling/internal/clrsfixture"
+)
+
+// SourceFile binds one upstream file used to derive this vertical's grammar or
+// exact conventional operation. SHA256 is over the file bytes at Commit.
+type SourceFile struct {
+	Path    string
+	GitBlob string
+	SHA256  string
+}
+
+// SourceEvidence extends the canonical source record with the supporting files
+// used to derive this vertical. It references rather than repeats repository,
+// commit, tree, generator, requirements and licence metadata.
+type SourceEvidence struct {
+	SourceRecordPath string
+	SourceID         string
+	Formatter        SourceFile
+	Spec             SourceFile
+	Algorithm        SourceFile
+	Sampler          SourceFile
+	Probing          SourceFile
+}
+
+// PinnedSourceEvidence returns the exact official source inspected for the
+// no-hint prompt/reference grammar and matrix-chain split operation.
+func PinnedSourceEvidence() SourceEvidence {
+	return SourceEvidence{
+		SourceRecordPath: "tooling/clrs-generator/upstream.json",
+		SourceID:         "sha256:7ec3b6b7528d04f517c4e9b7c3e0cd0f7034a775d225d469d1aca5c00fec10d1",
+		Formatter: SourceFile{
+			Path:    "clrs/_src/clrs_text/clrs_utils.py",
+			GitBlob: "64a2714ca879cd62a4c1d1db0a80e6c23bf61541",
+			SHA256:  "d6d320eb1536be8fbdb512315d55eada2db3ff87afd613762f125d38a9e7a53c",
+		},
+		Spec: SourceFile{
+			Path:    "clrs/_src/specs.py",
+			GitBlob: "db3b02e14072152df590a8df518ef058fd167930",
+			SHA256:  "51f1cc936b28189c7b2e3b2030c30e224fb448f3d2846181983329448f1ed018",
+		},
+		Algorithm: SourceFile{
+			Path:    "clrs/_src/algorithms/dynamic_programming.py",
+			GitBlob: "b8f814ba8cf59a6d0fb508509999ccccdfed4e54",
+			SHA256:  "d966b8cfc3867e06daa2c9352e0371b3364cdf35272f11efe084c1a88460b0f9",
+		},
+		Sampler: SourceFile{
+			Path:    "clrs/_src/samplers.py",
+			GitBlob: "442a5c6d1da86c2956d8dcc78c9339ded296e1a8",
+			SHA256:  "01921e9ca7fa0cc81a8ce82dd76869820f1e9ad8863d5b76b088b0610a2e0473",
+		},
+		Probing: SourceFile{
+			Path:    "clrs/_src/probing.py",
+			GitBlob: "e4ba102eecdfee2934268a33727da964a2119d37",
+			SHA256:  "6ee8bea717c6a820fec0457c8be01a4459d5b2daab9c2c883ab8db333478f064",
+		},
+	}
+}
+
+// ValidateSource checks that this grammar evidence points to the supplied
+// canonical source record.
+func (evidence SourceEvidence) ValidateSource(source clrsfixture.SourceRecord) error {
+	if evidence != PinnedSourceEvidence() {
+		return fmt.Errorf("matrix-chain supporting source evidence differs from the pinned record")
+	}
+	identity, err := source.Identity()
+	if err != nil {
+		return fmt.Errorf("validate matrix-chain source record: %w", err)
+	}
+	if identity.String() != evidence.SourceID {
+		return fmt.Errorf("matrix-chain source identity = %s, want %s", identity, evidence.SourceID)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

- add the bounded Go matrix-chain specialist and source contract
- verify pinned CLRS bytes and preserve exact NO_RESULT authority
- cover deterministic prompts, adapter boundaries, malformed inputs, and resource limits

## Verification

- gofmt clean
- go test -race -count=1 ./internal/clrsmatrixchain
- go vet ./internal/clrsmatrixchain
- package coverage: 86.4%
- rebased tree is byte-identical to the previously validated specialist stack

Tracks #12.