### PR TITLE
feat(experiment): add KMP specialist vertical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,11 @@ the exact diff; this file records why the project changed.
   checks each held predecessor forest against the same bounded non-negative
   graph without calling the specialist solver; source-bound requests remain
   isolated from held answers, and all construction output remains `NO_RESULT`.
+- The KMP construction vertical now parses the pinned categorical string split
+  and returns the first haystack match, or the haystack length when none exists.
+  A separate naive matcher validates held references without calling the KMP
+  solver; source-bound requests retain no answer bytes, and all construction
+  output remains `NO_RESULT`.
 - A versioned PDF semantic sentinel now binds the current source, book, A4 and
   tag metadata, Poppler tool identity, separate structure and text streams,
   exact diagnostics, and six nonlinear content anchors. Atomic evidence keeps

--- a/tooling/internal/clrskmp/adapter.go
+++ b/tooling/internal/clrskmp/adapter.go
@@ -1,0 +1,342 @@
+package clrskmp
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/lusoris/20-watts-was-enough/tooling/internal/clrsfixture"
+	"github.com/lusoris/20-watts-was-enough/tooling/internal/specialistcontrol"
+)
+
+const (
+	maximumIdentityBytes            = 128
+	maximumReferencesCeiling        = 4_096
+	maximumReferenceSetBytesCeiling = 64 << 20
+	// Four fixture identities, one prompt digest and the effective-size integer.
+	heldIdentityBytes = 5*sha256.Size + 8
+)
+
+// ErrReferenceLimit means a separately held verifier index is open or too
+// large for the configured construction run.
+var ErrReferenceLimit = errors.New("KMP reference limit exceeded")
+
+// Specialist is the exact conventional CLRS Knuth-Morris-Pratt
+// implementation. It owns no reference data and sees only the invocation.
+type Specialist struct {
+	id     string
+	limits Limits
+}
+
+// NewSpecialist closes the candidate-visible solver identity and bounds.
+func NewSpecialist(id string, limits Limits) (Specialist, error) {
+	if !validIdentity(id) {
+		return Specialist{}, errors.New("KMP specialist identity is invalid")
+	}
+	if err := limits.Validate(); err != nil {
+		return Specialist{}, err
+	}
+	return Specialist{id: id, limits: limits}, nil
+}
+
+// Invoke implements specialistcontrol.Specialist.
+func (specialist Specialist) Invoke(
+	ctx context.Context,
+	invocation specialistcontrol.Invocation,
+) (specialistcontrol.SpecialistResult, error) {
+	refused := specialistcontrol.SpecialistResult{
+		Binding: invocation.Binding, SpecialistID: specialist.id, State: specialistcontrol.ResultRefused,
+	}
+	if ctx == nil {
+		return refused, errors.New("invoke KMP specialist: nil context")
+	}
+	if err := ctx.Err(); err != nil {
+		return refused, err
+	}
+	if invocation.Task != specialistcontrol.TaskKMPMatcher || invocation.Binding == (specialistcontrol.Binding{}) ||
+		invocation.MaxResultBytes <= 0 {
+		return refused, nil
+	}
+	answer, err := Solve(ctx, invocation.Payload, specialist.limits)
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return refused, err
+		}
+		if errors.Is(err, ErrInvalidLimits) || errors.Is(err, ErrMalformedPrompt) ||
+			errors.Is(err, ErrPromptLimit) || errors.Is(err, ErrAnswerLimit) {
+			return refused, nil
+		}
+		return refused, fmt.Errorf("solve KMP invocation: %w", err)
+	}
+	if len(answer) > invocation.MaxResultBytes {
+		return refused, nil
+	}
+	return specialistcontrol.SpecialistResult{
+		Binding:      invocation.Binding,
+		SpecialistID: specialist.id,
+		State:        specialistcontrol.ResultCompleted,
+		Payload:      answer,
+	}, nil
+}
+
+// VerifierLimits bound the separately held reference index. They are safety
+// caps, not fixture counts or an experiment sampling decision.
+type VerifierLimits struct {
+	MaxReferences     int
+	MaxReferenceBytes int64
+}
+
+// Validate rejects an open or impractically large verifier index.
+func (limits VerifierLimits) Validate() error {
+	if limits.MaxReferences <= 0 || limits.MaxReferences > maximumReferencesCeiling ||
+		limits.MaxReferenceBytes <= 0 || limits.MaxReferenceBytes > maximumReferenceSetBytesCeiling {
+		return ErrReferenceLimit
+	}
+	return nil
+}
+
+type referenceKey struct {
+	runID     string
+	requestID string
+}
+
+type heldReference struct {
+	source             clrsfixture.SourceID
+	contract           clrsfixture.ContractID
+	candidateID        clrsfixture.CandidateID
+	verifierID         clrsfixture.VerifierID
+	promptSHA256       [sha256.Size]byte
+	effectiveInputSize int64
+	answer             []byte
+}
+
+type boundCandidate struct {
+	id     clrsfixture.CandidateID
+	prompt []byte
+}
+
+// RequestSet is the candidate-only projection of one validated KMP dataset
+// run. It cannot be constructed from a raw prompt or held answer.
+type RequestSet struct {
+	runID      string
+	candidates []boundCandidate
+}
+
+// Verifier independently exact-scores against separately held references.
+type Verifier struct {
+	specialistID string
+	limits       Limits
+	references   map[referenceKey]heldReference
+}
+
+// BindDataset validates the exact contract-selected KMP candidate and verifier
+// sets, then returns separate candidate-only and held-reference views. Every
+// value remains NO_RESULT.
+func BindDataset(
+	runID string,
+	specialistID string,
+	source clrsfixture.SourceRecord,
+	contract clrsfixture.GenerationContract,
+	candidates clrsfixture.CandidateSet,
+	verifiers clrsfixture.VerifierSet,
+	limits Limits,
+	verifierLimits VerifierLimits,
+) (RequestSet, Verifier, error) {
+	if !validIdentity(runID) || !validIdentity(specialistID) {
+		return RequestSet{}, Verifier{}, errors.New("KMP run or specialist identity is invalid")
+	}
+	if err := limits.Validate(); err != nil {
+		return RequestSet{}, Verifier{}, err
+	}
+	if err := verifierLimits.Validate(); err != nil {
+		return RequestSet{}, Verifier{}, err
+	}
+	if err := PinnedSourceEvidence().ValidateSource(source); err != nil {
+		return RequestSet{}, Verifier{}, err
+	}
+	task, err := kmpTaskPlan(source, contract)
+	if err != nil {
+		return RequestSet{}, Verifier{}, err
+	}
+	pairs, err := clrsfixture.PairExamples(source, contract, task.OutputRelativePath, candidates, verifiers)
+	if err != nil {
+		return RequestSet{}, Verifier{}, fmt.Errorf("pair KMP dataset: %w", err)
+	}
+	if len(pairs) == 0 || len(pairs) > verifierLimits.MaxReferences {
+		return RequestSet{}, Verifier{}, fmt.Errorf("%w: reference count is %d", ErrReferenceLimit, len(pairs))
+	}
+
+	requestSet := RequestSet{runID: runID, candidates: make([]boundCandidate, 0, len(pairs))}
+	validated := make(map[referenceKey]heldReference, len(pairs))
+	var retainedBytes int64
+	for index, pair := range pairs {
+		candidate, held, bindErr := bindPair(pair, limits)
+		if bindErr != nil {
+			return RequestSet{}, Verifier{}, fmt.Errorf("bind KMP pair %d: %w", index, bindErr)
+		}
+		requestID := candidate.id.String()
+		retainedBytes += int64(len(runID)+len(requestID)+len(held.answer)) + heldIdentityBytes
+		if retainedBytes > verifierLimits.MaxReferenceBytes {
+			return RequestSet{}, Verifier{}, fmt.Errorf("%w: retained bytes exceed %d", ErrReferenceLimit, verifierLimits.MaxReferenceBytes)
+		}
+		key := referenceKey{runID: runID, requestID: requestID}
+		if _, duplicate := validated[key]; duplicate {
+			return RequestSet{}, Verifier{}, fmt.Errorf("duplicate KMP reference %s/%s", key.runID, key.requestID)
+		}
+		requestSet.candidates = append(requestSet.candidates, candidate)
+		validated[key] = held
+	}
+	return requestSet, Verifier{specialistID: specialistID, limits: limits, references: validated}, nil
+}
+
+// Requests returns fresh candidate-only controller packets for one closed run
+// window. RequestID is the source-and-contract-bound CandidateID.
+func (set RequestSet) Requests(issuedAt, deadline time.Time) ([]specialistcontrol.Request, error) {
+	if !validIdentity(set.runID) || len(set.candidates) == 0 {
+		return nil, errors.New("KMP request set is unbound")
+	}
+	if issuedAt.IsZero() || deadline.IsZero() || !deadline.After(issuedAt) {
+		return nil, errors.New("KMP request window is invalid")
+	}
+	requests := make([]specialistcontrol.Request, 0, len(set.candidates))
+	for _, candidate := range set.candidates {
+		requestID := candidate.id.String()
+		if !validIdentity(requestID) || len(candidate.prompt) == 0 {
+			return nil, errors.New("KMP bound candidate is invalid")
+		}
+		requests = append(requests, specialistcontrol.Request{
+			RunID:     set.runID,
+			RequestID: requestID,
+			Task:      specialistcontrol.TaskKMPMatcher,
+			Payload:   append([]byte(nil), candidate.prompt...),
+			IssuedAt:  issuedAt,
+			Deadline:  deadline,
+		})
+	}
+	return requests, nil
+}
+
+// Verify implements specialistcontrol.ExactVerifier.
+func (verifier Verifier) Verify(
+	ctx context.Context,
+	invocation specialistcontrol.Invocation,
+	candidate specialistcontrol.Candidate,
+) (specialistcontrol.Verification, error) {
+	verification := specialistcontrol.Verification{
+		Binding: candidate.Binding, CandidateBinding: candidate.CandidateBinding,
+		Verdict: specialistcontrol.VerificationAbstain,
+	}
+	if ctx == nil {
+		return verification, errors.New("verify KMP candidate: nil context")
+	}
+	if err := ctx.Err(); err != nil {
+		return verification, err
+	}
+	if invocation.Task != specialistcontrol.TaskKMPMatcher || invocation.Binding != candidate.Binding ||
+		candidate.Binding == (specialistcontrol.Binding{}) ||
+		candidate.CandidateBinding == (specialistcontrol.CandidateBinding{}) ||
+		candidate.SpecialistID != verifier.specialistID || candidate.State != specialistcontrol.ResultCompleted {
+		return verification, errors.New("verify KMP candidate: invalid invocation binding")
+	}
+	held, present := verifier.references[referenceKey{runID: invocation.RunID, requestID: invocation.RequestID}]
+	if !present || held.candidateID.String() != invocation.RequestID ||
+		held.promptSHA256 != sha256.Sum256(invocation.Payload) {
+		return verification, errors.New("verify KMP candidate: no exact prompt-bound reference")
+	}
+	input, err := parsePrompt(ctx, invocation.Payload, verifier.limits)
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return verification, err
+		}
+		return verification, errors.New("verify KMP candidate: prompt semantics differ from the held candidate")
+	}
+	if int64(input.totalSize()) != held.effectiveInputSize {
+		return verification, errors.New("verify KMP candidate: prompt semantics differ from the held candidate")
+	}
+	if len(candidate.Payload) == 0 || len(candidate.Payload) > verifier.limits.MaxAnswerBytes {
+		return verification, errors.New("verify KMP candidate: answer crosses verifier bounds")
+	}
+	if bytes.Equal(candidate.Payload, held.answer) {
+		verification.Verdict = specialistcontrol.VerificationExact
+	} else {
+		verification.Verdict = specialistcontrol.VerificationMismatch
+	}
+	return verification, nil
+}
+
+func kmpTaskPlan(
+	source clrsfixture.SourceRecord,
+	contract clrsfixture.GenerationContract,
+) (clrsfixture.TaskPlan, error) {
+	plan, err := contract.Plan(source)
+	if err != nil {
+		return clrsfixture.TaskPlan{}, fmt.Errorf("plan KMP dataset: %w", err)
+	}
+	for _, task := range plan.Tasks {
+		if task.Task == clrsfixture.TaskKMPMatcher {
+			return task, nil
+		}
+	}
+	return clrsfixture.TaskPlan{}, errors.New("generation contract has no KMP task")
+}
+
+func bindPair(pair clrsfixture.PairedExample, limits Limits) (boundCandidate, heldReference, error) {
+	candidate := pair.Candidate
+	verifier := pair.Verifier
+	if candidate.Task != clrsfixture.TaskKMPMatcher ||
+		candidate.LengthSemantics != clrsfixture.LengthDeclaredInput || candidate.UseHints ||
+		candidate.RequestedLength != candidate.EffectiveInputSize ||
+		verifier.CandidateID != candidate.ID {
+		return boundCandidate{}, heldReference{}, errors.New("pair differs from KMP no-hint length semantics")
+	}
+	if candidate.EffectiveInputSize <= 0 || candidate.EffectiveInputSize > int64(limits.MaxValues) {
+		return boundCandidate{}, heldReference{}, fmt.Errorf(
+			"%w: effective input size %d exceeds 1..%d",
+			ErrPromptLimit,
+			candidate.EffectiveInputSize,
+			limits.MaxValues,
+		)
+	}
+	prompt := []byte(candidate.Prompt)
+	input, err := parsePrompt(context.Background(), prompt, limits)
+	if err != nil {
+		return boundCandidate{}, heldReference{}, fmt.Errorf("validate candidate prompt: %w", err)
+	}
+	if int64(input.totalSize()) != candidate.EffectiveInputSize {
+		return boundCandidate{}, heldReference{}, fmt.Errorf(
+			"prompt node count = %d, want effective input size %d",
+			input.totalSize(), candidate.EffectiveInputSize,
+		)
+	}
+	answer := []byte(verifier.Reference)
+	if err := validateReference(context.Background(), answer, limits, input); err != nil {
+		return boundCandidate{}, heldReference{}, err
+	}
+	return boundCandidate{id: candidate.ID, prompt: append([]byte(nil), prompt...)}, heldReference{
+		source:             candidate.Source,
+		contract:           candidate.Contract,
+		candidateID:        candidate.ID,
+		verifierID:         verifier.ID,
+		promptSHA256:       sha256.Sum256(prompt),
+		effectiveInputSize: candidate.EffectiveInputSize,
+		answer:             append([]byte(nil), answer...),
+	}, nil
+}
+
+func validIdentity(value string) bool {
+	if len(value) == 0 || len(value) > maximumIdentityBytes {
+		return false
+	}
+	for index := range len(value) {
+		character := value[index]
+		if (character < 'a' || character > 'z') && (character < 'A' || character > 'Z') &&
+			(character < '0' || character > '9') && character != '.' && character != '_' &&
+			character != ':' && character != '-' {
+			return false
+		}
+	}
+	return true
+}

--- a/tooling/internal/clrskmp/adapter_test.go
+++ b/tooling/internal/clrskmp/adapter_test.go
@@ -1,0 +1,967 @@
+package clrskmp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lusoris/20-watts-was-enough/tooling/internal/clrsfixture"
+	"github.com/lusoris/20-watts-was-enough/tooling/internal/specialistcontrol"
+)
+
+const (
+	testRunID        = "run-001"
+	testSpecialistID = "exact-kmp-v1"
+)
+
+var verticalNow = time.Date(2026, time.August, 31, 12, 0, 0, 0, time.UTC)
+
+type recorderFunc func(context.Context, specialistcontrol.Decision) error
+
+func (function recorderFunc) RecordDecision(ctx context.Context, decision specialistcontrol.Decision) error {
+	return function(ctx, decision)
+}
+
+type specialistFunc func(context.Context, specialistcontrol.Invocation) (specialistcontrol.SpecialistResult, error)
+
+func (function specialistFunc) Invoke(ctx context.Context, invocation specialistcontrol.Invocation) (specialistcontrol.SpecialistResult, error) {
+	return function(ctx, invocation)
+}
+
+type verifierFunc func(context.Context, specialistcontrol.Invocation, specialistcontrol.Candidate) (specialistcontrol.Verification, error)
+
+func (function verifierFunc) Verify(ctx context.Context, invocation specialistcontrol.Invocation, candidate specialistcontrol.Candidate) (specialistcontrol.Verification, error) {
+	return function(ctx, invocation, candidate)
+}
+
+func TestBindDatasetBuildsContractBoundRequestsAndIsolatesReferences(t *testing.T) {
+	t.Parallel()
+	fixture := newImportFixture(t, clrsfixture.TaskKMPMatcher)
+	reorderedVerifiers := cloneVerifierSet(fixture.verifiers)
+	for left, right := 0, len(reorderedVerifiers.Examples)-1; left < right; left, right = left+1, right-1 {
+		reorderedVerifiers.Examples[left], reorderedVerifiers.Examples[right] =
+			reorderedVerifiers.Examples[right], reorderedVerifiers.Examples[left]
+	}
+	requestSet, verifier, err := BindDataset(
+		testRunID,
+		testSpecialistID,
+		fixture.source,
+		fixture.contract,
+		fixture.candidates,
+		reorderedVerifiers,
+		testLimits(),
+		testVerifierLimits(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requests, err := requestSet.Requests(verticalNow.Add(-time.Second), verticalNow.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(requests) != fixture.task.ExpectedExamples {
+		t.Fatalf("request count = %d, want %d", len(requests), fixture.task.ExpectedExamples)
+	}
+	for index, request := range requests {
+		candidate := fixture.candidates.Examples[index]
+		if request.RunID != testRunID || request.RequestID != candidate.ID.String() ||
+			request.Task != specialistcontrol.TaskKMPMatcher ||
+			!bytes.Equal(request.Payload, []byte(candidate.Prompt)) {
+			t.Fatalf("request %d = %#v, candidate %#v", index, request, candidate)
+		}
+		key := referenceKey{runID: testRunID, requestID: request.RequestID}
+		held, present := verifier.references[key]
+		expectedVerifier := fixture.verifiers.Examples[index]
+		if !present || held.source != candidate.Source || held.contract != candidate.Contract ||
+			held.candidateID != candidate.ID || held.verifierID != expectedVerifier.ID ||
+			held.effectiveInputSize != candidate.EffectiveInputSize ||
+			!bytes.Equal(held.answer, []byte(expectedVerifier.Reference)) {
+			t.Fatalf("held reference %d = %#v", index, held)
+		}
+	}
+	for _, candidateType := range []reflect.Type{
+		reflect.TypeOf(RequestSet{}),
+		reflect.TypeOf(boundCandidate{}),
+		reflect.TypeOf(specialistcontrol.Invocation{}),
+	} {
+		for index := 0; index < candidateType.NumField(); index++ {
+			name := strings.ToLower(candidateType.Field(index).Name)
+			if strings.Contains(name, "answer") || strings.Contains(name, "reference") {
+				t.Fatalf("candidate-visible type %s exposes verifier field %q", candidateType, name)
+			}
+		}
+	}
+}
+
+func TestBindDatasetUsesTheExactPinnedKMPTaskPlan(t *testing.T) {
+	t.Parallel()
+	fixture := newImportFixture(t, clrsfixture.TaskKMPMatcher)
+	wantSizes := []clrsfixture.SizeSelection{
+		{Role: clrsfixture.SizePublishedTrain, RequestedLength: 10},
+		{Role: clrsfixture.SizePublishedInterpolation, RequestedLength: 8},
+		{Role: clrsfixture.SizePublishedExtrapolation, RequestedLength: 32},
+	}
+	if fixture.task.Family != clrsfixture.FamilyString ||
+		fixture.task.LengthSemantics != clrsfixture.LengthDeclaredInput ||
+		fixture.task.OutputRelativePath != "shakedown/kmp_matcher.json" ||
+		fixture.task.ExpectedExamples != 9 || !reflect.DeepEqual(fixture.task.Sizes, wantSizes) {
+		t.Fatalf("KMP task plan = %#v, want exact shakedown plan", fixture.task)
+	}
+	if !reflect.DeepEqual(fixture.contract.Seeds, []int64{3, 14, 35}) ||
+		fixture.contract.SamplesPerCell != 1 || fixture.contract.UseHints {
+		t.Fatalf("KMP contract cells = seeds %v, samples %d, hints %t", fixture.contract.Seeds, fixture.contract.SamplesPerCell, fixture.contract.UseHints)
+	}
+}
+
+func TestSpecialistMatchesEveryContractBoundSyntheticCell(t *testing.T) {
+	t.Parallel()
+	fixture := newImportFixture(t, clrsfixture.TaskKMPMatcher)
+	requestSet, _ := bindFixture(t, fixture, testLimits(), testVerifierLimits())
+	requests, err := requestSet.Requests(verticalNow.Add(-time.Second), verticalNow.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	specialist, err := NewSpecialist(testSpecialistID, testLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for index, request := range requests {
+		invocation, _ := verificationInputs(request, nil)
+		result, invokeErr := specialist.Invoke(context.Background(), invocation)
+		want := []byte(fixture.verifiers.Examples[index].Reference)
+		if invokeErr != nil || result.State != specialistcontrol.ResultCompleted ||
+			result.SpecialistID != testSpecialistID || result.Binding != invocation.Binding ||
+			!bytes.Equal(result.Payload, want) {
+			t.Fatalf("cell %d result/error = %#v/%v, want %q", index, result, invokeErr, want)
+		}
+	}
+}
+
+func TestSpecialistClosesIdentityInvocationAndOutputBounds(t *testing.T) {
+	t.Parallel()
+	if _, err := NewSpecialist("bad specialist", testLimits()); err == nil {
+		t.Fatal("NewSpecialist accepted an unsafe identity")
+	}
+	if _, err := NewSpecialist(testSpecialistID, withLimits(func(value *Limits) { value.MaxValues = 0 })); !errors.Is(err, ErrInvalidLimits) {
+		t.Fatalf("NewSpecialist(open limits) error = %v, want ErrInvalidLimits", err)
+	}
+	specialist, err := NewSpecialist(testSpecialistID, testLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixture := newImportFixture(t, clrsfixture.TaskKMPMatcher)
+	requestSet, _ := bindFixture(t, fixture, testLimits(), testVerifierLimits())
+	requests, err := requestSet.Requests(verticalNow.Add(-time.Second), verticalNow.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	invocation, _ := verificationInputs(requests[0], nil)
+	if _, err := specialist.Invoke(nil, invocation); err == nil {
+		t.Fatal("Invoke accepted a nil context")
+	}
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := specialist.Invoke(cancelled, invocation); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Invoke(cancelled) error = %v, want context.Canceled", err)
+	}
+	for name, mutate := range map[string]func(*specialistcontrol.Invocation){
+		"foreign task": func(value *specialistcontrol.Invocation) { value.Task = specialistcontrol.TaskBinarySearch },
+		"zero binding": func(value *specialistcontrol.Invocation) { value.Binding = specialistcontrol.Binding{} },
+		"open output":  func(value *specialistcontrol.Invocation) { value.MaxResultBytes = 0 },
+		"small output": func(value *specialistcontrol.Invocation) { value.MaxResultBytes = 1 },
+	} {
+		changed := invocation
+		mutate(&changed)
+		result, invokeErr := specialist.Invoke(context.Background(), changed)
+		if invokeErr != nil || result.State != specialistcontrol.ResultRefused {
+			t.Fatalf("Invoke(%s) = %#v, error %v, want refusal", name, result, invokeErr)
+		}
+	}
+}
+
+func TestBindDatasetRejectsForeignAndTamperedContractRecords(t *testing.T) {
+	t.Parallel()
+	kmp := newImportFixture(t, clrsfixture.TaskKMPMatcher)
+	insertion := newImportFixture(t, clrsfixture.TaskInsertionSort)
+	if _, _, err := BindDataset(
+		testRunID,
+		testSpecialistID,
+		insertion.source,
+		insertion.contract,
+		insertion.candidates,
+		insertion.verifiers,
+		testLimits(),
+		testVerifierLimits(),
+	); err == nil {
+		t.Fatal("BindDataset accepted a valid foreign task set")
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*clrsfixture.CandidateSet, *clrsfixture.VerifierSet)
+	}{
+		{"candidate identity", func(c *clrsfixture.CandidateSet, _ *clrsfixture.VerifierSet) { c.Examples[0].ID[0] ^= 1 }},
+		{"candidate prompt", func(c *clrsfixture.CandidateSet, _ *clrsfixture.VerifierSet) { c.Examples[0].Prompt += " mutation" }},
+		{"candidate task", func(c *clrsfixture.CandidateSet, _ *clrsfixture.VerifierSet) {
+			c.Examples[0].Task = clrsfixture.TaskInsertionSort
+		}},
+		{"candidate effective size", func(c *clrsfixture.CandidateSet, _ *clrsfixture.VerifierSet) { c.Examples[0].EffectiveInputSize++ }},
+		{"candidate hints", func(c *clrsfixture.CandidateSet, _ *clrsfixture.VerifierSet) { c.Examples[0].UseHints = true }},
+		{"verifier identity", func(_ *clrsfixture.CandidateSet, v *clrsfixture.VerifierSet) { v.Examples[0].ID[0] ^= 1 }},
+		{"verifier answer", func(_ *clrsfixture.CandidateSet, v *clrsfixture.VerifierSet) { v.Examples[0].Reference += " mutation" }},
+		{"missing candidate", func(c *clrsfixture.CandidateSet, _ *clrsfixture.VerifierSet) { c.Examples = c.Examples[1:] }},
+		{"missing verifier", func(_ *clrsfixture.CandidateSet, v *clrsfixture.VerifierSet) { v.Examples = v.Examples[1:] }},
+		{"reordered candidates", func(c *clrsfixture.CandidateSet, _ *clrsfixture.VerifierSet) {
+			c.Examples[0], c.Examples[1] = c.Examples[1], c.Examples[0]
+		}},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			candidates := cloneCandidateSet(kmp.candidates)
+			verifiers := cloneVerifierSet(kmp.verifiers)
+			test.mutate(&candidates, &verifiers)
+			if _, _, err := BindDataset(
+				testRunID,
+				testSpecialistID,
+				kmp.source,
+				kmp.contract,
+				candidates,
+				verifiers,
+				testLimits(),
+				testVerifierLimits(),
+			); err == nil {
+				t.Fatalf("BindDataset accepted %s", test.name)
+			}
+		})
+	}
+
+	foreignSource := kmp.source
+	foreignSource.Commit = "a" + foreignSource.Commit[1:]
+	if _, _, err := BindDataset(
+		testRunID, testSpecialistID, foreignSource, kmp.contract,
+		kmp.candidates, kmp.verifiers, testLimits(), testVerifierLimits(),
+	); err == nil {
+		t.Fatal("BindDataset accepted a source record outside the pinned KMP evidence")
+	}
+	foreignContract := kmp.contract
+	foreignContract.Seeds = append([]int64(nil), kmp.contract.Seeds...)
+	foreignContract.Seeds[0]++
+	if _, _, err := BindDataset(
+		testRunID, testSpecialistID, kmp.source, foreignContract,
+		kmp.candidates, kmp.verifiers, testLimits(), testVerifierLimits(),
+	); err == nil {
+		t.Fatal("BindDataset accepted a mutated generation contract")
+	}
+}
+
+func TestBindDatasetRejectsPromptSemanticsMissingFromTheGenericImporter(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		mutate func(*testExample)
+	}{
+		{"effective input size mismatch", func(example *testExample) {
+			example.prompt, example.reference = kmpExample(3, example.seed)
+		}},
+		{"hint-bearing prompt", func(example *testExample) { example.prompt += "hint:\n" }},
+		{"noncontiguous input split", func(example *testExample) {
+			example.prompt = strings.Replace(example.prompt, "0 0 1 1], key", "0 1 0 1], key", 1)
+		}},
+		{"wrong output marker", func(example *testExample) {
+			example.prompt = strings.Replace(example.prompt, "\nmatch:\n", "\nreturn:\n", 1)
+		}},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			fixture := newImportFixture(t, clrsfixture.TaskKMPMatcher)
+			test.mutate(&fixture.dataset.examples[0])
+			fixture.importDataset(t)
+			if _, _, err := BindDataset(
+				testRunID, testSpecialistID, fixture.source, fixture.contract,
+				fixture.candidates, fixture.verifiers, testLimits(), testVerifierLimits(),
+			); err == nil {
+				t.Fatalf("BindDataset accepted %s", test.name)
+			}
+		})
+	}
+}
+
+func TestBindDatasetRejectsSemanticallyWrongHeldAnswers(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		mutate func(*testExample)
+	}{
+		{"wrong first match", func(example *testExample) { example.reference = "1\n\n" }},
+		{"leading zero", func(example *testExample) { example.reference = "00\n\n" }},
+		{"out of range", func(example *testExample) { example.reference = "99\n\n" }},
+		{"foreign syntax", func(example *testExample) { example.reference = "[0]\n\n" }},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			fixture := newImportFixture(t, clrsfixture.TaskKMPMatcher)
+			test.mutate(&fixture.dataset.examples[0])
+			fixture.importDataset(t)
+			if _, _, err := BindDataset(
+				testRunID, testSpecialistID, fixture.source, fixture.contract,
+				fixture.candidates, fixture.verifiers, testLimits(), testVerifierLimits(),
+			); err == nil {
+				t.Fatalf("BindDataset accepted %s held answer", test.name)
+			}
+		})
+	}
+}
+
+func TestRequestSetAndVerifierSnapshotTheirSeparateInputs(t *testing.T) {
+	t.Parallel()
+	fixture := newImportFixture(t, clrsfixture.TaskKMPMatcher)
+	originalPrompt := fixture.candidates.Examples[0].Prompt
+	originalAnswer := fixture.verifiers.Examples[0].Reference
+	requestSet, verifier := bindFixture(t, fixture, testLimits(), testVerifierLimits())
+	fixture.candidates.Examples[0].Prompt = "mutated"
+	fixture.verifiers.Examples[0].Reference = "mutated"
+
+	requests, err := requestSet.Requests(verticalNow.Add(-time.Second), verticalNow.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	requests[0].Payload[0] = 'X'
+	fresh, err := requestSet.Requests(verticalNow.Add(-time.Second), verticalNow.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(fresh[0].Payload) != originalPrompt {
+		t.Fatalf("fresh request payload = %q, want original prompt", fresh[0].Payload)
+	}
+	invocation, candidate := verificationInputs(fresh[0], []byte(originalAnswer))
+	verification, err := verifier.Verify(context.Background(), invocation, candidate)
+	if err != nil || verification.Verdict != specialistcontrol.VerificationExact {
+		t.Fatalf("Verify(snapshot) = %#v, error %v", verification, err)
+	}
+
+	for name, window := range map[string][2]time.Time{
+		"zero issued":   {{}, verticalNow},
+		"zero deadline": {verticalNow, {}},
+		"equal":         {verticalNow, verticalNow},
+		"reverse":       {verticalNow, verticalNow.Add(-time.Second)},
+	} {
+		if _, err := requestSet.Requests(window[0], window[1]); err == nil {
+			t.Fatalf("Requests accepted %s window", name)
+		}
+	}
+	if _, err := (RequestSet{}).Requests(verticalNow, verticalNow.Add(time.Second)); err == nil {
+		t.Fatal("zero RequestSet produced requests")
+	}
+}
+
+func TestVerifierRejectsRunCandidateAndPromptSubstitution(t *testing.T) {
+	t.Parallel()
+	fixture := newImportFixture(t, clrsfixture.TaskKMPMatcher)
+	requestSet, verifier := bindFixture(t, fixture, testLimits(), testVerifierLimits())
+	requests, err := requestSet.Requests(verticalNow.Add(-time.Second), verticalNow.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	answer := []byte(fixture.verifiers.Examples[0].Reference)
+	invocation, candidate := verificationInputs(requests[0], answer)
+	if verification, err := verifier.Verify(context.Background(), invocation, candidate); err != nil ||
+		verification.Verdict != specialistcontrol.VerificationExact {
+		t.Fatalf("baseline verification = %#v, error %v", verification, err)
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*specialistcontrol.Invocation)
+	}{
+		{"run", func(value *specialistcontrol.Invocation) { value.RunID = "run-foreign" }},
+		{"candidate identity", func(value *specialistcontrol.Invocation) { value.RequestID = requests[3].RequestID }},
+		{"prompt", func(value *specialistcontrol.Invocation) { value.Payload[0] = 'X' }},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			changed := invocation
+			changed.Payload = append([]byte(nil), invocation.Payload...)
+			test.mutate(&changed)
+			if _, err := verifier.Verify(context.Background(), changed, candidate); err == nil {
+				t.Fatalf("Verify accepted %s substitution", test.name)
+			}
+		})
+	}
+	cancelled := &cancelAfterChecksContext{Context: context.Background(), cancelAt: 3}
+	if _, err := verifier.Verify(cancelled, invocation, candidate); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Verify(mid-parse cancellation) error = %v, want context.Canceled", err)
+	}
+}
+
+func TestVerifierRejectsCandidateBindingAndIdentitySubstitution(t *testing.T) {
+	t.Parallel()
+	fixture := newImportFixture(t, clrsfixture.TaskKMPMatcher)
+	requestSet, verifier := bindFixture(t, fixture, testLimits(), testVerifierLimits())
+	requests, err := requestSet.Requests(verticalNow.Add(-time.Second), verticalNow.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	invocation, baseline := verificationInputs(requests[0], []byte(fixture.verifiers.Examples[0].Reference))
+	tests := []struct {
+		name   string
+		mutate func(*specialistcontrol.Candidate)
+	}{
+		{"request binding", func(value *specialistcontrol.Candidate) { value.Binding[0] ^= 1 }},
+		{"candidate binding", func(value *specialistcontrol.Candidate) {
+			value.CandidateBinding = specialistcontrol.CandidateBinding{}
+		}},
+		{"specialist identity", func(value *specialistcontrol.Candidate) { value.SpecialistID = "foreign-kmp" }},
+		{"result state", func(value *specialistcontrol.Candidate) { value.State = specialistcontrol.ResultRefused }},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			changed := baseline
+			changed.Payload = append([]byte(nil), baseline.Payload...)
+			test.mutate(&changed)
+			if _, err := verifier.Verify(context.Background(), invocation, changed); err == nil {
+				t.Fatalf("Verify accepted %s substitution", test.name)
+			}
+		})
+	}
+}
+
+func TestVerifierClosesContextPromptSizeAndAnswerBounds(t *testing.T) {
+	t.Parallel()
+	fixture := newImportFixture(t, clrsfixture.TaskKMPMatcher)
+	requestSet, verifier := bindFixture(t, fixture, testLimits(), testVerifierLimits())
+	requests, err := requestSet.Requests(verticalNow.Add(-time.Second), verticalNow.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	invocation, candidate := verificationInputs(requests[0], []byte(fixture.verifiers.Examples[0].Reference))
+	if _, err := verifier.Verify(nil, invocation, candidate); err == nil {
+		t.Fatal("Verify accepted a nil context")
+	}
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := verifier.Verify(cancelled, invocation, candidate); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Verify(cancelled) error = %v, want context.Canceled", err)
+	}
+	for name, payload := range map[string][]byte{
+		"empty":     nil,
+		"oversized": bytes.Repeat([]byte{'0'}, testLimits().MaxAnswerBytes+1),
+	} {
+		changed := candidate
+		changed.Payload = payload
+		if _, err := verifier.Verify(context.Background(), invocation, changed); err == nil {
+			t.Fatalf("Verify accepted %s candidate payload", name)
+		}
+	}
+
+	tampered := verifier
+	tampered.references = make(map[referenceKey]heldReference, len(verifier.references))
+	for key, held := range verifier.references {
+		tampered.references[key] = held
+	}
+	key := referenceKey{runID: invocation.RunID, requestID: invocation.RequestID}
+	held := tampered.references[key]
+	held.effectiveInputSize++
+	tampered.references[key] = held
+	if _, err := tampered.Verify(context.Background(), invocation, candidate); err == nil {
+		t.Fatal("Verify accepted a held effective-size substitution")
+	}
+}
+
+func TestBindDatasetClosesRunAndReferenceBounds(t *testing.T) {
+	t.Parallel()
+	fixture := newImportFixture(t, clrsfixture.TaskKMPMatcher)
+	tests := []struct {
+		name             string
+		runID            string
+		specialistID     string
+		limits           Limits
+		verifierLimits   VerifierLimits
+		wantReferenceErr bool
+	}{
+		{"empty run", "", testSpecialistID, testLimits(), testVerifierLimits(), false},
+		{"bad specialist", testRunID, "bad specialist", testLimits(), testVerifierLimits(), false},
+		{"open reference count", testRunID, testSpecialistID, testLimits(), VerifierLimits{MaxReferenceBytes: 1024}, true},
+		{"small reference count", testRunID, testSpecialistID, testLimits(), VerifierLimits{MaxReferences: 8, MaxReferenceBytes: 16 << 10}, true},
+		{"small reference bytes", testRunID, testSpecialistID, testLimits(), VerifierLimits{MaxReferences: 16, MaxReferenceBytes: 1}, true},
+		{"small value count", testRunID, testSpecialistID, withLimits(func(value *Limits) { value.MaxValues = 8 }), testVerifierLimits(), false},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			_, _, err := BindDataset(
+				test.runID, test.specialistID, fixture.source, fixture.contract,
+				fixture.candidates, fixture.verifiers, test.limits, test.verifierLimits,
+			)
+			if err == nil {
+				t.Fatalf("BindDataset accepted %s", test.name)
+			}
+			if test.wantReferenceErr && !errors.Is(err, ErrReferenceLimit) {
+				t.Fatalf("BindDataset(%s) error = %v, want ErrReferenceLimit", test.name, err)
+			}
+		})
+	}
+}
+
+func TestKMPVerticalRecordsBeforeEffectAndKeepsReferenceOutOfSpecialist(t *testing.T) {
+	t.Parallel()
+	runner, events, request, reference := verticalRunner(t, nil)
+	run, err := runner.Run(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.Decision.State != specialistcontrol.DecisionInvoke ||
+		run.Outcome.State != specialistcontrol.OutcomeVerified ||
+		run.Outcome.Authority != specialistcontrol.ResultAuthority ||
+		!bytes.Equal(run.Outcome.Payload, reference) {
+		t.Fatalf("vertical outcome = %#v", run)
+	}
+	if !reflect.DeepEqual(*events, []string{"record", "invoke", "verify"}) {
+		t.Fatalf("effect order = %v, want record/invoke/verify", *events)
+	}
+}
+
+func TestKMPVerticalRefusesMalformedAndOversizedInputBeforeVerification(t *testing.T) {
+	t.Parallel()
+	fixture := newImportFixture(t, clrsfixture.TaskKMPMatcher)
+	requestSet, verifier := bindFixture(t, fixture, testLimits(), testVerifierLimits())
+	requests, err := requestSet.Requests(verticalNow.Add(-time.Second), verticalNow.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, prompt := range map[string][]byte{
+		"malformed": []byte("kmp_matcher:\nstring: [0 1 0], key: [0 1 2]\nmatch:\n"),
+		"oversized": []byte("kmp_matcher:\nstring: [0 0 0 1], key: [3 3 0 0]\nmatch:\n"),
+	} {
+		name, prompt := name, prompt
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			limits := testLimits()
+			limits.MaxValues = 3
+			specialist, err := NewSpecialist(testSpecialistID, limits)
+			if err != nil {
+				t.Fatal(err)
+			}
+			verifierCalled := false
+			observedVerifier := verifierFunc(func(ctx context.Context, invocation specialistcontrol.Invocation, candidate specialistcontrol.Candidate) (specialistcontrol.Verification, error) {
+				verifierCalled = true
+				return verifier.Verify(ctx, invocation, candidate)
+			})
+			runner := newVerticalRunner(
+				t, specialist,
+				recorderFunc(func(context.Context, specialistcontrol.Decision) error { return nil }),
+				observedVerifier, func() time.Time { return verticalNow },
+			)
+			request := requests[0]
+			request.Payload = prompt
+			run, runErr := runner.Run(context.Background(), request)
+			if runErr != nil || verifierCalled || run.Outcome.State != specialistcontrol.OutcomeRefused ||
+				run.Outcome.Reason != specialistcontrol.ReasonSpecialistRefused ||
+				run.Outcome.Authority != specialistcontrol.ResultAuthority {
+				t.Fatalf("Run(%s) error/verifier/outcome = %v/%t/%#v", name, runErr, verifierCalled, run.Outcome)
+			}
+		})
+	}
+}
+
+func TestKMPVerticalTypesCancellationAndDeadlineAsNoResult(t *testing.T) {
+	t.Parallel()
+	t.Run("cancelled", func(t *testing.T) {
+		t.Parallel()
+		runner, _, request, _ := verticalRunner(t, nil)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		run, err := runner.Run(ctx, request)
+		if !errors.Is(err, context.Canceled) || run.Outcome.State != specialistcontrol.OutcomeAbstained ||
+			run.Outcome.Reason != specialistcontrol.ReasonCancelled ||
+			run.Outcome.Authority != specialistcontrol.ResultAuthority {
+			t.Fatalf("cancelled outcome/error = %#v/%v", run.Outcome, err)
+		}
+	})
+
+	t.Run("deadline", func(t *testing.T) {
+		t.Parallel()
+		fixture := newImportFixture(t, clrsfixture.TaskKMPMatcher)
+		requestSet, verifier := bindFixture(t, fixture, testLimits(), testVerifierLimits())
+		requests, err := requestSet.Requests(verticalNow.Add(-time.Second), verticalNow.Add(time.Second))
+		if err != nil {
+			t.Fatal(err)
+		}
+		specialist, err := NewSpecialist(testSpecialistID, testLimits())
+		if err != nil {
+			t.Fatal(err)
+		}
+		calls := 0
+		clock := func() time.Time {
+			calls++
+			if calls == 2 {
+				return requests[0].Deadline
+			}
+			return verticalNow
+		}
+		invoked := false
+		runner := newVerticalRunner(
+			t,
+			specialistFunc(func(ctx context.Context, invocation specialistcontrol.Invocation) (specialistcontrol.SpecialistResult, error) {
+				invoked = true
+				return specialist.Invoke(ctx, invocation)
+			}),
+			recorderFunc(func(context.Context, specialistcontrol.Decision) error { return nil }),
+			verifier, clock,
+		)
+		run, runErr := runner.Run(context.Background(), requests[0])
+		if runErr != nil || invoked || run.Outcome.State != specialistcontrol.OutcomeAbstained ||
+			run.Outcome.Reason != specialistcontrol.ReasonDeadlineElapsed ||
+			run.Outcome.Authority != specialistcontrol.ResultAuthority {
+			t.Fatalf("deadline outcome/error/invoked = %#v/%v/%t", run.Outcome, runErr, invoked)
+		}
+	})
+}
+
+func TestKMPVerticalAbstainsOnWrongAnswer(t *testing.T) {
+	t.Parallel()
+	fixture := newImportFixture(t, clrsfixture.TaskKMPMatcher)
+	requestSet, verifier := bindFixture(t, fixture, testLimits(), testVerifierLimits())
+	requests, err := requestSet.Requests(verticalNow.Add(-time.Second), verticalNow.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrong := specialistFunc(func(_ context.Context, invocation specialistcontrol.Invocation) (specialistcontrol.SpecialistResult, error) {
+		return specialistcontrol.SpecialistResult{
+			Binding: invocation.Binding, SpecialistID: testSpecialistID,
+			State: specialistcontrol.ResultCompleted, Payload: []byte("99\n\n"),
+		}, nil
+	})
+	runner := newVerticalRunner(
+		t, wrong,
+		recorderFunc(func(context.Context, specialistcontrol.Decision) error { return nil }),
+		verifier, func() time.Time { return verticalNow },
+	)
+	run, runErr := runner.Run(context.Background(), requests[0])
+	if runErr != nil || run.Outcome.State != specialistcontrol.OutcomeAbstained ||
+		run.Outcome.Reason != specialistcontrol.ReasonVerificationMismatch ||
+		run.Outcome.Authority != specialistcontrol.ResultAuthority || len(run.Outcome.Payload) != 0 {
+		t.Fatalf("wrong-answer outcome/error = %#v/%v", run.Outcome, runErr)
+	}
+}
+
+func verticalRunner(
+	t *testing.T,
+	clock func() time.Time,
+) (specialistcontrol.Runner, *[]string, specialistcontrol.Request, []byte) {
+	t.Helper()
+	if clock == nil {
+		clock = func() time.Time { return verticalNow }
+	}
+	fixture := newImportFixture(t, clrsfixture.TaskKMPMatcher)
+	requestSet, verifier := bindFixture(t, fixture, testLimits(), testVerifierLimits())
+	requests, err := requestSet.Requests(verticalNow.Add(-time.Second), verticalNow.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	reference := []byte(fixture.verifiers.Examples[0].Reference)
+	specialist, err := NewSpecialist(testSpecialistID, testLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	events := make([]string, 0, 3)
+	observedSpecialist := specialistFunc(func(ctx context.Context, invocation specialistcontrol.Invocation) (specialistcontrol.SpecialistResult, error) {
+		events = append(events, "invoke")
+		if bytes.Contains(invocation.Payload, reference) {
+			t.Fatal("verifier-only reference bytes leaked into the specialist request")
+		}
+		return specialist.Invoke(ctx, invocation)
+	})
+	observedVerifier := verifierFunc(func(ctx context.Context, invocation specialistcontrol.Invocation, candidate specialistcontrol.Candidate) (specialistcontrol.Verification, error) {
+		events = append(events, "verify")
+		return verifier.Verify(ctx, invocation, candidate)
+	})
+	runner := newVerticalRunner(
+		t, observedSpecialist,
+		recorderFunc(func(context.Context, specialistcontrol.Decision) error {
+			events = append(events, "record")
+			return nil
+		}),
+		observedVerifier, clock,
+	)
+	return runner, &events, requests[0], reference
+}
+
+func newVerticalRunner(
+	t *testing.T,
+	target specialistcontrol.Specialist,
+	recorder specialistcontrol.DecisionRecorder,
+	verifier specialistcontrol.ExactVerifier,
+	clock func() time.Time,
+) specialistcontrol.Runner {
+	t.Helper()
+	routes := make([]specialistcontrol.Route, 0, len(specialistcontrol.Tasks()))
+	specialists := make(map[string]specialistcontrol.Specialist, len(specialistcontrol.Tasks()))
+	for _, task := range specialistcontrol.Tasks() {
+		id := "unavailable-" + string(task)
+		if task == specialistcontrol.TaskKMPMatcher {
+			id = testSpecialistID
+			specialists[id] = target
+		} else {
+			specialists[id] = specialistFunc(func(_ context.Context, invocation specialistcontrol.Invocation) (specialistcontrol.SpecialistResult, error) {
+				return specialistcontrol.SpecialistResult{
+					Binding: invocation.Binding, SpecialistID: "unavailable-" + string(invocation.Task),
+					State: specialistcontrol.ResultAbstained,
+				}, nil
+			})
+		}
+		routes = append(routes, specialistcontrol.Route{Task: task, SpecialistID: id})
+	}
+	policy, err := specialistcontrol.NewPolicy(specialistcontrol.Limits{
+		MaxRequestBytes: 1024,
+		MaxResultBytes:  1024,
+		MaxRequestAge:   2 * time.Second,
+		MaxExecution:    2 * time.Second,
+	}, routes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner, err := specialistcontrol.NewRunner(policy, recorder, specialists, verifier, clock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return runner
+}
+
+type testExample struct {
+	prompt    string
+	reference string
+	length    int64
+	seed      int64
+	useHints  bool
+}
+
+type testDataset struct {
+	name     string
+	examples []testExample
+}
+
+type importFixture struct {
+	source     clrsfixture.SourceRecord
+	contract   clrsfixture.GenerationContract
+	task       clrsfixture.TaskPlan
+	dataset    testDataset
+	candidates clrsfixture.CandidateSet
+	verifiers  clrsfixture.VerifierSet
+}
+
+func newImportFixture(t *testing.T, task clrsfixture.TaskKind) importFixture {
+	t.Helper()
+	sourceBody := readGeneratorFile(t, "upstream.json")
+	source, err := clrsfixture.ParseSourceRecord(sourceBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	contractBody := readGeneratorFile(t, "contract.json")
+	contract, err := clrsfixture.ParseGenerationContract(contractBody, source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := contract.Plan(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var selected clrsfixture.TaskPlan
+	for _, candidate := range plan.Tasks {
+		if candidate.Task == task {
+			selected = candidate
+			break
+		}
+	}
+	if selected.Task == "" {
+		t.Fatalf("task %s is absent from tracked contract", task)
+	}
+	fixture := importFixture{
+		source: source, contract: contract, task: selected,
+		dataset: makeTestDataset(plan, selected),
+	}
+	fixture.importDataset(t)
+	return fixture
+}
+
+func (fixture *importFixture) importDataset(t *testing.T) {
+	t.Helper()
+	body, err := json.Marshal(fixture.dataset.jsonValue())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixture.candidates, fixture.verifiers, err = clrsfixture.ImportDataset(
+		bytes.NewReader(body),
+		fixture.source,
+		fixture.contract,
+		fixture.task.OutputRelativePath,
+		testImportLimits(),
+	)
+	if err != nil {
+		t.Fatalf("import synthetic contract-bound %s dataset: %v", fixture.task.Task, err)
+	}
+}
+
+func makeTestDataset(plan clrsfixture.GenerationPlan, task clrsfixture.TaskPlan) testDataset {
+	dataset := testDataset{name: "clrs_text_" + string(task.Task)}
+	for _, size := range task.Sizes {
+		for _, seed := range plan.Seeds {
+			for sample := 0; sample < plan.SamplesPerCell; sample++ {
+				prompt := fmt.Sprintf("%s:\ninput: %d/%d/%d", task.Task, size.RequestedLength, seed, sample)
+				reference := fmt.Sprintf("reference-%d-%d-%d", size.RequestedLength, seed, sample)
+				if task.Task == clrsfixture.TaskKMPMatcher {
+					prompt, reference = kmpExample(size.RequestedLength, seed)
+				}
+				dataset.examples = append(dataset.examples, testExample{
+					prompt: prompt, reference: reference,
+					length: size.RequestedLength, seed: seed, useHints: plan.UseHints,
+				})
+			}
+		}
+	}
+	return dataset
+}
+
+func (dataset testDataset) jsonValue() map[string]any {
+	examples := make([]any, 0, len(dataset.examples))
+	for _, example := range dataset.examples {
+		examples = append(examples, map[string]any{
+			"prompt":     example.prompt,
+			"references": []string{example.reference},
+			"auxiliary": map[string]any{
+				"length": example.length, "seed": example.seed, "use_hints": example.useHints,
+			},
+		})
+	}
+	return map[string]any{"name": dataset.name, "examples": examples}
+}
+
+func kmpExample(length, seed int64) (string, string) {
+	totalLength := int(length)
+	needleLength := pinnedNeedleLength(totalLength)
+	haystackLength := totalLength - needleLength
+	needle := make([]string, needleLength)
+	for index := range needle {
+		needle[index] = strconv.Itoa((index + int(seed)) % (alphabetSize - 1))
+	}
+	haystack := make([]string, haystackLength)
+	for index := range haystack {
+		haystack[index] = strconv.Itoa(alphabetSize - 1)
+	}
+	maximumStartExclusive := haystackLength - needleLength
+	matchIndex := 0
+	switch seed {
+	case 14:
+		matchIndex = maximumStartExclusive / 2
+	case 35:
+		matchIndex = maximumStartExclusive - 1
+	}
+	copy(haystack[matchIndex:matchIndex+needleLength], needle)
+	mask := make([]string, 0, totalLength)
+	for range haystackLength {
+		mask = append(mask, "0")
+	}
+	for range needleLength {
+		mask = append(mask, "1")
+	}
+	key := append(append(make([]string, 0, totalLength), haystack...), needle...)
+	prompt := "kmp_matcher:\nstring: [" + strings.Join(mask, " ") + "], key: [" + strings.Join(key, " ") + "]\nmatch:\n"
+	return prompt, strconv.Itoa(matchIndex) + "\n\n"
+}
+
+func readGeneratorFile(t *testing.T, name string) []byte {
+	t.Helper()
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("locate KMP adapter test")
+	}
+	body, err := os.ReadFile(filepath.Join(filepath.Dir(filename), "..", "..", "clrs-generator", name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return body
+}
+
+func bindFixture(
+	t *testing.T,
+	fixture importFixture,
+	limits Limits,
+	verifierLimits VerifierLimits,
+) (RequestSet, Verifier) {
+	t.Helper()
+	requestSet, verifier, err := BindDataset(
+		testRunID,
+		testSpecialistID,
+		fixture.source,
+		fixture.contract,
+		fixture.candidates,
+		fixture.verifiers,
+		limits,
+		verifierLimits,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return requestSet, verifier
+}
+
+func verificationInputs(
+	request specialistcontrol.Request,
+	answer []byte,
+) (specialistcontrol.Invocation, specialistcontrol.Candidate) {
+	invocation := specialistcontrol.Invocation{
+		RunID: request.RunID, RequestID: request.RequestID, Task: request.Task,
+		Payload: append([]byte(nil), request.Payload...), Binding: specialistcontrol.Binding{1},
+		Deadline: request.Deadline, MaxResultBytes: 1024,
+	}
+	candidate := specialistcontrol.Candidate{
+		Binding: invocation.Binding, CandidateBinding: specialistcontrol.CandidateBinding{1},
+		SpecialistID: testSpecialistID, State: specialistcontrol.ResultCompleted,
+		Payload: append([]byte(nil), answer...),
+	}
+	return invocation, candidate
+}
+
+func cloneCandidateSet(set clrsfixture.CandidateSet) clrsfixture.CandidateSet {
+	set.Examples = append([]clrsfixture.CandidateExample(nil), set.Examples...)
+	return set
+}
+
+func cloneVerifierSet(set clrsfixture.VerifierSet) clrsfixture.VerifierSet {
+	set.Examples = append([]clrsfixture.VerifierExample(nil), set.Examples...)
+	return set
+}
+
+func testImportLimits() clrsfixture.ImportLimits {
+	return clrsfixture.ImportLimits{
+		MaxDatasetBytes: 1 << 20, MaxExamples: 16,
+		MaxPromptBytes: 512, MaxReferenceBytes: 512, MaxDeclaredLength: 64,
+	}
+}
+
+func testVerifierLimits() VerifierLimits {
+	return VerifierLimits{MaxReferences: 16, MaxReferenceBytes: 16 << 10}
+}
+
+func withLimits(change func(*Limits)) Limits {
+	limits := testLimits()
+	change(&limits)
+	return limits
+}

--- a/tooling/internal/clrskmp/prompt.go
+++ b/tooling/internal/clrskmp/prompt.go
@@ -1,0 +1,306 @@
+package clrskmp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+)
+
+const (
+	promptPrefix = "kmp_matcher:\nstring: ["
+	keyMarker    = "], key: ["
+	promptSuffix = "]\nmatch:\n"
+	answerSuffix = "\n\n"
+
+	alphabetSize              = 4
+	maximumPromptBytesCeiling = 1 << 20
+	maximumValuesCeiling      = 4_096
+	maximumAnswerBytesCeiling = 1 << 20
+)
+
+var (
+	// ErrInvalidLimits means a caller did not close every parser/output bound.
+	ErrInvalidLimits = errors.New("invalid KMP limits")
+	// ErrMalformedPrompt means bytes do not match the bounded no-hint grammar.
+	ErrMalformedPrompt = errors.New("malformed KMP prompt")
+	// ErrPromptLimit means candidate-visible input crossed a configured bound.
+	ErrPromptLimit = errors.New("KMP prompt limit exceeded")
+	// ErrAnswerLimit means the exact answer crossed a configured output bound.
+	ErrAnswerLimit = errors.New("KMP answer limit exceeded")
+)
+
+// Limits are parser safety caps, not selected experiment sizes.
+type Limits struct {
+	MaxPromptBytes int
+	MaxValues      int
+	MaxAnswerBytes int
+}
+
+// Validate rejects open or impractically large bounds.
+func (limits Limits) Validate() error {
+	if limits.MaxPromptBytes <= 0 || limits.MaxPromptBytes > maximumPromptBytesCeiling ||
+		limits.MaxValues <= 0 || limits.MaxValues > maximumValuesCeiling ||
+		limits.MaxAnswerBytes <= 0 || limits.MaxAnswerBytes > maximumAnswerBytesCeiling {
+		return ErrInvalidLimits
+	}
+	return nil
+}
+
+type matchInput struct {
+	haystack []byte
+	needle   []byte
+}
+
+func (input matchInput) totalSize() int {
+	return len(input.haystack) + len(input.needle)
+}
+
+// Solve returns the first exact haystack match, or the haystack length when no
+// match exists, for the bounded no-hint categorical grammar. A successful
+// answer is construction evidence and remains NO_RESULT.
+func Solve(ctx context.Context, prompt []byte, limits Limits) ([]byte, error) {
+	if ctx == nil {
+		return nil, errors.New("solve KMP matcher: nil context")
+	}
+	if err := limits.Validate(); err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	input, err := parsePrompt(ctx, prompt, limits)
+	if err != nil {
+		return nil, err
+	}
+	index, err := kmpFirstMatch(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+	answer := []byte(strconv.Itoa(index) + answerSuffix)
+	if len(answer) > limits.MaxAnswerBytes {
+		return nil, fmt.Errorf("%w: %d bytes exceeds %d", ErrAnswerLimit, len(answer), limits.MaxAnswerBytes)
+	}
+	return answer, nil
+}
+
+func parsePrompt(ctx context.Context, prompt []byte, limits Limits) (matchInput, error) {
+	if len(prompt) > limits.MaxPromptBytes {
+		return matchInput{}, fmt.Errorf("%w: %d bytes exceeds %d", ErrPromptLimit, len(prompt), limits.MaxPromptBytes)
+	}
+	if len(prompt) == 0 || !utf8.Valid(prompt) {
+		return matchInput{}, ErrMalformedPrompt
+	}
+	body, found := strings.CutPrefix(string(prompt), promptPrefix)
+	if !found {
+		return matchInput{}, fmt.Errorf("%w: wrong task or string marker", ErrMalformedPrompt)
+	}
+	body, found = strings.CutSuffix(body, promptSuffix)
+	if !found {
+		return matchInput{}, fmt.Errorf("%w: wrong output marker", ErrMalformedPrompt)
+	}
+	maskBody, keyBody, found := strings.Cut(body, keyMarker)
+	if !found || maskBody == "" || keyBody == "" {
+		return matchInput{}, fmt.Errorf("%w: missing string mask or categorical key", ErrMalformedPrompt)
+	}
+	maskTokens, err := boundedTokens(maskBody, limits.MaxValues, "string mask")
+	if err != nil {
+		return matchInput{}, err
+	}
+	keyTokens, err := boundedTokens(keyBody, limits.MaxValues, "categorical key")
+	if err != nil {
+		return matchInput{}, err
+	}
+	if len(maskTokens) != len(keyTokens) {
+		return matchInput{}, fmt.Errorf("%w: string mask has %d nodes but key has %d", ErrMalformedPrompt, len(maskTokens), len(keyTokens))
+	}
+	haystackLength, err := parseStringMask(ctx, maskTokens)
+	if err != nil {
+		return matchInput{}, err
+	}
+	keys, err := parseCategoricalKey(ctx, keyTokens)
+	if err != nil {
+		return matchInput{}, err
+	}
+	return matchInput{
+		haystack: append([]byte(nil), keys[:haystackLength]...),
+		needle:   append([]byte(nil), keys[haystackLength:]...),
+	}, nil
+}
+
+func boundedTokens(body string, maximum int, field string) ([]string, error) {
+	tokens := strings.Split(body, " ")
+	if len(tokens) > maximum {
+		return nil, fmt.Errorf("%w: %s has %d nodes, exceeds %d", ErrPromptLimit, field, len(tokens), maximum)
+	}
+	if len(tokens) == 0 || tokens[0] == "" {
+		return nil, fmt.Errorf("%w: %s is empty", ErrMalformedPrompt, field)
+	}
+	return tokens, nil
+}
+
+func parseStringMask(ctx context.Context, tokens []string) (int, error) {
+	haystackLength := 0
+	needleLength := 0
+	inNeedle := false
+	for index, token := range tokens {
+		if err := ctx.Err(); err != nil {
+			return 0, err
+		}
+		switch token {
+		case "0":
+			if inNeedle {
+				return 0, fmt.Errorf("%w: string mask returns to the haystack at node %d", ErrMalformedPrompt, index)
+			}
+			haystackLength++
+		case "1":
+			inNeedle = true
+			needleLength++
+		default:
+			return 0, fmt.Errorf("%w: string mask node %d is not 0 or 1", ErrMalformedPrompt, index)
+		}
+	}
+	if haystackLength == 0 || needleLength == 0 || haystackLength <= needleLength {
+		return 0, fmt.Errorf("%w: string mask does not contain a longer haystack followed by a needle", ErrMalformedPrompt)
+	}
+	expectedNeedle := pinnedNeedleLength(len(tokens))
+	if needleLength != expectedNeedle {
+		return 0, fmt.Errorf("%w: needle length = %d, want pinned sampler length %d", ErrMalformedPrompt, needleLength, expectedNeedle)
+	}
+	return haystackLength, nil
+}
+
+func parseCategoricalKey(ctx context.Context, tokens []string) ([]byte, error) {
+	values := make([]byte, 0, len(tokens))
+	for index, token := range tokens {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if len(token) != 1 || token[0] < '0' || token[0] >= '0'+alphabetSize {
+			return nil, fmt.Errorf("%w: key node %d is outside categorical alphabet 0..%d", ErrMalformedPrompt, index, alphabetSize-1)
+		}
+		values = append(values, token[0]-'0')
+	}
+	return values, nil
+}
+
+func pinnedNeedleLength(totalLength int) int {
+	if totalLength < 5 {
+		return 1
+	}
+	return totalLength / 5
+}
+
+func kmpFirstMatch(ctx context.Context, input matchInput) (int, error) {
+	if ctx == nil {
+		return 0, errors.New("match KMP input: nil context")
+	}
+	if len(input.haystack) == 0 || len(input.needle) == 0 {
+		return 0, errors.New("match KMP input: haystack and needle must be non-empty")
+	}
+	prefix, err := prefixTable(ctx, input.needle)
+	if err != nil {
+		return 0, err
+	}
+	matched := 0
+	for index, value := range input.haystack {
+		if err := ctx.Err(); err != nil {
+			return 0, err
+		}
+		for matched > 0 && input.needle[matched] != value {
+			if err := ctx.Err(); err != nil {
+				return 0, err
+			}
+			matched = prefix[matched-1]
+		}
+		if input.needle[matched] == value {
+			matched++
+		}
+		if matched == len(input.needle) {
+			return index - len(input.needle) + 1, nil
+		}
+	}
+	return len(input.haystack), nil
+}
+
+func prefixTable(ctx context.Context, needle []byte) ([]int, error) {
+	prefix := make([]int, len(needle))
+	for index, matched := 1, 0; index < len(needle); index++ {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		for matched > 0 && needle[matched] != needle[index] {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+			matched = prefix[matched-1]
+		}
+		if needle[matched] == needle[index] {
+			matched++
+		}
+		prefix[index] = matched
+	}
+	return prefix, nil
+}
+
+func parseAnswer(reference []byte, limits Limits, haystackLength int) (int, error) {
+	if len(reference) == 0 || len(reference) > limits.MaxAnswerBytes || !utf8.Valid(reference) {
+		return 0, fmt.Errorf("%w: reference must contain 1..%d UTF-8 bytes", ErrAnswerLimit, limits.MaxAnswerBytes)
+	}
+	body, found := strings.CutSuffix(string(reference), answerSuffix)
+	if !found || body == "" || (len(body) > 1 && body[0] == '0') {
+		return 0, errors.New("reference is not one canonical non-negative index")
+	}
+	for index := range len(body) {
+		if body[index] < '0' || body[index] > '9' {
+			return 0, errors.New("reference is not one canonical non-negative index")
+		}
+	}
+	parsed, err := strconv.ParseUint(body, 10, 31)
+	if err != nil || parsed > uint64(haystackLength) {
+		return 0, fmt.Errorf("reference index is outside 0..%d", haystackLength)
+	}
+	return int(parsed), nil
+}
+
+// validateReference independently proves the held index with a naive scan. It
+// deliberately does not call Solve, kmpFirstMatch or prefixTable.
+func validateReference(ctx context.Context, reference []byte, limits Limits, input matchInput) error {
+	index, err := parseAnswer(reference, limits, len(input.haystack))
+	if err != nil {
+		return err
+	}
+	expected, err := naiveFirstMatch(ctx, input)
+	if err != nil {
+		return err
+	}
+	if index != expected {
+		return fmt.Errorf("reference index = %d, want first-match index %d", index, expected)
+	}
+	return nil
+}
+
+func naiveFirstMatch(ctx context.Context, input matchInput) (int, error) {
+	lastStart := len(input.haystack) - len(input.needle)
+	for start := 0; start <= lastStart; start++ {
+		if err := ctx.Err(); err != nil {
+			return 0, err
+		}
+		matches := true
+		for offset, value := range input.needle {
+			if err := ctx.Err(); err != nil {
+				return 0, err
+			}
+			if input.haystack[start+offset] != value {
+				matches = false
+				break
+			}
+		}
+		if matches {
+			return start, nil
+		}
+	}
+	return len(input.haystack), nil
+}

--- a/tooling/internal/clrskmp/prompt_test.go
+++ b/tooling/internal/clrskmp/prompt_test.go
@@ -1,0 +1,259 @@
+package clrskmp
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/lusoris/20-watts-was-enough/tooling/internal/clrsfixture"
+)
+
+type cancelAfterChecksContext struct {
+	context.Context
+	cancelAt int
+	checks   int
+}
+
+func (ctx *cancelAfterChecksContext) Err() error {
+	ctx.checks++
+	if ctx.checks >= ctx.cancelAt {
+		return context.Canceled
+	}
+	return nil
+}
+
+func TestSolveMatchesPinnedNoHintPromptAndReferenceGrammar(t *testing.T) {
+	t.Parallel()
+	prompt := []byte("kmp_matcher:\nstring: [0 0 0 0 0 0 0 0 1 1], key: [3 2 1 2 3 0 0 0 1 2]\nmatch:\n")
+	want := "2\n\n"
+	first, err := Solve(context.Background(), prompt, testLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := Solve(context.Background(), prompt, testLimits())
+	if err != nil || string(first) != want || string(second) != want {
+		t.Fatalf("Solve() = %q/%q, error %v, want exact %q", first, second, err, want)
+	}
+}
+
+func TestSolveReturnsFirstOverlapOrHaystackLength(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		prompt string
+		want   string
+	}{
+		"first match": {
+			prompt: "kmp_matcher:\nstring: [0 0 0 0 0 0 0 0 1 1], key: [1 2 1 2 3 0 0 0 1 2]\nmatch:\n",
+			want:   "0\n\n",
+		},
+		"overlap fallback": {
+			prompt: "kmp_matcher:\nstring: [0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1 1 1], key: [0 1 0 0 1 0 1 3 3 3 3 3 3 3 3 3 0 1 0 1]\nmatch:\n",
+			want:   "3\n\n",
+		},
+		"single-symbol needle": {
+			prompt: "kmp_matcher:\nstring: [0 0 0 0 0 0 0 1], key: [3 2 1 0 3 3 3 0]\nmatch:\n",
+			want:   "3\n\n",
+		},
+		"no match sentinel": {
+			prompt: "kmp_matcher:\nstring: [0 0 0 0 0 0 0 0 1 1], key: [3 3 3 3 3 3 3 3 0 1]\nmatch:\n",
+			want:   "8\n\n",
+		},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			answer, err := Solve(context.Background(), []byte(test.prompt), testLimits())
+			if err != nil || string(answer) != test.want {
+				t.Fatalf("Solve() = %q, error %v, want %q", answer, err, test.want)
+			}
+		})
+	}
+}
+
+func TestKMPMatchesIndependentStandardLibraryOracleExhaustively(t *testing.T) {
+	t.Parallel()
+	for haystackLength := 1; haystackLength <= 7; haystackLength++ {
+		for needleLength := 1; needleLength <= 4; needleLength++ {
+			for haystackWord := 0; haystackWord < 1<<haystackLength; haystackWord++ {
+				haystack := binaryWord(haystackWord, haystackLength)
+				for needleWord := 0; needleWord < 1<<needleLength; needleWord++ {
+					needle := binaryWord(needleWord, needleLength)
+					got, err := kmpFirstMatch(context.Background(), matchInput{haystack: haystack, needle: needle})
+					if err != nil {
+						t.Fatal(err)
+					}
+					want := bytes.Index(haystack, needle)
+					if want < 0 {
+						want = len(haystack)
+					}
+					if got != want {
+						t.Fatalf("KMP(%v, %v) = %d, want %d", haystack, needle, got, want)
+					}
+				}
+			}
+		}
+	}
+}
+
+func TestSolveRejectsMalformedAndOversizedPrompts(t *testing.T) {
+	t.Parallel()
+	valid := "kmp_matcher:\nstring: [0 0 0 0 0 0 0 0 1 1], key: [3 2 1 2 3 0 0 0 1 2]\nmatch:\n"
+	tests := map[string]struct {
+		prompt string
+		mutate func(*Limits)
+		want   error
+	}{
+		"wrong task":       {prompt: strings.Replace(valid, "kmp_matcher", "naive_string_matcher", 1), want: ErrMalformedPrompt},
+		"hinted trace":     {prompt: strings.Replace(valid, "\nmatch:\n", ", initial_trace: [0]\ntrace | s:\n", 1), want: ErrMalformedPrompt},
+		"needle first":     {prompt: strings.Replace(valid, "string: [0", "string: [1", 1), want: ErrMalformedPrompt},
+		"split returns":    {prompt: strings.Replace(valid, "0 0 1 1]", "0 1 0 1]", 1), want: ErrMalformedPrompt},
+		"wrong split size": {prompt: strings.Replace(valid, "0 0 1 1]", "0 1 1 1]", 1), want: ErrMalformedPrompt},
+		"mask category":    {prompt: strings.Replace(valid, "string: [0", "string: [2", 1), want: ErrMalformedPrompt},
+		"key category":     {prompt: strings.Replace(valid, "key: [3", "key: [4", 1), want: ErrMalformedPrompt},
+		"key count":        {prompt: strings.Replace(valid, " 1 2]\nmatch", "]\nmatch", 1), want: ErrMalformedPrompt},
+		"missing newline":  {prompt: strings.TrimSuffix(valid, "\n"), want: ErrMalformedPrompt},
+		"comma separator":  {prompt: strings.Replace(valid, "0 0 0", "0, 0 0", 1), want: ErrMalformedPrompt},
+		"double space":     {prompt: strings.Replace(valid, "0 0 0", "0  0 0", 1), want: ErrMalformedPrompt},
+		"too many nodes":   {prompt: valid, mutate: func(limits *Limits) { limits.MaxValues = 9 }, want: ErrPromptLimit},
+		"oversized prompt": {prompt: valid, mutate: func(limits *Limits) {
+			limits.MaxPromptBytes = len(valid) - 1
+		}, want: ErrPromptLimit},
+		"oversized answer": {prompt: valid, mutate: func(limits *Limits) {
+			limits.MaxAnswerBytes = 2
+		}, want: ErrAnswerLimit},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			limits := testLimits()
+			if test.mutate != nil {
+				test.mutate(&limits)
+			}
+			if _, err := Solve(context.Background(), []byte(test.prompt), limits); !errors.Is(err, test.want) {
+				t.Fatalf("Solve() error = %v, want %v", err, test.want)
+			}
+		})
+	}
+}
+
+func TestSolveHonoursCancellationAndClosedLimits(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	prompt := []byte("kmp_matcher:\nstring: [0 0 0 0 0 0 0 1], key: [3 2 1 0 3 3 3 0]\nmatch:\n")
+	if _, err := Solve(ctx, prompt, testLimits()); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Solve(cancelled) error = %v, want context.Canceled", err)
+	}
+	limits := testLimits()
+	limits.MaxValues = 0
+	if _, err := Solve(context.Background(), prompt, limits); !errors.Is(err, ErrInvalidLimits) {
+		t.Fatalf("Solve(open limits) error = %v, want ErrInvalidLimits", err)
+	}
+}
+
+func TestMatcherAndIndependentVerifierCheckCancellationInsideWork(t *testing.T) {
+	t.Parallel()
+	prefixContext := &cancelAfterChecksContext{Context: context.Background(), cancelAt: 2}
+	if _, err := kmpFirstMatch(prefixContext, matchInput{
+		haystack: []byte{0, 1, 0, 1, 0, 1}, needle: []byte{0, 1, 0, 1},
+	}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("KMP prefix cancellation error = %v, want context.Canceled", err)
+	}
+	searchContext := &cancelAfterChecksContext{Context: context.Background(), cancelAt: 3}
+	if _, err := kmpFirstMatch(searchContext, matchInput{
+		haystack: []byte{3, 3, 3, 3, 3, 3}, needle: []byte{0},
+	}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("KMP search cancellation error = %v, want context.Canceled", err)
+	}
+	verifierContext := &cancelAfterChecksContext{Context: context.Background(), cancelAt: 3}
+	if _, err := naiveFirstMatch(verifierContext, matchInput{
+		haystack: []byte{3, 3, 3, 3, 3, 3}, needle: []byte{0},
+	}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("naive verifier cancellation error = %v, want context.Canceled", err)
+	}
+}
+
+func TestValidateReferenceRejectsWrongOrNonCanonicalIndexes(t *testing.T) {
+	t.Parallel()
+	input := matchInput{haystack: []byte{3, 2, 1, 2, 3, 0, 0, 0}, needle: []byte{1, 2}}
+	for name, reference := range map[string]string{
+		"wrong first match": "3\n\n",
+		"leading zero":      "02\n\n",
+		"out of range":      "9\n\n",
+		"foreign syntax":    "[2]\n\n",
+	} {
+		if err := validateReference(context.Background(), []byte(reference), testLimits(), input); err == nil {
+			t.Fatalf("validateReference accepted %s reference %q", name, reference)
+		}
+	}
+	if err := validateReference(context.Background(), []byte("2\n\n"), testLimits(), input); err != nil {
+		t.Fatalf("validateReference rejected exact first match: %v", err)
+	}
+}
+
+func TestPinnedSourceEvidenceIsExact(t *testing.T) {
+	t.Parallel()
+	evidence := PinnedSourceEvidence()
+	if evidence.SourceRecordPath != "tooling/clrs-generator/upstream.json" ||
+		evidence.SourceID != "sha256:7ec3b6b7528d04f517c4e9b7c3e0cd0f7034a775d225d469d1aca5c00fec10d1" {
+		t.Fatalf("source identity = %#v", evidence)
+	}
+	if evidence.Formatter.SHA256 != "d6d320eb1536be8fbdb512315d55eada2db3ff87afd613762f125d38a9e7a53c" ||
+		evidence.Spec.SHA256 != "51f1cc936b28189c7b2e3b2030c30e224fb448f3d2846181983329448f1ed018" ||
+		evidence.Algorithm.Path != "clrs/_src/algorithms/strings.py" ||
+		evidence.Algorithm.GitBlob != "3d5bbe3ae5e3b684afb56dcddbbff52b5f1cf30e" ||
+		evidence.Algorithm.SHA256 != "b9a7c21460c1689c283f7353b827add518c99800adcd39f85f1be84ac220bc75" ||
+		evidence.Sampler.SHA256 != "01921e9ca7fa0cc81a8ce82dd76869820f1e9ad8863d5b76b088b0610a2e0473" ||
+		evidence.Probing.SHA256 != "6ee8bea717c6a820fec0457c8be01a4459d5b2daab9c2c883ab8db333478f064" {
+		t.Fatalf("source file identities = %#v", evidence)
+	}
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("locate KMP source test")
+	}
+	body, err := os.ReadFile(filepath.Join(filepath.Dir(filename), "..", "..", "clrs-generator", "upstream.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	source, err := clrsfixture.ParseSourceRecord(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := evidence.ValidateSource(source); err != nil {
+		t.Fatal(err)
+	}
+	mutations := []func(*SourceEvidence){
+		func(value *SourceEvidence) { value.SourceRecordPath = "other.json" },
+		func(value *SourceEvidence) { value.Formatter.SHA256 = strings.Repeat("0", 64) },
+		func(value *SourceEvidence) { value.Spec.GitBlob = strings.Repeat("0", 40) },
+		func(value *SourceEvidence) { value.Algorithm.Path = "strings-other.py" },
+		func(value *SourceEvidence) { value.Sampler.SHA256 = strings.Repeat("f", 64) },
+		func(value *SourceEvidence) { value.Probing.GitBlob = strings.Repeat("a", 40) },
+	}
+	for index, mutate := range mutations {
+		changed := evidence
+		mutate(&changed)
+		if err := changed.ValidateSource(source); err == nil {
+			t.Fatalf("ValidateSource accepted supporting-evidence mutation %d", index)
+		}
+	}
+}
+
+func binaryWord(word, length int) []byte {
+	values := make([]byte, length)
+	for index := range length {
+		values[index] = byte((word >> index) & 1)
+	}
+	return values
+}
+
+func testLimits() Limits {
+	return Limits{MaxPromptBytes: 512, MaxValues: 64, MaxAnswerBytes: 32}
+}

--- a/tooling/internal/clrskmp/source.go
+++ b/tooling/internal/clrskmp/source.go
@@ -1,0 +1,80 @@
+// Package clrskmp implements the exact-program Knuth-Morris-Pratt vertical for
+// the CLRS-Text development shakedown. Every value remains NO_RESULT.
+package clrskmp
+
+import (
+	"fmt"
+
+	"github.com/lusoris/20-watts-was-enough/tooling/internal/clrsfixture"
+)
+
+// SourceFile binds one upstream file used to derive this vertical's grammar or
+// exact conventional operation. SHA256 is over the file bytes at Commit.
+type SourceFile struct {
+	Path    string
+	GitBlob string
+	SHA256  string
+}
+
+// SourceEvidence extends the canonical source record with the supporting files
+// used to derive this vertical. It references rather than repeats repository,
+// commit, tree, generator, requirements and licence metadata.
+type SourceEvidence struct {
+	SourceRecordPath string
+	SourceID         string
+	Formatter        SourceFile
+	Spec             SourceFile
+	Algorithm        SourceFile
+	Sampler          SourceFile
+	Probing          SourceFile
+}
+
+// PinnedSourceEvidence returns the exact official source inspected for the
+// no-hint prompt/reference grammar and Knuth-Morris-Pratt operation.
+func PinnedSourceEvidence() SourceEvidence {
+	return SourceEvidence{
+		SourceRecordPath: "tooling/clrs-generator/upstream.json",
+		SourceID:         "sha256:7ec3b6b7528d04f517c4e9b7c3e0cd0f7034a775d225d469d1aca5c00fec10d1",
+		Formatter: SourceFile{
+			Path:    "clrs/_src/clrs_text/clrs_utils.py",
+			GitBlob: "64a2714ca879cd62a4c1d1db0a80e6c23bf61541",
+			SHA256:  "d6d320eb1536be8fbdb512315d55eada2db3ff87afd613762f125d38a9e7a53c",
+		},
+		Spec: SourceFile{
+			Path:    "clrs/_src/specs.py",
+			GitBlob: "db3b02e14072152df590a8df518ef058fd167930",
+			SHA256:  "51f1cc936b28189c7b2e3b2030c30e224fb448f3d2846181983329448f1ed018",
+		},
+		Algorithm: SourceFile{
+			Path:    "clrs/_src/algorithms/strings.py",
+			GitBlob: "3d5bbe3ae5e3b684afb56dcddbbff52b5f1cf30e",
+			SHA256:  "b9a7c21460c1689c283f7353b827add518c99800adcd39f85f1be84ac220bc75",
+		},
+		Sampler: SourceFile{
+			Path:    "clrs/_src/samplers.py",
+			GitBlob: "442a5c6d1da86c2956d8dcc78c9339ded296e1a8",
+			SHA256:  "01921e9ca7fa0cc81a8ce82dd76869820f1e9ad8863d5b76b088b0610a2e0473",
+		},
+		Probing: SourceFile{
+			Path:    "clrs/_src/probing.py",
+			GitBlob: "e4ba102eecdfee2934268a33727da964a2119d37",
+			SHA256:  "6ee8bea717c6a820fec0457c8be01a4459d5b2daab9c2c883ab8db333478f064",
+		},
+	}
+}
+
+// ValidateSource checks that this grammar evidence points to the supplied
+// canonical source record.
+func (evidence SourceEvidence) ValidateSource(source clrsfixture.SourceRecord) error {
+	if evidence != PinnedSourceEvidence() {
+		return fmt.Errorf("KMP supporting source evidence differs from the pinned record")
+	}
+	identity, err := source.Identity()
+	if err != nil {
+		return fmt.Errorf("validate KMP source record: %w", err)
+	}
+	if identity.String() != evidence.SourceID {
+		return fmt.Errorf("KMP source identity = %s, want %s", identity, evidence.SourceID)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

- add the bounded Go Knuth-Morris-Pratt specialist and source contract
- keep prompts deterministic and outputs independently verified
- reject malformed input, oversized work, and candidate/verifier coupling

## Verification

- `go -C tooling test -race -count=1 ./internal/clrskmp`
- `go -C tooling vet ./internal/clrskmp`
- package coverage: 91.3%
- full aggregate gate: 722 passed, one intentional skip

Tracks #12.