### PR TITLE
feat(experiment): add Bellman-Ford specialist vertical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,11 @@ the exact diff; this file records why the project changed.
   Go. A separate interval-order verifier proves each held split is cost-minimal
   without calling the specialist solver; source-bound requests remain isolated
   from held answers, and all construction output remains `NO_RESULT`.
+- The Bellman-Ford construction vertical now reproduces the pinned synchronous
+  relaxation and predecessor-vector grammar in Go. A separate Dijkstra verifier
+  checks each held predecessor forest against the same bounded non-negative
+  graph without calling the specialist solver; source-bound requests remain
+  isolated from held answers, and all construction output remains `NO_RESULT`.
 - A versioned PDF semantic sentinel now binds the current source, book, A4 and
   tag metadata, Poppler tool identity, separate structure and text streams,
   exact diagnostics, and six nonlinear content anchors. Atomic evidence keeps

--- a/tooling/internal/clrsbellmanford/adapter.go
+++ b/tooling/internal/clrsbellmanford/adapter.go
@@ -1,0 +1,346 @@
+package clrsbellmanford
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/lusoris/20-watts-was-enough/tooling/internal/clrsfixture"
+	"github.com/lusoris/20-watts-was-enough/tooling/internal/specialistcontrol"
+)
+
+const (
+	maximumIdentityBytes            = 128
+	maximumReferencesCeiling        = 4_096
+	maximumReferenceSetBytesCeiling = 64 << 20
+	// Four fixture identities, one prompt digest and the effective-size integer.
+	heldIdentityBytes = 5*sha256.Size + 8
+)
+
+var ErrReferenceLimit = errors.New("Bellman-Ford reference limit exceeded")
+
+// Specialist is the exact pinned CLRS Bellman-Ford implementation. It
+// owns no reference data and sees only specialistcontrol.Invocation.
+type Specialist struct {
+	id     string
+	limits Limits
+}
+
+// NewSpecialist closes the candidate-visible solver identity and bounds.
+func NewSpecialist(id string, limits Limits) (Specialist, error) {
+	if !validIdentity(id) {
+		return Specialist{}, errors.New("Bellman-Ford specialist identity is invalid")
+	}
+	if err := limits.Validate(); err != nil {
+		return Specialist{}, err
+	}
+	return Specialist{id: id, limits: limits}, nil
+}
+
+// Invoke implements specialistcontrol.Specialist.
+func (specialist Specialist) Invoke(
+	ctx context.Context,
+	invocation specialistcontrol.Invocation,
+) (specialistcontrol.SpecialistResult, error) {
+	refused := specialistcontrol.SpecialistResult{
+		Binding: invocation.Binding, SpecialistID: specialist.id, State: specialistcontrol.ResultRefused,
+	}
+	if ctx == nil {
+		return refused, errors.New("invoke Bellman-Ford specialist: nil context")
+	}
+	if err := ctx.Err(); err != nil {
+		return refused, err
+	}
+	if invocation.Task != specialistcontrol.TaskBellmanFord || invocation.Binding == (specialistcontrol.Binding{}) ||
+		invocation.MaxResultBytes <= 0 {
+		return refused, nil
+	}
+	answer, err := Solve(ctx, invocation.Payload, specialist.limits)
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return refused, err
+		}
+		if errors.Is(err, ErrInvalidLimits) || errors.Is(err, ErrMalformedPrompt) ||
+			errors.Is(err, ErrPromptLimit) || errors.Is(err, ErrAnswerLimit) {
+			return refused, nil
+		}
+		return refused, fmt.Errorf("solve Bellman-Ford invocation: %w", err)
+	}
+	if len(answer) > invocation.MaxResultBytes {
+		return refused, nil
+	}
+	return specialistcontrol.SpecialistResult{
+		Binding:      invocation.Binding,
+		SpecialistID: specialist.id,
+		State:        specialistcontrol.ResultCompleted,
+		Payload:      answer,
+	}, nil
+}
+
+// VerifierLimits bound the separately held reference index. They are safety
+// caps, not fixture counts or an experiment sampling decision.
+type VerifierLimits struct {
+	MaxReferences     int
+	MaxReferenceBytes int64
+}
+
+// Validate rejects an open or impractically large verifier index.
+func (limits VerifierLimits) Validate() error {
+	if limits.MaxReferences <= 0 || limits.MaxReferences > maximumReferencesCeiling ||
+		limits.MaxReferenceBytes <= 0 || limits.MaxReferenceBytes > maximumReferenceSetBytesCeiling {
+		return ErrReferenceLimit
+	}
+	return nil
+}
+
+type referenceKey struct {
+	runID     string
+	requestID string
+}
+
+type heldReference struct {
+	source             clrsfixture.SourceID
+	contract           clrsfixture.ContractID
+	candidateID        clrsfixture.CandidateID
+	verifierID         clrsfixture.VerifierID
+	promptSHA256       [sha256.Size]byte
+	effectiveInputSize int64
+	answer             []byte
+}
+
+type boundCandidate struct {
+	id     clrsfixture.CandidateID
+	prompt []byte
+}
+
+// RequestSet is the candidate-only projection of one validated Bellman-Ford
+// dataset run. It cannot be constructed from a raw prompt or held answer.
+type RequestSet struct {
+	runID      string
+	candidates []boundCandidate
+}
+
+// Verifier independently exact-scores against separately held references.
+type Verifier struct {
+	specialistID string
+	limits       Limits
+	references   map[referenceKey]heldReference
+}
+
+// BindDataset validates the exact contract-selected Bellman-Ford candidate
+// and verifier sets, then returns separate candidate-only and held-reference
+// views. Every value remains NO_RESULT.
+func BindDataset(
+	runID string,
+	specialistID string,
+	source clrsfixture.SourceRecord,
+	contract clrsfixture.GenerationContract,
+	candidates clrsfixture.CandidateSet,
+	verifiers clrsfixture.VerifierSet,
+	limits Limits,
+	verifierLimits VerifierLimits,
+) (RequestSet, Verifier, error) {
+	if !validIdentity(runID) || !validIdentity(specialistID) {
+		return RequestSet{}, Verifier{}, errors.New("Bellman-Ford run or specialist identity is invalid")
+	}
+	if err := limits.Validate(); err != nil {
+		return RequestSet{}, Verifier{}, err
+	}
+	if err := verifierLimits.Validate(); err != nil {
+		return RequestSet{}, Verifier{}, err
+	}
+	if err := PinnedSourceEvidence().ValidateSource(source); err != nil {
+		return RequestSet{}, Verifier{}, err
+	}
+	task, err := bellmanFordTaskPlan(source, contract)
+	if err != nil {
+		return RequestSet{}, Verifier{}, err
+	}
+	pairs, err := clrsfixture.PairExamples(
+		source,
+		contract,
+		task.OutputRelativePath,
+		candidates,
+		verifiers,
+	)
+	if err != nil {
+		return RequestSet{}, Verifier{}, fmt.Errorf("pair Bellman-Ford dataset: %w", err)
+	}
+	if len(pairs) == 0 || len(pairs) > verifierLimits.MaxReferences {
+		return RequestSet{}, Verifier{}, fmt.Errorf("%w: reference count is %d", ErrReferenceLimit, len(pairs))
+	}
+
+	requestSet := RequestSet{runID: runID, candidates: make([]boundCandidate, 0, len(pairs))}
+	validated := make(map[referenceKey]heldReference, len(pairs))
+	var retainedBytes int64
+	for index, pair := range pairs {
+		candidate, held, bindErr := bindPair(pair, limits)
+		if bindErr != nil {
+			return RequestSet{}, Verifier{}, fmt.Errorf("bind Bellman-Ford pair %d: %w", index, bindErr)
+		}
+		requestID := candidate.id.String()
+		retainedBytes += int64(len(runID)+len(requestID)+len(held.answer)) + heldIdentityBytes
+		if retainedBytes > verifierLimits.MaxReferenceBytes {
+			return RequestSet{}, Verifier{}, fmt.Errorf("%w: retained bytes exceed %d", ErrReferenceLimit, verifierLimits.MaxReferenceBytes)
+		}
+		key := referenceKey{runID: runID, requestID: requestID}
+		if _, duplicate := validated[key]; duplicate {
+			return RequestSet{}, Verifier{}, fmt.Errorf("duplicate Bellman-Ford reference %s/%s", key.runID, key.requestID)
+		}
+		requestSet.candidates = append(requestSet.candidates, candidate)
+		validated[key] = held
+	}
+	return requestSet, Verifier{specialistID: specialistID, limits: limits, references: validated}, nil
+}
+
+// Requests returns fresh candidate-only controller packets for one closed run
+// window. RequestID is the source-and-contract-bound CandidateID.
+func (set RequestSet) Requests(issuedAt, deadline time.Time) ([]specialistcontrol.Request, error) {
+	if !validIdentity(set.runID) || len(set.candidates) == 0 {
+		return nil, errors.New("Bellman-Ford request set is unbound")
+	}
+	if issuedAt.IsZero() || deadline.IsZero() || !deadline.After(issuedAt) {
+		return nil, errors.New("Bellman-Ford request window is invalid")
+	}
+	requests := make([]specialistcontrol.Request, 0, len(set.candidates))
+	for _, candidate := range set.candidates {
+		requestID := candidate.id.String()
+		if !validIdentity(requestID) || len(candidate.prompt) == 0 {
+			return nil, errors.New("Bellman-Ford bound candidate is invalid")
+		}
+		requests = append(requests, specialistcontrol.Request{
+			RunID:     set.runID,
+			RequestID: requestID,
+			Task:      specialistcontrol.TaskBellmanFord,
+			Payload:   append([]byte(nil), candidate.prompt...),
+			IssuedAt:  issuedAt,
+			Deadline:  deadline,
+		})
+	}
+	return requests, nil
+}
+
+// Verify implements specialistcontrol.ExactVerifier.
+func (verifier Verifier) Verify(
+	ctx context.Context,
+	invocation specialistcontrol.Invocation,
+	candidate specialistcontrol.Candidate,
+) (specialistcontrol.Verification, error) {
+	verification := specialistcontrol.Verification{
+		Binding: candidate.Binding, CandidateBinding: candidate.CandidateBinding,
+		Verdict: specialistcontrol.VerificationAbstain,
+	}
+	if ctx == nil {
+		return verification, errors.New("verify Bellman-Ford candidate: nil context")
+	}
+	if err := ctx.Err(); err != nil {
+		return verification, err
+	}
+	if invocation.Task != specialistcontrol.TaskBellmanFord || invocation.Binding != candidate.Binding ||
+		candidate.Binding == (specialistcontrol.Binding{}) ||
+		candidate.CandidateBinding == (specialistcontrol.CandidateBinding{}) ||
+		candidate.SpecialistID != verifier.specialistID || candidate.State != specialistcontrol.ResultCompleted {
+		return verification, errors.New("verify Bellman-Ford candidate: invalid invocation binding")
+	}
+	held, present := verifier.references[referenceKey{runID: invocation.RunID, requestID: invocation.RequestID}]
+	if !present || held.candidateID.String() != invocation.RequestID ||
+		held.promptSHA256 != sha256.Sum256(invocation.Payload) {
+		return verification, errors.New("verify Bellman-Ford candidate: no exact prompt-bound reference")
+	}
+	input, err := parsePrompt(ctx, invocation.Payload, verifier.limits)
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return verification, err
+		}
+		return verification, errors.New("verify Bellman-Ford candidate: prompt semantics differ from the held candidate")
+	}
+	if int64(len(input.weights)) != held.effectiveInputSize {
+		return verification, errors.New("verify Bellman-Ford candidate: prompt semantics differ from the held candidate")
+	}
+	if len(candidate.Payload) == 0 || len(candidate.Payload) > verifier.limits.MaxAnswerBytes {
+		return verification, errors.New("verify Bellman-Ford candidate: answer crosses verifier bounds")
+	}
+	if bytes.Equal(candidate.Payload, held.answer) {
+		verification.Verdict = specialistcontrol.VerificationExact
+	} else {
+		verification.Verdict = specialistcontrol.VerificationMismatch
+	}
+	return verification, nil
+}
+
+func bellmanFordTaskPlan(
+	source clrsfixture.SourceRecord,
+	contract clrsfixture.GenerationContract,
+) (clrsfixture.TaskPlan, error) {
+	plan, err := contract.Plan(source)
+	if err != nil {
+		return clrsfixture.TaskPlan{}, fmt.Errorf("plan Bellman-Ford dataset: %w", err)
+	}
+	for _, task := range plan.Tasks {
+		if task.Task == clrsfixture.TaskBellmanFord {
+			return task, nil
+		}
+	}
+	return clrsfixture.TaskPlan{}, errors.New("generation contract has no Bellman-Ford task")
+}
+
+func bindPair(pair clrsfixture.PairedExample, limits Limits) (boundCandidate, heldReference, error) {
+	candidate := pair.Candidate
+	verifier := pair.Verifier
+	if candidate.Task != clrsfixture.TaskBellmanFord ||
+		candidate.LengthSemantics != clrsfixture.LengthDeclaredInput || candidate.UseHints ||
+		candidate.RequestedLength != candidate.EffectiveInputSize ||
+		verifier.CandidateID != candidate.ID {
+		return boundCandidate{}, heldReference{}, errors.New("pair differs from Bellman-Ford no-hint length semantics")
+	}
+	if candidate.EffectiveInputSize <= 0 || candidate.EffectiveInputSize > int64(limits.MaxNodes) {
+		return boundCandidate{}, heldReference{}, fmt.Errorf(
+			"%w: effective input size %d exceeds 1..%d",
+			ErrPromptLimit,
+			candidate.EffectiveInputSize,
+			limits.MaxNodes,
+		)
+	}
+	prompt := []byte(candidate.Prompt)
+	input, err := parsePrompt(context.Background(), prompt, limits)
+	if err != nil {
+		return boundCandidate{}, heldReference{}, fmt.Errorf("validate candidate prompt: %w", err)
+	}
+	if int64(len(input.weights)) != candidate.EffectiveInputSize {
+		return boundCandidate{}, heldReference{}, fmt.Errorf(
+			"prompt node count = %d, want effective input size %d",
+			len(input.weights), candidate.EffectiveInputSize,
+		)
+	}
+	answer := []byte(verifier.Reference)
+	if err := validateReference(context.Background(), answer, limits, input); err != nil {
+		return boundCandidate{}, heldReference{}, err
+	}
+	return boundCandidate{id: candidate.ID, prompt: append([]byte(nil), prompt...)}, heldReference{
+		source:             candidate.Source,
+		contract:           candidate.Contract,
+		candidateID:        candidate.ID,
+		verifierID:         verifier.ID,
+		promptSHA256:       sha256.Sum256(prompt),
+		effectiveInputSize: candidate.EffectiveInputSize,
+		answer:             append([]byte(nil), answer...),
+	}, nil
+}
+
+func validIdentity(value string) bool {
+	if len(value) == 0 || len(value) > maximumIdentityBytes {
+		return false
+	}
+	for index := range len(value) {
+		character := value[index]
+		if (character < 'a' || character > 'z') && (character < 'A' || character > 'Z') &&
+			(character < '0' || character > '9') && character != '.' && character != '_' &&
+			character != ':' && character != '-' {
+			return false
+		}
+	}
+	return true
+}

--- a/tooling/internal/clrsbellmanford/adapter_test.go
+++ b/tooling/internal/clrsbellmanford/adapter_test.go
@@ -1,0 +1,844 @@
+package clrsbellmanford
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lusoris/20-watts-was-enough/tooling/internal/clrsfixture"
+	"github.com/lusoris/20-watts-was-enough/tooling/internal/specialistcontrol"
+)
+
+const (
+	testRunID        = "run-001"
+	testSpecialistID = "exact-bellman-ford-v1"
+)
+
+var verticalNow = time.Date(2026, time.August, 31, 12, 0, 0, 0, time.UTC)
+
+type recorderFunc func(context.Context, specialistcontrol.Decision) error
+
+func (function recorderFunc) RecordDecision(ctx context.Context, decision specialistcontrol.Decision) error {
+	return function(ctx, decision)
+}
+
+type specialistFunc func(context.Context, specialistcontrol.Invocation) (specialistcontrol.SpecialistResult, error)
+
+func (function specialistFunc) Invoke(ctx context.Context, invocation specialistcontrol.Invocation) (specialistcontrol.SpecialistResult, error) {
+	return function(ctx, invocation)
+}
+
+type verifierFunc func(context.Context, specialistcontrol.Invocation, specialistcontrol.Candidate) (specialistcontrol.Verification, error)
+
+func (function verifierFunc) Verify(ctx context.Context, invocation specialistcontrol.Invocation, candidate specialistcontrol.Candidate) (specialistcontrol.Verification, error) {
+	return function(ctx, invocation, candidate)
+}
+
+func TestBindDatasetBuildsContractBoundRequestsAndIsolatesReferences(t *testing.T) {
+	t.Parallel()
+	fixture := newImportFixture(t, clrsfixture.TaskBellmanFord)
+	reorderedVerifiers := cloneVerifierSet(fixture.verifiers)
+	for left, right := 0, len(reorderedVerifiers.Examples)-1; left < right; left, right = left+1, right-1 {
+		reorderedVerifiers.Examples[left], reorderedVerifiers.Examples[right] =
+			reorderedVerifiers.Examples[right], reorderedVerifiers.Examples[left]
+	}
+	requestSet, verifier, err := BindDataset(
+		testRunID,
+		testSpecialistID,
+		fixture.source,
+		fixture.contract,
+		fixture.candidates,
+		reorderedVerifiers,
+		testLimits(),
+		testVerifierLimits(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requests, err := requestSet.Requests(verticalNow.Add(-time.Second), verticalNow.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(requests) != fixture.task.ExpectedExamples {
+		t.Fatalf("request count = %d, want %d", len(requests), fixture.task.ExpectedExamples)
+	}
+	for index, request := range requests {
+		candidate := fixture.candidates.Examples[index]
+		if request.RunID != testRunID || request.RequestID != candidate.ID.String() ||
+			request.Task != specialistcontrol.TaskBellmanFord ||
+			!bytes.Equal(request.Payload, []byte(candidate.Prompt)) {
+			t.Fatalf("request %d = %#v, candidate %#v", index, request, candidate)
+		}
+		key := referenceKey{runID: testRunID, requestID: request.RequestID}
+		held, present := verifier.references[key]
+		expectedVerifier := fixture.verifiers.Examples[index]
+		if !present || held.source != candidate.Source || held.contract != candidate.Contract ||
+			held.candidateID != candidate.ID || held.verifierID != expectedVerifier.ID ||
+			held.effectiveInputSize != candidate.EffectiveInputSize ||
+			!bytes.Equal(held.answer, []byte(expectedVerifier.Reference)) {
+			t.Fatalf("held reference %d = %#v", index, held)
+		}
+	}
+	for _, candidateType := range []reflect.Type{
+		reflect.TypeOf(RequestSet{}),
+		reflect.TypeOf(boundCandidate{}),
+		reflect.TypeOf(specialistcontrol.Invocation{}),
+	} {
+		for index := 0; index < candidateType.NumField(); index++ {
+			name := strings.ToLower(candidateType.Field(index).Name)
+			if strings.Contains(name, "answer") || strings.Contains(name, "reference") {
+				t.Fatalf("candidate-visible type %s exposes verifier field %q", candidateType, name)
+			}
+		}
+	}
+}
+
+func TestSpecialistMatchesEveryContractBoundSyntheticCell(t *testing.T) {
+	t.Parallel()
+	fixture := newImportFixture(t, clrsfixture.TaskBellmanFord)
+	requestSet, _ := bindFixture(t, fixture, testLimits(), testVerifierLimits())
+	requests, err := requestSet.Requests(verticalNow.Add(-time.Second), verticalNow.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	specialist, err := NewSpecialist(testSpecialistID, testLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for index, request := range requests {
+		invocation, _ := verificationInputs(request, nil)
+		result, invokeErr := specialist.Invoke(context.Background(), invocation)
+		want := []byte(fixture.verifiers.Examples[index].Reference)
+		if invokeErr != nil || result.State != specialistcontrol.ResultCompleted ||
+			result.SpecialistID != testSpecialistID || result.Binding != invocation.Binding ||
+			!bytes.Equal(result.Payload, want) {
+			t.Fatalf("cell %d result/error = %#v/%v, want %q", index, result, invokeErr, want)
+		}
+	}
+}
+
+func TestBindDatasetRejectsForeignAndTamperedContractRecords(t *testing.T) {
+	t.Parallel()
+	bellman := newImportFixture(t, clrsfixture.TaskBellmanFord)
+	insertion := newImportFixture(t, clrsfixture.TaskInsertionSort)
+	if _, _, err := BindDataset(
+		testRunID,
+		testSpecialistID,
+		insertion.source,
+		insertion.contract,
+		insertion.candidates,
+		insertion.verifiers,
+		testLimits(),
+		testVerifierLimits(),
+	); err == nil {
+		t.Fatal("BindDataset accepted a valid foreign task set")
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*clrsfixture.CandidateSet, *clrsfixture.VerifierSet)
+	}{
+		{"candidate identity", func(c *clrsfixture.CandidateSet, _ *clrsfixture.VerifierSet) { c.Examples[0].ID[0] ^= 1 }},
+		{"candidate prompt", func(c *clrsfixture.CandidateSet, _ *clrsfixture.VerifierSet) { c.Examples[0].Prompt += " mutation" }},
+		{"candidate task", func(c *clrsfixture.CandidateSet, _ *clrsfixture.VerifierSet) {
+			c.Examples[0].Task = clrsfixture.TaskInsertionSort
+		}},
+		{"candidate effective size", func(c *clrsfixture.CandidateSet, _ *clrsfixture.VerifierSet) { c.Examples[0].EffectiveInputSize++ }},
+		{"candidate hints", func(c *clrsfixture.CandidateSet, _ *clrsfixture.VerifierSet) { c.Examples[0].UseHints = true }},
+		{"verifier identity", func(_ *clrsfixture.CandidateSet, v *clrsfixture.VerifierSet) { v.Examples[0].ID[0] ^= 1 }},
+		{"verifier answer", func(_ *clrsfixture.CandidateSet, v *clrsfixture.VerifierSet) { v.Examples[0].Reference += " mutation" }},
+		{"missing candidate", func(c *clrsfixture.CandidateSet, _ *clrsfixture.VerifierSet) { c.Examples = c.Examples[1:] }},
+		{"missing verifier", func(_ *clrsfixture.CandidateSet, v *clrsfixture.VerifierSet) { v.Examples = v.Examples[1:] }},
+		{"reordered candidates", func(c *clrsfixture.CandidateSet, _ *clrsfixture.VerifierSet) {
+			c.Examples[0], c.Examples[1] = c.Examples[1], c.Examples[0]
+		}},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			candidates := cloneCandidateSet(bellman.candidates)
+			verifiers := cloneVerifierSet(bellman.verifiers)
+			test.mutate(&candidates, &verifiers)
+			if _, _, err := BindDataset(
+				testRunID,
+				testSpecialistID,
+				bellman.source,
+				bellman.contract,
+				candidates,
+				verifiers,
+				testLimits(),
+				testVerifierLimits(),
+			); err == nil {
+				t.Fatalf("BindDataset accepted %s", test.name)
+			}
+		})
+	}
+
+	foreignSource := bellman.source
+	foreignSource.Commit = "a" + foreignSource.Commit[1:]
+	if _, _, err := BindDataset(
+		testRunID, testSpecialistID, foreignSource, bellman.contract,
+		bellman.candidates, bellman.verifiers, testLimits(), testVerifierLimits(),
+	); err == nil {
+		t.Fatal("BindDataset accepted a source record outside the pinned Bellman-Ford evidence")
+	}
+	foreignContract := bellman.contract
+	foreignContract.Seeds = append([]int64(nil), bellman.contract.Seeds...)
+	foreignContract.Seeds[0]++
+	if _, _, err := BindDataset(
+		testRunID, testSpecialistID, bellman.source, foreignContract,
+		bellman.candidates, bellman.verifiers, testLimits(), testVerifierLimits(),
+	); err == nil {
+		t.Fatal("BindDataset accepted a mutated generation contract")
+	}
+}
+
+func TestBindDatasetRejectsPromptSemanticsMissingFromTheGenericImporter(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		mutate func(*testExample)
+	}{
+		{"effective input size mismatch", func(example *testExample) {
+			example.prompt, example.reference = bellmanExample(3, example.seed)
+		}},
+		{"hint-bearing prompt", func(example *testExample) { example.prompt += "hint:\n" }},
+		{"wrong input marker", func(example *testExample) {
+			example.prompt = strings.Replace(example.prompt, "\ns: ", "\nsource: ", 1)
+		}},
+		{"wrong output marker", func(example *testExample) {
+			example.prompt = strings.Replace(example.prompt, "\npi:\n", "\nd:\n", 1)
+		}},
+		{"asymmetric graph", func(example *testExample) {
+			example.prompt = strings.Replace(example.prompt, "A: [[0.0 0.4", "A: [[0.0 0.5", 1)
+		}},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			fixture := newImportFixture(t, clrsfixture.TaskBellmanFord)
+			test.mutate(&fixture.dataset.examples[0])
+			fixture.importDataset(t)
+			if _, _, err := BindDataset(
+				testRunID, testSpecialistID, fixture.source, fixture.contract,
+				fixture.candidates, fixture.verifiers, testLimits(), testVerifierLimits(),
+			); err == nil {
+				t.Fatalf("BindDataset accepted %s", test.name)
+			}
+		})
+	}
+}
+
+func TestBindDatasetRejectsSemanticallyWrongHeldAnswers(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		mutate func(*testExample)
+	}{
+		{"wrong shape", func(example *testExample) { example.reference = "1\n\n" }},
+		{"leading zero", func(example *testExample) { example.reference = "[01 2 3 3 3 4 5 6 7 8]\n\n" }},
+		{"out of range", func(example *testExample) { example.reference = "[99 2 3 3 3 4 5 6 7 8]\n\n" }},
+		{"foreign syntax", func(example *testExample) { example.reference = "[[1 2 3 3 3 4 5 6 7 8]]\n\n" }},
+		{"changed source", func(example *testExample) { example.reference = "[1 2 3 2 3 4 5 6 7 8]\n\n" }},
+		{"broken path", func(example *testExample) { example.reference = "[0 2 3 3 3 4 5 6 7 8]\n\n" }},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			fixture := newImportFixture(t, clrsfixture.TaskBellmanFord)
+			test.mutate(&fixture.dataset.examples[0])
+			fixture.importDataset(t)
+			if _, _, err := BindDataset(
+				testRunID, testSpecialistID, fixture.source, fixture.contract,
+				fixture.candidates, fixture.verifiers, testLimits(), testVerifierLimits(),
+			); err == nil {
+				t.Fatalf("BindDataset accepted %s held answer", test.name)
+			}
+		})
+	}
+}
+
+func TestRequestSetAndVerifierSnapshotTheirSeparateInputs(t *testing.T) {
+	t.Parallel()
+	fixture := newImportFixture(t, clrsfixture.TaskBellmanFord)
+	originalPrompt := fixture.candidates.Examples[0].Prompt
+	originalAnswer := fixture.verifiers.Examples[0].Reference
+	requestSet, verifier := bindFixture(t, fixture, testLimits(), testVerifierLimits())
+	fixture.candidates.Examples[0].Prompt = "mutated"
+	fixture.verifiers.Examples[0].Reference = "mutated"
+
+	requests, err := requestSet.Requests(verticalNow.Add(-time.Second), verticalNow.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	requests[0].Payload[0] = 'X'
+	fresh, err := requestSet.Requests(verticalNow.Add(-time.Second), verticalNow.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(fresh[0].Payload) != originalPrompt {
+		t.Fatalf("fresh request payload = %q, want original prompt", fresh[0].Payload)
+	}
+	invocation, candidate := verificationInputs(fresh[0], []byte(originalAnswer))
+	verification, err := verifier.Verify(context.Background(), invocation, candidate)
+	if err != nil || verification.Verdict != specialistcontrol.VerificationExact {
+		t.Fatalf("Verify(snapshot) = %#v, error %v", verification, err)
+	}
+
+	for name, window := range map[string][2]time.Time{
+		"zero issued":   {{}, verticalNow},
+		"zero deadline": {verticalNow, {}},
+		"equal":         {verticalNow, verticalNow},
+		"reverse":       {verticalNow, verticalNow.Add(-time.Second)},
+	} {
+		if _, err := requestSet.Requests(window[0], window[1]); err == nil {
+			t.Fatalf("Requests accepted %s window", name)
+		}
+	}
+	if _, err := (RequestSet{}).Requests(verticalNow, verticalNow.Add(time.Second)); err == nil {
+		t.Fatal("zero RequestSet produced requests")
+	}
+}
+
+func TestVerifierRejectsRunCandidateAndPromptSubstitution(t *testing.T) {
+	t.Parallel()
+	fixture := newImportFixture(t, clrsfixture.TaskBellmanFord)
+	requestSet, verifier := bindFixture(t, fixture, testLimits(), testVerifierLimits())
+	requests, err := requestSet.Requests(verticalNow.Add(-time.Second), verticalNow.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	answer := []byte(fixture.verifiers.Examples[0].Reference)
+	invocation, candidate := verificationInputs(requests[0], answer)
+	if verification, err := verifier.Verify(context.Background(), invocation, candidate); err != nil ||
+		verification.Verdict != specialistcontrol.VerificationExact {
+		t.Fatalf("baseline verification = %#v, error %v", verification, err)
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*specialistcontrol.Invocation)
+	}{
+		{"run", func(value *specialistcontrol.Invocation) { value.RunID = "run-foreign" }},
+		{"candidate identity", func(value *specialistcontrol.Invocation) { value.RequestID = requests[3].RequestID }},
+		{"prompt", func(value *specialistcontrol.Invocation) { value.Payload[0] = 'X' }},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			changed := invocation
+			changed.Payload = append([]byte(nil), invocation.Payload...)
+			test.mutate(&changed)
+			if _, err := verifier.Verify(context.Background(), changed, candidate); err == nil {
+				t.Fatalf("Verify accepted %s substitution", test.name)
+			}
+		})
+	}
+	cancelled := &cancelAfterChecksContext{Context: context.Background(), cancelAt: 3}
+	if _, err := verifier.Verify(cancelled, invocation, candidate); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Verify(mid-parse cancellation) error = %v, want context.Canceled", err)
+	}
+}
+
+func TestBindDatasetClosesRunAndReferenceBounds(t *testing.T) {
+	t.Parallel()
+	fixture := newImportFixture(t, clrsfixture.TaskBellmanFord)
+	tests := []struct {
+		name             string
+		runID            string
+		specialistID     string
+		limits           Limits
+		verifierLimits   VerifierLimits
+		wantReferenceErr bool
+	}{
+		{"empty run", "", testSpecialistID, testLimits(), testVerifierLimits(), false},
+		{"bad specialist", testRunID, "bad specialist", testLimits(), testVerifierLimits(), false},
+		{"open reference count", testRunID, testSpecialistID, testLimits(), VerifierLimits{MaxReferenceBytes: 1024}, true},
+		{"small reference count", testRunID, testSpecialistID, testLimits(), VerifierLimits{MaxReferences: 8, MaxReferenceBytes: 16 << 10}, true},
+		{"small reference bytes", testRunID, testSpecialistID, testLimits(), VerifierLimits{MaxReferences: 16, MaxReferenceBytes: 1}, true},
+		{"small node count", testRunID, testSpecialistID, withLimits(func(value *Limits) { value.MaxNodes = 8 }), testVerifierLimits(), false},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			_, _, err := BindDataset(
+				test.runID, test.specialistID, fixture.source, fixture.contract,
+				fixture.candidates, fixture.verifiers, test.limits, test.verifierLimits,
+			)
+			if err == nil {
+				t.Fatalf("BindDataset accepted %s", test.name)
+			}
+			if test.wantReferenceErr && !errors.Is(err, ErrReferenceLimit) {
+				t.Fatalf("BindDataset(%s) error = %v, want ErrReferenceLimit", test.name, err)
+			}
+		})
+	}
+}
+
+func TestBellmanFordVerticalRecordsBeforeEffectAndKeepsReferenceOutOfSpecialist(t *testing.T) {
+	t.Parallel()
+	runner, events, request, reference := verticalRunner(t, nil)
+	run, err := runner.Run(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.Decision.State != specialistcontrol.DecisionInvoke ||
+		run.Outcome.State != specialistcontrol.OutcomeVerified ||
+		run.Outcome.Authority != specialistcontrol.ResultAuthority ||
+		!bytes.Equal(run.Outcome.Payload, reference) {
+		t.Fatalf("vertical outcome = %#v", run)
+	}
+	if !reflect.DeepEqual(*events, []string{"record", "invoke", "verify"}) {
+		t.Fatalf("effect order = %v, want record/invoke/verify", *events)
+	}
+}
+
+func TestBellmanFordVerticalRefusesMalformedAndOversizedInputBeforeVerification(t *testing.T) {
+	t.Parallel()
+	fixture := newImportFixture(t, clrsfixture.TaskBellmanFord)
+	requestSet, verifier := bindFixture(t, fixture, testLimits(), testVerifierLimits())
+	requests, err := requestSet.Requests(verticalNow.Add(-time.Second), verticalNow.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, prompt := range map[string][]byte{
+		"malformed": []byte("bellman_ford:\nsource: 0, A: [[0.0 0.1], [0.1 0.0]]\npi:\n"),
+		"oversized": []byte("bellman_ford:\ns: 0, A: [[0.0 0.1 0.0 0.0], [0.1 0.0 0.1 0.0], [0.0 0.1 0.0 0.1], [0.0 0.0 0.1 0.0]]\npi:\n"),
+	} {
+		name, prompt := name, prompt
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			limits := testLimits()
+			limits.MaxNodes = 3
+			specialist, err := NewSpecialist(testSpecialistID, limits)
+			if err != nil {
+				t.Fatal(err)
+			}
+			verifierCalled := false
+			observedVerifier := verifierFunc(func(ctx context.Context, invocation specialistcontrol.Invocation, candidate specialistcontrol.Candidate) (specialistcontrol.Verification, error) {
+				verifierCalled = true
+				return verifier.Verify(ctx, invocation, candidate)
+			})
+			runner := newVerticalRunner(
+				t, specialist,
+				recorderFunc(func(context.Context, specialistcontrol.Decision) error { return nil }),
+				observedVerifier, func() time.Time { return verticalNow },
+			)
+			request := requests[0]
+			request.Payload = prompt
+			run, runErr := runner.Run(context.Background(), request)
+			if runErr != nil || verifierCalled || run.Outcome.State != specialistcontrol.OutcomeRefused ||
+				run.Outcome.Reason != specialistcontrol.ReasonSpecialistRefused ||
+				run.Outcome.Authority != specialistcontrol.ResultAuthority {
+				t.Fatalf("Run(%s) error/verifier/outcome = %v/%t/%#v", name, runErr, verifierCalled, run.Outcome)
+			}
+		})
+	}
+}
+
+func TestBellmanFordVerticalTypesCancellationAndDeadlineAsNoResult(t *testing.T) {
+	t.Parallel()
+	t.Run("cancelled", func(t *testing.T) {
+		t.Parallel()
+		runner, _, request, _ := verticalRunner(t, nil)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		run, err := runner.Run(ctx, request)
+		if !errors.Is(err, context.Canceled) || run.Outcome.State != specialistcontrol.OutcomeAbstained ||
+			run.Outcome.Reason != specialistcontrol.ReasonCancelled ||
+			run.Outcome.Authority != specialistcontrol.ResultAuthority {
+			t.Fatalf("cancelled outcome/error = %#v/%v", run.Outcome, err)
+		}
+	})
+
+	t.Run("deadline", func(t *testing.T) {
+		t.Parallel()
+		fixture := newImportFixture(t, clrsfixture.TaskBellmanFord)
+		requestSet, verifier := bindFixture(t, fixture, testLimits(), testVerifierLimits())
+		requests, err := requestSet.Requests(verticalNow.Add(-time.Second), verticalNow.Add(time.Second))
+		if err != nil {
+			t.Fatal(err)
+		}
+		specialist, err := NewSpecialist(testSpecialistID, testLimits())
+		if err != nil {
+			t.Fatal(err)
+		}
+		calls := 0
+		clock := func() time.Time {
+			calls++
+			if calls == 2 {
+				return requests[0].Deadline
+			}
+			return verticalNow
+		}
+		invoked := false
+		runner := newVerticalRunner(
+			t,
+			specialistFunc(func(ctx context.Context, invocation specialistcontrol.Invocation) (specialistcontrol.SpecialistResult, error) {
+				invoked = true
+				return specialist.Invoke(ctx, invocation)
+			}),
+			recorderFunc(func(context.Context, specialistcontrol.Decision) error { return nil }),
+			verifier, clock,
+		)
+		run, runErr := runner.Run(context.Background(), requests[0])
+		if runErr != nil || invoked || run.Outcome.State != specialistcontrol.OutcomeAbstained ||
+			run.Outcome.Reason != specialistcontrol.ReasonDeadlineElapsed ||
+			run.Outcome.Authority != specialistcontrol.ResultAuthority {
+			t.Fatalf("deadline outcome/error/invoked = %#v/%v/%t", run.Outcome, runErr, invoked)
+		}
+	})
+}
+
+func TestBellmanFordVerticalAbstainsOnWrongAnswer(t *testing.T) {
+	t.Parallel()
+	fixture := newImportFixture(t, clrsfixture.TaskBellmanFord)
+	requestSet, verifier := bindFixture(t, fixture, testLimits(), testVerifierLimits())
+	requests, err := requestSet.Requests(verticalNow.Add(-time.Second), verticalNow.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrong := specialistFunc(func(_ context.Context, invocation specialistcontrol.Invocation) (specialistcontrol.SpecialistResult, error) {
+		return specialistcontrol.SpecialistResult{
+			Binding: invocation.Binding, SpecialistID: testSpecialistID,
+			State: specialistcontrol.ResultCompleted, Payload: []byte("99\n\n"),
+		}, nil
+	})
+	runner := newVerticalRunner(
+		t, wrong,
+		recorderFunc(func(context.Context, specialistcontrol.Decision) error { return nil }),
+		verifier, func() time.Time { return verticalNow },
+	)
+	run, runErr := runner.Run(context.Background(), requests[0])
+	if runErr != nil || run.Outcome.State != specialistcontrol.OutcomeAbstained ||
+		run.Outcome.Reason != specialistcontrol.ReasonVerificationMismatch ||
+		run.Outcome.Authority != specialistcontrol.ResultAuthority || len(run.Outcome.Payload) != 0 {
+		t.Fatalf("wrong-answer outcome/error = %#v/%v", run.Outcome, runErr)
+	}
+}
+
+func verticalRunner(
+	t *testing.T,
+	clock func() time.Time,
+) (specialistcontrol.Runner, *[]string, specialistcontrol.Request, []byte) {
+	t.Helper()
+	if clock == nil {
+		clock = func() time.Time { return verticalNow }
+	}
+	fixture := newImportFixture(t, clrsfixture.TaskBellmanFord)
+	requestSet, verifier := bindFixture(t, fixture, testLimits(), testVerifierLimits())
+	requests, err := requestSet.Requests(verticalNow.Add(-time.Second), verticalNow.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	reference := []byte(fixture.verifiers.Examples[0].Reference)
+	specialist, err := NewSpecialist(testSpecialistID, testLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	events := make([]string, 0, 3)
+	observedSpecialist := specialistFunc(func(ctx context.Context, invocation specialistcontrol.Invocation) (specialistcontrol.SpecialistResult, error) {
+		events = append(events, "invoke")
+		if bytes.Contains(invocation.Payload, reference) {
+			t.Fatal("verifier-only reference bytes leaked into the specialist request")
+		}
+		return specialist.Invoke(ctx, invocation)
+	})
+	observedVerifier := verifierFunc(func(ctx context.Context, invocation specialistcontrol.Invocation, candidate specialistcontrol.Candidate) (specialistcontrol.Verification, error) {
+		events = append(events, "verify")
+		return verifier.Verify(ctx, invocation, candidate)
+	})
+	runner := newVerticalRunner(
+		t, observedSpecialist,
+		recorderFunc(func(context.Context, specialistcontrol.Decision) error {
+			events = append(events, "record")
+			return nil
+		}),
+		observedVerifier, clock,
+	)
+	return runner, &events, requests[0], reference
+}
+
+func newVerticalRunner(
+	t *testing.T,
+	target specialistcontrol.Specialist,
+	recorder specialistcontrol.DecisionRecorder,
+	verifier specialistcontrol.ExactVerifier,
+	clock func() time.Time,
+) specialistcontrol.Runner {
+	t.Helper()
+	routes := make([]specialistcontrol.Route, 0, len(specialistcontrol.Tasks()))
+	specialists := make(map[string]specialistcontrol.Specialist, len(specialistcontrol.Tasks()))
+	for _, task := range specialistcontrol.Tasks() {
+		id := "unavailable-" + string(task)
+		if task == specialistcontrol.TaskBellmanFord {
+			id = testSpecialistID
+			specialists[id] = target
+		} else {
+			specialists[id] = specialistFunc(func(_ context.Context, invocation specialistcontrol.Invocation) (specialistcontrol.SpecialistResult, error) {
+				return specialistcontrol.SpecialistResult{
+					Binding: invocation.Binding, SpecialistID: "unavailable-" + string(invocation.Task),
+					State: specialistcontrol.ResultAbstained,
+				}, nil
+			})
+		}
+		routes = append(routes, specialistcontrol.Route{Task: task, SpecialistID: id})
+	}
+	policy, err := specialistcontrol.NewPolicy(specialistcontrol.Limits{
+		MaxRequestBytes: 64 << 10,
+		MaxResultBytes:  8 << 10,
+		MaxRequestAge:   2 * time.Second,
+		MaxExecution:    2 * time.Second,
+	}, routes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner, err := specialistcontrol.NewRunner(policy, recorder, specialists, verifier, clock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return runner
+}
+
+type testExample struct {
+	prompt    string
+	reference string
+	length    int64
+	seed      int64
+	useHints  bool
+}
+
+type testDataset struct {
+	name     string
+	examples []testExample
+}
+
+type importFixture struct {
+	source     clrsfixture.SourceRecord
+	contract   clrsfixture.GenerationContract
+	task       clrsfixture.TaskPlan
+	dataset    testDataset
+	candidates clrsfixture.CandidateSet
+	verifiers  clrsfixture.VerifierSet
+}
+
+func newImportFixture(t *testing.T, task clrsfixture.TaskKind) importFixture {
+	t.Helper()
+	sourceBody := readGeneratorFile(t, "upstream.json")
+	source, err := clrsfixture.ParseSourceRecord(sourceBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	contractBody := readGeneratorFile(t, "contract.json")
+	contract, err := clrsfixture.ParseGenerationContract(contractBody, source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := contract.Plan(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var selected clrsfixture.TaskPlan
+	for _, candidate := range plan.Tasks {
+		if candidate.Task == task {
+			selected = candidate
+			break
+		}
+	}
+	if selected.Task == "" {
+		t.Fatalf("task %s is absent from tracked contract", task)
+	}
+	fixture := importFixture{
+		source: source, contract: contract, task: selected,
+		dataset: makeTestDataset(plan, selected),
+	}
+	fixture.importDataset(t)
+	return fixture
+}
+
+func (fixture *importFixture) importDataset(t *testing.T) {
+	t.Helper()
+	body, err := json.Marshal(fixture.dataset.jsonValue())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixture.candidates, fixture.verifiers, err = clrsfixture.ImportDataset(
+		bytes.NewReader(body),
+		fixture.source,
+		fixture.contract,
+		fixture.task.OutputRelativePath,
+		testImportLimits(),
+	)
+	if err != nil {
+		t.Fatalf("import synthetic contract-bound %s dataset: %v", fixture.task.Task, err)
+	}
+}
+
+func makeTestDataset(plan clrsfixture.GenerationPlan, task clrsfixture.TaskPlan) testDataset {
+	dataset := testDataset{name: "clrs_text_" + string(task.Task)}
+	for _, size := range task.Sizes {
+		for _, seed := range plan.Seeds {
+			for sample := 0; sample < plan.SamplesPerCell; sample++ {
+				prompt := fmt.Sprintf("%s:\ninput: %d/%d/%d", task.Task, size.RequestedLength, seed, sample)
+				reference := fmt.Sprintf("reference-%d-%d-%d", size.RequestedLength, seed, sample)
+				if task.Task == clrsfixture.TaskBellmanFord {
+					prompt, reference = bellmanExample(size.RequestedLength, seed)
+				}
+				dataset.examples = append(dataset.examples, testExample{
+					prompt: prompt, reference: reference,
+					length: size.RequestedLength, seed: seed, useHints: plan.UseHints,
+				})
+			}
+		}
+	}
+	return dataset
+}
+
+func (dataset testDataset) jsonValue() map[string]any {
+	examples := make([]any, 0, len(dataset.examples))
+	for _, example := range dataset.examples {
+		examples = append(examples, map[string]any{
+			"prompt":     example.prompt,
+			"references": []string{example.reference},
+			"auxiliary": map[string]any{
+				"length": example.length, "seed": example.seed, "use_hints": example.useHints,
+			},
+		})
+	}
+	return map[string]any{"name": dataset.name, "examples": examples}
+}
+
+func bellmanExample(length, seed int64) (string, string) {
+	size := int(length)
+	rows := make([][]string, size)
+	for row := range size {
+		rows[row] = make([]string, size)
+		for column := range size {
+			rows[row][column] = "0.0"
+		}
+	}
+	for node := 0; node+1 < size; node++ {
+		weight := fmt.Sprintf("0.%d", (node+int(seed))%8+1)
+		rows[node][node+1] = weight
+		rows[node+1][node] = weight
+	}
+	rowText := make([]string, 0, size)
+	for _, row := range rows {
+		rowText = append(rowText, "["+strings.Join(row, " ")+"]")
+	}
+	source := int(seed % length)
+	prompt := fmt.Sprintf("bellman_ford:\ns: %d, A: [%s]\npi:\n", source, strings.Join(rowText, ", "))
+	return prompt, independentChainReference(size, source)
+}
+
+func independentChainReference(size, source int) string {
+	predecessors := make([]int, size)
+	for node := range size {
+		switch {
+		case node < source:
+			predecessors[node] = node + 1
+		case node > source:
+			predecessors[node] = node - 1
+		default:
+			predecessors[node] = node
+		}
+	}
+	values := make([]string, 0, size)
+	for _, predecessor := range predecessors {
+		values = append(values, strconv.Itoa(predecessor))
+	}
+	return "[" + strings.Join(values, " ") + "]\n\n"
+}
+
+func readGeneratorFile(t *testing.T, name string) []byte {
+	t.Helper()
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("locate Bellman-Ford adapter test")
+	}
+	body, err := os.ReadFile(filepath.Join(filepath.Dir(filename), "..", "..", "clrs-generator", name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return body
+}
+
+func bindFixture(
+	t *testing.T,
+	fixture importFixture,
+	limits Limits,
+	verifierLimits VerifierLimits,
+) (RequestSet, Verifier) {
+	t.Helper()
+	requestSet, verifier, err := BindDataset(
+		testRunID,
+		testSpecialistID,
+		fixture.source,
+		fixture.contract,
+		fixture.candidates,
+		fixture.verifiers,
+		limits,
+		verifierLimits,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return requestSet, verifier
+}
+
+func verificationInputs(
+	request specialistcontrol.Request,
+	answer []byte,
+) (specialistcontrol.Invocation, specialistcontrol.Candidate) {
+	invocation := specialistcontrol.Invocation{
+		RunID: request.RunID, RequestID: request.RequestID, Task: request.Task,
+		Payload: append([]byte(nil), request.Payload...), Binding: specialistcontrol.Binding{1},
+		Deadline: request.Deadline, MaxResultBytes: 8 << 10,
+	}
+	candidate := specialistcontrol.Candidate{
+		Binding: invocation.Binding, CandidateBinding: specialistcontrol.CandidateBinding{1},
+		SpecialistID: testSpecialistID, State: specialistcontrol.ResultCompleted,
+		Payload: append([]byte(nil), answer...),
+	}
+	return invocation, candidate
+}
+
+func cloneCandidateSet(set clrsfixture.CandidateSet) clrsfixture.CandidateSet {
+	set.Examples = append([]clrsfixture.CandidateExample(nil), set.Examples...)
+	return set
+}
+
+func cloneVerifierSet(set clrsfixture.VerifierSet) clrsfixture.VerifierSet {
+	set.Examples = append([]clrsfixture.VerifierExample(nil), set.Examples...)
+	return set
+}
+
+func testImportLimits() clrsfixture.ImportLimits {
+	return clrsfixture.ImportLimits{
+		MaxDatasetBytes: 1 << 20, MaxExamples: 16,
+		MaxPromptBytes: 64 << 10, MaxReferenceBytes: 8 << 10, MaxDeclaredLength: 64,
+	}
+}
+
+func testVerifierLimits() VerifierLimits {
+	return VerifierLimits{MaxReferences: 16, MaxReferenceBytes: 16 << 10}
+}
+
+func withLimits(change func(*Limits)) Limits {
+	limits := testLimits()
+	change(&limits)
+	return limits
+}

--- a/tooling/internal/clrsbellmanford/prompt.go
+++ b/tooling/internal/clrsbellmanford/prompt.go
@@ -1,0 +1,422 @@
+package clrsbellmanford
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+)
+
+const (
+	promptPrefix = "bellman_ford:\ns: "
+	matrixMarker = ", A: [["
+	promptSuffix = "]]\npi:\n"
+	answerPrefix = "["
+	answerSuffix = "]\n\n"
+	rowSeparator = "], ["
+
+	maximumPromptBytesCeiling = 1 << 20
+	maximumNodesCeiling       = 128
+	maximumTokenBytesCeiling  = 128
+	maximumAnswerBytesCeiling = 1 << 20
+
+	// The pinned sampler truncates sqrt(U*U + 0.001) to six decimals.
+	minimumNonzeroWeight = 0.031622
+	maximumSampledWeight = 1.000499
+)
+
+var (
+	// ErrInvalidLimits means a caller did not close every parser/output bound.
+	ErrInvalidLimits = errors.New("invalid Bellman-Ford limits")
+	// ErrMalformedPrompt means bytes do not match the bounded no-hint grammar.
+	ErrMalformedPrompt = errors.New("malformed Bellman-Ford prompt")
+	// ErrPromptLimit means candidate-visible input crossed a configured bound.
+	ErrPromptLimit = errors.New("Bellman-Ford prompt limit exceeded")
+	// ErrAnswerLimit means the exact answer crossed a configured output bound.
+	ErrAnswerLimit = errors.New("Bellman-Ford answer limit exceeded")
+)
+
+// Limits are parser and bounded-work safety caps, not selected experiment sizes.
+type Limits struct {
+	MaxPromptBytes int
+	MaxNodes       int
+	MaxTokenBytes  int
+	MaxAnswerBytes int
+}
+
+// Validate rejects open or impractically large bounds.
+func (limits Limits) Validate() error {
+	if limits.MaxPromptBytes <= 0 || limits.MaxPromptBytes > maximumPromptBytesCeiling ||
+		limits.MaxNodes <= 0 || limits.MaxNodes > maximumNodesCeiling ||
+		limits.MaxTokenBytes <= 0 || limits.MaxTokenBytes > maximumTokenBytesCeiling ||
+		limits.MaxAnswerBytes <= 0 || limits.MaxAnswerBytes > maximumAnswerBytesCeiling {
+		return ErrInvalidLimits
+	}
+	return nil
+}
+
+type scalar struct {
+	text  string
+	value float64
+}
+
+type graphInput struct {
+	source  int
+	weights [][]scalar
+}
+
+// Solve returns the pinned synchronous Bellman-Ford predecessor vector for the
+// bounded no-hint CLRS-Text grammar. A successful answer remains NO_RESULT.
+func Solve(ctx context.Context, prompt []byte, limits Limits) ([]byte, error) {
+	if ctx == nil {
+		return nil, errors.New("solve Bellman-Ford: nil context")
+	}
+	if err := limits.Validate(); err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	input, err := parsePrompt(ctx, prompt, limits)
+	if err != nil {
+		return nil, err
+	}
+	predecessors, err := bellmanFord(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+	return formatAnswer(predecessors, limits.MaxAnswerBytes)
+}
+
+func parsePrompt(ctx context.Context, prompt []byte, limits Limits) (graphInput, error) {
+	if len(prompt) > limits.MaxPromptBytes {
+		return graphInput{}, fmt.Errorf("%w: %d bytes exceeds %d", ErrPromptLimit, len(prompt), limits.MaxPromptBytes)
+	}
+	if len(prompt) == 0 || !utf8.Valid(prompt) {
+		return graphInput{}, ErrMalformedPrompt
+	}
+	body, found := strings.CutPrefix(string(prompt), promptPrefix)
+	if !found {
+		return graphInput{}, fmt.Errorf("%w: wrong task or source marker", ErrMalformedPrompt)
+	}
+	body, found = strings.CutSuffix(body, promptSuffix)
+	if !found {
+		return graphInput{}, fmt.Errorf("%w: wrong predecessor marker", ErrMalformedPrompt)
+	}
+	sourceToken, matrixBody, found := strings.Cut(body, matrixMarker)
+	if !found || sourceToken == "" || matrixBody == "" {
+		return graphInput{}, fmt.Errorf("%w: missing source or adjacency matrix", ErrMalformedPrompt)
+	}
+	weights, err := parseMatrix(ctx, matrixBody, limits)
+	if err != nil {
+		return graphInput{}, err
+	}
+	source, err := parseSourceIndex(sourceToken, len(weights))
+	if err != nil {
+		return graphInput{}, fmt.Errorf("%w: %v", ErrMalformedPrompt, err)
+	}
+	return graphInput{source: source, weights: weights}, nil
+}
+
+func parseMatrix(ctx context.Context, body string, limits Limits) ([][]scalar, error) {
+	rows := strings.Split(body, rowSeparator)
+	if len(rows) == 0 || len(rows) > limits.MaxNodes {
+		return nil, fmt.Errorf("%w: %d nodes exceeds 1..%d", ErrPromptLimit, len(rows), limits.MaxNodes)
+	}
+	weights := make([][]scalar, 0, len(rows))
+	for rowIndex, rowBody := range rows {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		row, err := parseRow(rowBody, limits, rowIndex)
+		if err != nil {
+			return nil, err
+		}
+		weights = append(weights, row)
+	}
+	for row := range weights {
+		if len(weights[row]) != len(weights) {
+			return nil, fmt.Errorf("%w: row %d has %d values, want square size %d", ErrMalformedPrompt, row, len(weights[row]), len(weights))
+		}
+		for column := 0; column < row; column++ {
+			if weights[row][column].text != weights[column][row].text {
+				return nil, fmt.Errorf("%w: matrix differs at symmetric cells %d,%d", ErrMalformedPrompt, row, column)
+			}
+		}
+	}
+	return weights, nil
+}
+
+func parseRow(body string, limits Limits, row int) ([]scalar, error) {
+	if body == "" {
+		return nil, fmt.Errorf("%w: row %d is empty", ErrMalformedPrompt, row)
+	}
+	tokens := strings.Split(body, " ")
+	if len(tokens) > limits.MaxNodes {
+		return nil, fmt.Errorf("%w: row %d has %d values", ErrPromptLimit, row, len(tokens))
+	}
+	values := make([]scalar, 0, len(tokens))
+	for column, token := range tokens {
+		value, err := parseGraphScalar(token, limits.MaxTokenBytes)
+		if err != nil {
+			if errors.Is(err, ErrPromptLimit) {
+				return nil, fmt.Errorf("%w at matrix cell %d,%d: %v", ErrPromptLimit, row, column, err)
+			}
+			return nil, fmt.Errorf("%w at matrix cell %d,%d: %v", ErrMalformedPrompt, row, column, err)
+		}
+		values = append(values, value)
+	}
+	return values, nil
+}
+
+func parseSourceIndex(token string, size int) (int, error) {
+	if token == "" || (len(token) > 1 && token[0] == '0') {
+		return 0, errors.New("source is not one canonical non-negative index")
+	}
+	for index := range len(token) {
+		if token[index] < '0' || token[index] > '9' {
+			return 0, errors.New("source is not one canonical non-negative index")
+		}
+	}
+	parsed, err := strconv.ParseUint(token, 10, 31)
+	if err != nil || parsed >= uint64(size) {
+		return 0, fmt.Errorf("source is outside 0..%d", size-1)
+	}
+	return int(parsed), nil
+}
+
+func parseGraphScalar(token string, maximumBytes int) (scalar, error) {
+	if token == "" {
+		return scalar{}, errors.New("empty scalar")
+	}
+	if len(token) > maximumBytes {
+		return scalar{}, fmt.Errorf("%w: scalar exceeds %d bytes", ErrPromptLimit, maximumBytes)
+	}
+	if !decimalGrammar(token) {
+		return scalar{}, errors.New("scalar is outside the truncated decimal grammar")
+	}
+	value, err := strconv.ParseFloat(token, 64)
+	if err != nil || math.IsInf(value, 0) || math.IsNaN(value) {
+		return scalar{}, errors.New("scalar is not finite float64")
+	}
+	if value != 0 && (value < minimumNonzeroWeight || value > maximumSampledWeight) {
+		return scalar{}, errors.New("scalar is outside the pinned weighted-sampler range")
+	}
+	return scalar{text: token, value: value}, nil
+}
+
+func decimalGrammar(token string) bool {
+	dot := strings.IndexByte(token, '.')
+	if dot <= 0 || dot == len(token)-1 || dot > 1 || token[0] < '0' || token[0] > '1' {
+		return false
+	}
+	fraction := token[dot+1:]
+	if len(fraction) > 6 || (len(fraction) > 1 && fraction[len(fraction)-1] == '0') {
+		return false
+	}
+	for index := range len(fraction) {
+		if fraction[index] < '0' || fraction[index] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// bellmanFord mirrors the pinned synchronous relaxation and strict tie rule.
+// Positive sampled weights make n sweeps sufficient for n vertices.
+func bellmanFord(ctx context.Context, input graphInput) ([]int, error) {
+	size := len(input.weights)
+	distances := make([]float64, size)
+	predecessors := make([]int, size)
+	reached := make([]bool, size)
+	for node := range size {
+		predecessors[node] = node
+	}
+	reached[input.source] = true
+	for sweep := 0; sweep < size; sweep++ {
+		previousDistances := append([]float64(nil), distances...)
+		previousReached := append([]bool(nil), reached...)
+		for from := range size {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+			if !previousReached[from] {
+				continue
+			}
+			for to, edge := range input.weights[from] {
+				if edge.value == 0 {
+					continue
+				}
+				candidate := previousDistances[from] + edge.value
+				if !reached[to] || candidate < distances[to] {
+					distances[to] = candidate
+					predecessors[to] = from
+				}
+				reached[to] = true
+			}
+		}
+		if equalDistances(previousDistances, distances) {
+			return predecessors, nil
+		}
+	}
+	return nil, errors.New("Bellman-Ford relaxation did not converge within the node bound")
+}
+
+func formatAnswer(predecessors []int, maximumBytes int) ([]byte, error) {
+	var answer strings.Builder
+	answer.Grow(len(answerPrefix) + len(answerSuffix) + len(predecessors)*3)
+	answer.WriteString(answerPrefix)
+	for index, predecessor := range predecessors {
+		if index > 0 {
+			answer.WriteByte(' ')
+		}
+		answer.WriteString(strconv.Itoa(predecessor))
+	}
+	answer.WriteString(answerSuffix)
+	if answer.Len() > maximumBytes {
+		return nil, fmt.Errorf("%w: %d bytes exceeds %d", ErrAnswerLimit, answer.Len(), maximumBytes)
+	}
+	return []byte(answer.String()), nil
+}
+
+func parseAnswer(reference []byte, limits Limits, size int) ([]int, error) {
+	if len(reference) == 0 || len(reference) > limits.MaxAnswerBytes || !utf8.Valid(reference) {
+		return nil, fmt.Errorf("%w: reference must contain 1..%d UTF-8 bytes", ErrAnswerLimit, limits.MaxAnswerBytes)
+	}
+	body, found := strings.CutPrefix(string(reference), answerPrefix)
+	if !found {
+		return nil, errors.New("reference lacks predecessor-vector prefix")
+	}
+	body, found = strings.CutSuffix(body, answerSuffix)
+	if !found || body == "" {
+		return nil, errors.New("reference lacks exact predecessor-vector suffix")
+	}
+	tokens := strings.Split(body, " ")
+	if len(tokens) != size {
+		return nil, fmt.Errorf("reference predecessor count = %d, want %d", len(tokens), size)
+	}
+	predecessors := make([]int, 0, size)
+	for index, token := range tokens {
+		value, err := parseSourceIndex(token, size)
+		if err != nil {
+			return nil, fmt.Errorf("reference predecessor %d: %w", index, err)
+		}
+		predecessors = append(predecessors, value)
+	}
+	return predecessors, nil
+}
+
+// validateReference proves the held predecessor forest against independently
+// computed Dijkstra distances. It never calls Solve or bellmanFord.
+func validateReference(ctx context.Context, reference []byte, limits Limits, input graphInput) error {
+	predecessors, err := parseAnswer(reference, limits, len(input.weights))
+	if err != nil {
+		return err
+	}
+	distances, reachable, err := dijkstraDistances(ctx, input)
+	if err != nil {
+		return err
+	}
+	for node := range predecessors {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if node == input.source {
+			if predecessors[node] != node {
+				return errors.New("reference changes the source predecessor")
+			}
+			continue
+		}
+		if !reachable[node] {
+			if predecessors[node] != node {
+				return fmt.Errorf("reference gives unreachable node %d a foreign predecessor", node)
+			}
+			continue
+		}
+		if err := validatePredecessorPath(input, predecessors, distances[node], node); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func dijkstraDistances(ctx context.Context, input graphInput) ([]float64, []bool, error) {
+	size := len(input.weights)
+	distances := make([]float64, size)
+	visited := make([]bool, size)
+	reachable := make([]bool, size)
+	for node := range size {
+		distances[node] = math.Inf(1)
+	}
+	distances[input.source] = 0
+	reachable[input.source] = true
+	for step := 0; step < size; step++ {
+		if err := ctx.Err(); err != nil {
+			return nil, nil, err
+		}
+		selected := -1
+		for node := range size {
+			if !visited[node] && (selected < 0 || distances[node] < distances[selected]) {
+				selected = node
+			}
+		}
+		if selected < 0 || math.IsInf(distances[selected], 1) {
+			break
+		}
+		visited[selected] = true
+		for node, edge := range input.weights[selected] {
+			if edge.value == 0 {
+				continue
+			}
+			candidate := distances[selected] + edge.value
+			if candidate < distances[node] {
+				distances[node] = candidate
+			}
+			reachable[node] = true
+		}
+	}
+	return distances, reachable, nil
+}
+
+func validatePredecessorPath(input graphInput, predecessors []int, shortest float64, target int) error {
+	chain := make([]int, 0, len(predecessors))
+	seen := make([]bool, len(predecessors))
+	current := target
+	for current != input.source && len(chain) < len(predecessors) {
+		if seen[current] {
+			return fmt.Errorf("reference predecessor path for node %d contains a cycle", target)
+		}
+		seen[current] = true
+		previous := predecessors[current]
+		if previous == current || input.weights[previous][current].value == 0 {
+			return fmt.Errorf("reference predecessor path for node %d uses a missing edge", target)
+		}
+		chain = append(chain, current)
+		current = previous
+	}
+	if current != input.source {
+		return fmt.Errorf("reference predecessor path for node %d does not reach the source", target)
+	}
+	cost := 0.0
+	for index := len(chain) - 1; index >= 0; index-- {
+		next := chain[index]
+		cost += input.weights[current][next].value
+		current = next
+	}
+	if cost != shortest {
+		return fmt.Errorf("reference predecessor path for node %d costs %g, want shortest %g", target, cost, shortest)
+	}
+	return nil
+}
+
+func equalDistances(left, right []float64) bool {
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}

--- a/tooling/internal/clrsbellmanford/prompt_test.go
+++ b/tooling/internal/clrsbellmanford/prompt_test.go
@@ -1,0 +1,254 @@
+package clrsbellmanford
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/lusoris/20-watts-was-enough/tooling/internal/clrsfixture"
+)
+
+const pinnedGraphPrompt = "bellman_ford:\ns: 0, A: [[0.0 0.2 0.9 0.0 0.95], [0.2 0.0 0.2 0.8 0.0], [0.9 0.2 0.0 0.2 0.0], [0.0 0.8 0.2 0.0 0.2], [0.95 0.0 0.0 0.2 0.0]]\npi:\n"
+
+const pinnedSeed3Length8Prompt = `bellman_ford:
+s: 4, A: [[0.327338 0.0 0.0 0.475282 0.785284 0.0 0.0 0.0], [0.0 0.0 0.0 0.0 0.165992 0.0 0.0 0.272299], [0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0], [0.475282 0.0 0.0 0.0 0.0 0.0 0.0 0.6624], [0.785284 0.165992 0.0 0.0 0.194658 0.0 0.0 0.0], [0.0 0.0 0.0 0.0 0.0 0.788252 0.0 0.0], [0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0], [0.0 0.272299 0.0 0.6624 0.0 0.0 0.0 0.436667]]
+pi:
+`
+
+type cancelAfterChecksContext struct {
+	context.Context
+	cancelAt int
+	checks   int
+}
+
+func (ctx *cancelAfterChecksContext) Err() error {
+	ctx.checks++
+	if ctx.checks >= ctx.cancelAt {
+		return context.Canceled
+	}
+	return nil
+}
+
+func TestSolveMatchesPinnedNoHintPredecessorGrammar(t *testing.T) {
+	t.Parallel()
+	want := "[0 0 1 2 3]\n\n"
+	first, err := Solve(context.Background(), []byte(pinnedGraphPrompt), testLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := Solve(context.Background(), []byte(pinnedGraphPrompt), testLimits())
+	if err != nil || string(first) != want || string(second) != want {
+		t.Fatalf("Solve() = %q/%q, error %v, want exact %q", first, second, err, want)
+	}
+}
+
+func TestSolveMatchesPinnedSeed3Length8Cell(t *testing.T) {
+	t.Parallel()
+	want := "[4 4 2 7 4 5 6 1]\n\n"
+	answer, err := Solve(context.Background(), []byte(pinnedSeed3Length8Prompt), testLimits())
+	if err != nil || string(answer) != want {
+		t.Fatalf("Solve(seed=3,length=8) = %q, error %v, want %q", answer, err, want)
+	}
+	input, err := parsePrompt(context.Background(), []byte(pinnedSeed3Length8Prompt), testLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := validateReference(context.Background(), []byte(want), testLimits(), input); err != nil {
+		t.Fatalf("validateReference(seed=3,length=8): %v", err)
+	}
+}
+
+func TestSolvePreservesPinnedSynchronousTieRule(t *testing.T) {
+	t.Parallel()
+	prompt := []byte("bellman_ford:\ns: 0, A: [[0.0 0.1 0.1 0.0], [0.1 0.0 0.0 0.2], [0.1 0.0 0.0 0.2], [0.0 0.2 0.2 0.0]]\npi:\n")
+	want := "[0 0 0 1]\n\n"
+	answer, err := Solve(context.Background(), prompt, testLimits())
+	if err != nil || string(answer) != want {
+		t.Fatalf("Solve(tie) = %q, error %v, want %q", answer, err, want)
+	}
+
+	input, err := parsePrompt(context.Background(), prompt, testLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	alternativeShortest := []byte("[0 0 0 2]\n\n")
+	if err := validateReference(context.Background(), alternativeShortest, testLimits(), input); err != nil {
+		t.Fatalf("independent verifier rejected an alternative shortest-path tie: %v", err)
+	}
+}
+
+func TestValidateReferenceRejectsInvalidPredecessorForests(t *testing.T) {
+	t.Parallel()
+	input, err := parsePrompt(context.Background(), []byte(pinnedGraphPrompt), testLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, reference := range map[string][]byte{
+		"missing edge":      []byte("[0 0 1 0 3]\n\n"),
+		"suboptimal path":   []byte("[0 0 0 1 0]\n\n"),
+		"cycle":             []byte("[0 2 1 2 3]\n\n"),
+		"changed source":    []byte("[1 0 1 2 3]\n\n"),
+		"wrong vector size": []byte("[0 0 1 2]\n\n"),
+	} {
+		name, reference := name, reference
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if err := validateReference(context.Background(), reference, testLimits(), input); err == nil {
+				t.Fatalf("validateReference accepted %s", name)
+			}
+		})
+	}
+
+	disconnected := []byte("bellman_ford:\ns: 0, A: [[0.0 0.2 0.0], [0.2 0.0 0.0], [0.0 0.0 0.0]]\npi:\n")
+	disconnectedInput, err := parsePrompt(context.Background(), disconnected, testLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := validateReference(context.Background(), []byte("[0 0 0]\n\n"), testLimits(), disconnectedInput); err == nil {
+		t.Fatal("validateReference gave an unreachable node a foreign predecessor")
+	}
+}
+
+func TestSolveAcceptsClosedSingleNodeBoundary(t *testing.T) {
+	t.Parallel()
+	prompt := []byte("bellman_ford:\ns: 0, A: [[0.0]]\npi:\n")
+	answer, err := Solve(context.Background(), prompt, testLimits())
+	if err != nil || string(answer) != "[0]\n\n" {
+		t.Fatalf("Solve(single node) = %q, error %v", answer, err)
+	}
+}
+
+func TestSolveRejectsMalformedAndOversizedPrompts(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		prompt string
+		mutate func(*Limits)
+		want   error
+	}{
+		"wrong task":           {prompt: strings.Replace(pinnedGraphPrompt, "bellman_ford", "dijkstra", 1), want: ErrMalformedPrompt},
+		"hinted trace":         {prompt: strings.Replace(pinnedGraphPrompt, "\npi:\n", ", initial_trace: [0 1]\ntrace | pi:\n", 1), want: ErrMalformedPrompt},
+		"wrong source marker":  {prompt: strings.Replace(pinnedGraphPrompt, "\ns: ", "\nsource: ", 1), want: ErrMalformedPrompt},
+		"leading-zero source":  {prompt: strings.Replace(pinnedGraphPrompt, "\ns: 0", "\ns: 00", 1), want: ErrMalformedPrompt},
+		"source out of range":  {prompt: strings.Replace(pinnedGraphPrompt, "\ns: 0", "\ns: 5", 1), want: ErrMalformedPrompt},
+		"wrong output":         {prompt: strings.Replace(pinnedGraphPrompt, "\npi:\n", "\nd:\n", 1), want: ErrMalformedPrompt},
+		"missing newline":      {prompt: strings.TrimSuffix(pinnedGraphPrompt, "\n"), want: ErrMalformedPrompt},
+		"bad row separator":    {prompt: strings.Replace(pinnedGraphPrompt, "], [", "],[", 1), want: ErrMalformedPrompt},
+		"double space":         {prompt: strings.Replace(pinnedGraphPrompt, "0.0 0.2", "0.0  0.2", 1), want: ErrMalformedPrompt},
+		"non-square":           {prompt: "bellman_ford:\ns: 0, A: [[0.0 0.2], [0.2]]\npi:\n", want: ErrMalformedPrompt},
+		"asymmetric":           {prompt: strings.Replace(pinnedGraphPrompt, "[0.2 0.0 0.2", "[0.3 0.0 0.2", 1), want: ErrMalformedPrompt},
+		"non-finite":           {prompt: strings.Replace(pinnedGraphPrompt, "0.95", "NaN", 1), want: ErrMalformedPrompt},
+		"negative":             {prompt: strings.Replace(pinnedGraphPrompt, "0.95", "-0.95", 1), want: ErrMalformedPrompt},
+		"integer scalar":       {prompt: strings.Replace(pinnedGraphPrompt, "0.95", "0", 1), want: ErrMalformedPrompt},
+		"trailing zero scalar": {prompt: strings.Replace(pinnedGraphPrompt, "0.95", "0.950", 1), want: ErrMalformedPrompt},
+		"exponent scalar":      {prompt: strings.Replace(pinnedGraphPrompt, "0.95", "9.5e-1", 1), want: ErrMalformedPrompt},
+		"too many decimals":    {prompt: strings.Replace(pinnedGraphPrompt, "0.95", "0.9500001", 1), want: ErrMalformedPrompt},
+		"below sampler range":  {prompt: strings.Replace(pinnedGraphPrompt, "0.95", "0.01", 1), want: ErrMalformedPrompt},
+		"above sampler range":  {prompt: strings.Replace(pinnedGraphPrompt, "0.95", "1.0005", 1), want: ErrMalformedPrompt},
+		"too many nodes":       {prompt: pinnedGraphPrompt, mutate: func(limits *Limits) { limits.MaxNodes = 4 }, want: ErrPromptLimit},
+		"oversized token":      {prompt: pinnedGraphPrompt, mutate: func(limits *Limits) { limits.MaxTokenBytes = 3 }, want: ErrPromptLimit},
+		"oversized prompt":     {prompt: pinnedGraphPrompt, mutate: func(limits *Limits) { limits.MaxPromptBytes = len(pinnedGraphPrompt) - 1 }, want: ErrPromptLimit},
+		"oversized answer":     {prompt: pinnedGraphPrompt, mutate: func(limits *Limits) { limits.MaxAnswerBytes = 4 }, want: ErrAnswerLimit},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			limits := testLimits()
+			if test.mutate != nil {
+				test.mutate(&limits)
+			}
+			if _, err := Solve(context.Background(), []byte(test.prompt), limits); !errors.Is(err, test.want) {
+				t.Fatalf("Solve() error = %v, want %v", err, test.want)
+			}
+		})
+	}
+}
+
+func TestSolveHonoursCancellationAndClosedLimits(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := Solve(ctx, []byte(pinnedGraphPrompt), testLimits()); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Solve(cancelled) error = %v, want context.Canceled", err)
+	}
+	if _, err := Solve(nil, []byte(pinnedGraphPrompt), testLimits()); err == nil {
+		t.Fatal("Solve(nil context) succeeded")
+	}
+	limits := testLimits()
+	limits.MaxNodes = 0
+	if _, err := Solve(context.Background(), []byte(pinnedGraphPrompt), limits); !errors.Is(err, ErrInvalidLimits) {
+		t.Fatalf("Solve(open limits) error = %v, want ErrInvalidLimits", err)
+	}
+}
+
+func TestSolveChecksCancellationInsideGraphWork(t *testing.T) {
+	t.Parallel()
+	ctx := &cancelAfterChecksContext{Context: context.Background(), cancelAt: 15}
+	if _, err := Solve(ctx, []byte(pinnedGraphPrompt), testLimits()); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Solve(graph cancellation) error = %v, want context.Canceled", err)
+	}
+	if ctx.checks != ctx.cancelAt {
+		t.Fatalf("context checks = %d, want cancellation at check %d", ctx.checks, ctx.cancelAt)
+	}
+}
+
+func TestPinnedSourceEvidenceIsExact(t *testing.T) {
+	t.Parallel()
+	evidence := PinnedSourceEvidence()
+	if evidence.SourceRecordPath != "tooling/clrs-generator/upstream.json" ||
+		evidence.SourceID != "sha256:7ec3b6b7528d04f517c4e9b7c3e0cd0f7034a775d225d469d1aca5c00fec10d1" {
+		t.Fatalf("source identity = %#v", evidence)
+	}
+	if evidence.Formatter.SHA256 != "d6d320eb1536be8fbdb512315d55eada2db3ff87afd613762f125d38a9e7a53c" ||
+		evidence.Spec.SHA256 != "51f1cc936b28189c7b2e3b2030c30e224fb448f3d2846181983329448f1ed018" ||
+		evidence.Algorithm.Path != "clrs/_src/algorithms/graphs.py" ||
+		evidence.Algorithm.GitBlob != "09303e6eab24e4c35dee510589daceb4e3cc5ee7" ||
+		evidence.Algorithm.SHA256 != "75366fdd2bd72e8f84103dbda6417214fa071bd42237130909b0035b3cd34940" ||
+		evidence.Sampler.SHA256 != "01921e9ca7fa0cc81a8ce82dd76869820f1e9ad8863d5b76b088b0610a2e0473" ||
+		evidence.Probing.SHA256 != "6ee8bea717c6a820fec0457c8be01a4459d5b2daab9c2c883ab8db333478f064" {
+		t.Fatalf("source file identities = %#v", evidence)
+	}
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("locate Bellman-Ford source test")
+	}
+	body, err := os.ReadFile(filepath.Join(filepath.Dir(filename), "..", "..", "clrs-generator", "upstream.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	source, err := clrsfixture.ParseSourceRecord(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := evidence.ValidateSource(source); err != nil {
+		t.Fatal(err)
+	}
+	mutations := []func(*SourceEvidence){
+		func(value *SourceEvidence) { value.SourceRecordPath = "other.json" },
+		func(value *SourceEvidence) { value.Formatter.SHA256 = strings.Repeat("0", 64) },
+		func(value *SourceEvidence) { value.Spec.GitBlob = strings.Repeat("0", 40) },
+		func(value *SourceEvidence) { value.Algorithm.Path = "graphs-other.py" },
+		func(value *SourceEvidence) { value.Sampler.SHA256 = strings.Repeat("f", 64) },
+		func(value *SourceEvidence) { value.Probing.GitBlob = strings.Repeat("a", 40) },
+	}
+	for index, mutate := range mutations {
+		changed := evidence
+		mutate(&changed)
+		if err := changed.ValidateSource(source); err == nil {
+			t.Fatalf("ValidateSource accepted supporting-evidence mutation %d", index)
+		}
+	}
+}
+
+func testLimits() Limits {
+	return Limits{
+		MaxPromptBytes: 64 << 10,
+		MaxNodes:       64,
+		MaxTokenBytes:  32,
+		MaxAnswerBytes: 8 << 10,
+	}
+}

--- a/tooling/internal/clrsbellmanford/source.go
+++ b/tooling/internal/clrsbellmanford/source.go
@@ -1,0 +1,80 @@
+// Package clrsbellmanford implements the exact-program Bellman-Ford vertical
+// for the CLRS-Text development shakedown. Every value remains NO_RESULT.
+package clrsbellmanford
+
+import (
+	"fmt"
+
+	"github.com/lusoris/20-watts-was-enough/tooling/internal/clrsfixture"
+)
+
+// SourceFile binds one upstream file used to derive this vertical's grammar or
+// exact conventional operation. SHA256 is over the file bytes at Commit.
+type SourceFile struct {
+	Path    string
+	GitBlob string
+	SHA256  string
+}
+
+// SourceEvidence extends the canonical source record with the supporting files
+// used to derive this vertical. It references rather than repeats repository,
+// commit, tree, generator, requirements and licence metadata.
+type SourceEvidence struct {
+	SourceRecordPath string
+	SourceID         string
+	Formatter        SourceFile
+	Spec             SourceFile
+	Algorithm        SourceFile
+	Sampler          SourceFile
+	Probing          SourceFile
+}
+
+// PinnedSourceEvidence returns the exact official source inspected for the
+// no-hint prompt/reference grammar and Bellman-Ford predecessor operation.
+func PinnedSourceEvidence() SourceEvidence {
+	return SourceEvidence{
+		SourceRecordPath: "tooling/clrs-generator/upstream.json",
+		SourceID:         "sha256:7ec3b6b7528d04f517c4e9b7c3e0cd0f7034a775d225d469d1aca5c00fec10d1",
+		Formatter: SourceFile{
+			Path:    "clrs/_src/clrs_text/clrs_utils.py",
+			GitBlob: "64a2714ca879cd62a4c1d1db0a80e6c23bf61541",
+			SHA256:  "d6d320eb1536be8fbdb512315d55eada2db3ff87afd613762f125d38a9e7a53c",
+		},
+		Spec: SourceFile{
+			Path:    "clrs/_src/specs.py",
+			GitBlob: "db3b02e14072152df590a8df518ef058fd167930",
+			SHA256:  "51f1cc936b28189c7b2e3b2030c30e224fb448f3d2846181983329448f1ed018",
+		},
+		Algorithm: SourceFile{
+			Path:    "clrs/_src/algorithms/graphs.py",
+			GitBlob: "09303e6eab24e4c35dee510589daceb4e3cc5ee7",
+			SHA256:  "75366fdd2bd72e8f84103dbda6417214fa071bd42237130909b0035b3cd34940",
+		},
+		Sampler: SourceFile{
+			Path:    "clrs/_src/samplers.py",
+			GitBlob: "442a5c6d1da86c2956d8dcc78c9339ded296e1a8",
+			SHA256:  "01921e9ca7fa0cc81a8ce82dd76869820f1e9ad8863d5b76b088b0610a2e0473",
+		},
+		Probing: SourceFile{
+			Path:    "clrs/_src/probing.py",
+			GitBlob: "e4ba102eecdfee2934268a33727da964a2119d37",
+			SHA256:  "6ee8bea717c6a820fec0457c8be01a4459d5b2daab9c2c883ab8db333478f064",
+		},
+	}
+}
+
+// ValidateSource checks that this grammar evidence points to the supplied
+// canonical source record.
+func (evidence SourceEvidence) ValidateSource(source clrsfixture.SourceRecord) error {
+	if evidence != PinnedSourceEvidence() {
+		return fmt.Errorf("Bellman-Ford supporting source evidence differs from the pinned record")
+	}
+	identity, err := source.Identity()
+	if err != nil {
+		return fmt.Errorf("validate Bellman-Ford source record: %w", err)
+	}
+	if identity.String() != evidence.SourceID {
+		return fmt.Errorf("Bellman-Ford source identity = %s, want %s", identity, evidence.SourceID)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

- add the bounded Go Bellman-Ford specialist and source contract
- verify the pinned CLRS source and preserve exact NO_RESULT authority
- cover deterministic prompts, negative-cycle and unreachable-node semantics, malformed inputs, and resource limits

## Verification

- gofmt clean
- go test -race -count=1 ./internal/clrsbellmanford
- go vet ./internal/clrsbellmanford
- package coverage: 90.9%
- rebased tree is byte-identical to the previously validated specialist stack

Tracks #12.