### PR TITLE
feat(experiment): lock CLRS generator dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,11 +26,12 @@ the exact diff; this file records why the project changed.
   use. No dataset is generated or executed; every record remains `NO_RESULT`.
 - The CLRS generator-image foundation now binds a checksum-closed official
   source archive, the newest reviewed CPython/TensorFlow/JAX wheel intersection,
-  pinned resolver and shared builder identities, finite runtime containment and
-  an offline Go validator. Pinned upstream licence material and finite SBOM
-  retention remain mandatory admission gates. The state remains `NO_RESULT`
-  and blocked: no exact dependency lock, Dockerfile, wheelhouse, image, SBOM,
-  runtime smoke or byte-compared fixture generation is claimed.
+  pinned resolver, exact 62-package dependency graph, shared builder identities,
+  finite runtime containment and an offline Go validator. Pinned upstream
+  licence material and finite SBOM retention remain mandatory admission gates.
+  The state remains `NO_RESULT` and blocked: dependency resolution is closed,
+  but no Dockerfile, wheelhouse, image, SBOM, runtime smoke or byte-compared
+  fixture generation is claimed.
   The same slice hardens the shared renderer-authority reader against ancestor
   links, pathname replacement and same-size byte mutation without rejecting a
   valid Windows path solely because its canonical drive spelling differs. The

--- a/tooling/clrs-generator/README.md
+++ b/tooling/clrs-generator/README.md
@@ -1,11 +1,9 @@
 # CLRS generator image foundation
 
-No generator image is admitted yet. This directory records candidate inputs
-and blocked admission rules for a future Linux `amd64` image. Registry absence
-has not been checked; the repository state remains `blocked` and `NO_RESULT`.
-This is not yet a closed acceptance implementation: the exact dependency
-graph, build context and retained receipts still require bounded construction
-and review.
+No generator image is admitted yet. This directory now records the exact
+Linux `amd64` dependency graph, but the build context and retained acceptance
+receipts are still absent. Registry absence has not been checked; the state
+remains `blocked` and `NO_RESULT`.
 
 The Python image is a narrow exception to the Go-first tooling rule. The pinned
 official CLRS-Text generator imports TensorFlow and JAX; rewriting that path
@@ -19,14 +17,18 @@ the controller, validator and fixture-import boundary.
 - [`contract.json`](contract.json) fixes the six task families, seeds, sizes,
   output counts and byte limits from [Decision 0055](../../decisions/0055-freeze-clrs-text-as-a-controller-shakedown.md).
 - [`lock-input.json`](lock-input.json) binds the checksum-closed source archive,
-  CPython 3.13.15 base, uv 0.12.7 and the reviewed Linux `amd64` TensorFlow,
-  JAX, JAXlib, NumPy and tqdm wheel candidates. These are resolver inputs, not
-  an admitted transitive lock or proof that the pinned source runs with them.
+  CPython 3.13.15 base, uv 0.12.9, resolution cutoff and reviewed Linux `amd64`
+  TensorFlow, JAX, JAXlib, NumPy and tqdm wheel candidates.
+- [`pyproject.toml`](pyproject.toml) is derived from those inputs. Its
+  [`uv.lock`](uv.lock) resolves 62 packages and records 135 checksum-closed
+  artifacts. Two isolated runs of the pinned resolver produced identical lock
+  bytes. This closes dependency resolution only; it does not prove that the
+  source imports or runs.
 - [`image-contract.json`](image-contract.json) reuses the repository's pinned
   Buildx, BuildKit and timestamp-rewrite authority; fixes resource and runtime
   containment; binds the upstream licence's final image path; caps retained
-  SBOM bytes and packages; and records every absent acceptance identity as
-  `missing`.
+  SBOM bytes and packages; binds the exact dependency files; and records each
+  remaining acceptance identity as `missing`.
 
 Python 3.13 is the newest candidate interpreter because TensorFlow 2.21.0 has no
 CPython 3.14 wheel, while current JAX and JAXlib require Python 3.12 or newer.
@@ -44,20 +46,21 @@ go -C tooling test -race ./internal/clrsfixture
 go -C tooling vet ./internal/clrsfixture
 ```
 
-`CheckGeneratorImageFoundation` rejects ambiguous JSON throughout and
-non-canonical encoding in `lock-input.json` and `image-contract.json`. It also
-rejects symlinked authority files, changed source or generation identities,
-drift in the reviewed high-impact wheel candidates, stale shared-builder
-metadata and a lock, Dockerfile or wheelhouse manifest that appears while the
-contract still says it is missing. The upstream lower bounds and remaining
-transitive Python graph are still unresolved candidate inputs.
+`CheckGeneratorImageFoundation` rejects ambiguous JSON, non-canonical authority
+files, symlinks and unstable reads. It derives the project requirements from
+the reviewed inputs, binds the complete lock digest, checks its resolver
+header, cutoff, selected high-impact wheels, package count, artifact count and
+total recorded bytes, and rejects artifacts uploaded after the cutoff. A
+Dockerfile or wheelhouse manifest still fails while the contract marks it
+missing.
 
 ## Admission sequence
 
 The image stays blocked until one later, bounded change provides all of the
 following:
 
-1. an exact uv lock and hash-complete wheelhouse for Linux `amd64`;
+1. a hash-complete Linux `amd64` wheelhouse and manifest selected from the
+   exact uv lock;
 2. a checksum-closed Dockerfile and complete build context whose dependency
    install runs without network access;
 3. the 11,358-byte Apache-2.0 `LICENSE`, with its pinned source digest, at
@@ -84,6 +87,6 @@ seconds of wall time. The external runner must stop and remove the complete
 container after a five-second grace period. These are construction limits, not
 performance results.
 
-There is deliberately no `Dockerfile`, `uv.lock`, wheelhouse, generated fixture,
-admitted image digest or publication step in this foundation. [Issue 12](https://github.com/lusoris/20-watts-was-enough/issues/12)
+There is deliberately no `Dockerfile`, wheelhouse, generated fixture, admitted
+image digest or publication step in this foundation. [Issue 12](https://github.com/lusoris/20-watts-was-enough/issues/12)
 tracks the remaining acceptance work.

--- a/tooling/clrs-generator/image-contract.json
+++ b/tooling/clrs-generator/image-contract.json
@@ -10,7 +10,7 @@
   "generation_contract_id": "sha256:cc14fce405e8fa7d4719f1fc906e28d5e4b73235085c8f0722795efded2891a8",
   "lock_input": {
     "path": "tooling/clrs-generator/lock-input.json",
-    "sha256": "d7ff2963aa2f11e3cf001fc095520780539c85e4923448939c9ef9ede41eb827"
+    "sha256": "ea0e8f7d2d3ce347e82cbdd0e956dceca3da27ee499b52e18a6f6010526a5a19"
   },
   "builder": {
     "authority_path": "tooling/pdf-renderer/lock.json",
@@ -24,11 +24,13 @@
     "source_date_epoch": 1787658740
   },
   "dependency_lock": {
-    "state": "missing",
+    "state": "locked",
+    "project_path": "tooling/clrs-generator/pyproject.toml",
+    "project_sha256": "531aad8cccd8aeee8edaf1b5e07fb73ad93c8d0c7e3c309b1b69105fb34eddcb",
     "path": "tooling/clrs-generator/uv.lock",
-    "sha256": "",
-    "package_count": 0,
-    "artifact_count": 0
+    "sha256": "1aff6ff0e589539e07b3ee75579803ebd66636ab35568661680a703ed38ab640",
+    "package_count": 62,
+    "artifact_count": 135
   },
   "build_context": {
     "state": "missing",
@@ -146,7 +148,6 @@
     "source_context": "locked",
     "blocked_on": [
       "checksum_closed_build_context",
-      "exact_dependency_lock",
       "pinned_upstream_license_material",
       "image_bound_spdx_sbom",
       "no_network_runtime_smoke",

--- a/tooling/clrs-generator/lock-input.json
+++ b/tooling/clrs-generator/lock-input.json
@@ -23,11 +23,12 @@
   },
   "resolver": {
     "name": "uv",
-    "version": "0.12.7",
-    "image": "ghcr.io/astral-sh/uv:0.12.7@sha256:95f2aa1fe59274951cfe9b0cbc7972e879ff1004bc8945d130a32eb0dbd85945",
-    "revision": "61291a8ca5477a9ca653f14d2ac5665587c263fa",
+    "version": "0.12.9",
+    "image": "ghcr.io/astral-sh/uv:0.12.9@sha256:8b940d3a9d65bed080436972241af2e21c84b5e8c9193f7014ed71479ee795ff",
+    "revision": "9f928602938ac5cf1cd6b294a725833c16f5720e",
     "resolution": "highest-compatible",
-    "prerelease": "if-necessary-or-explicit"
+    "prerelease": "if-necessary",
+    "exclude_newer": "2026-08-31T13:22:50Z"
   },
   "upstream_requirements": {
     "path": "requirements/requirements.txt",

--- a/tooling/clrs-generator/pyproject.toml
+++ b/tooling/clrs-generator/pyproject.toml
@@ -1,0 +1,33 @@
+[project]
+name = "twenty-watts-clrs-generator"
+version = "0.0.0"
+requires-python = "==3.13.*"
+dependencies = [
+  "absl-py>=2.1.0",
+  "attrs>=24.2.0",
+  "chex>=0.1.86",
+  "dm-haiku>=0.0.12",
+  "jax==0.11.1",
+  "jaxlib==0.11.1",
+  "ml-collections>=0.1.1",
+  "numpy==2.5.2",
+  "opt-einsum>=3.3.0",
+  "optax>=0.2.3",
+  "six>=1.16.0",
+  "tensorflow==2.21.0",
+  "tfds-nightly>=4.9.6.dev202409060044",
+  "toolz>=0.12.1",
+  "tqdm==4.70.0",
+]
+
+[tool.uv]
+package = false
+resolution = "highest"
+prerelease = "if-necessary"
+exclude-newer = "2026-08-31T13:22:50Z"
+environments = [
+  "implementation_name == 'cpython' and sys_platform == 'linux' and platform_machine == 'x86_64'",
+]
+required-environments = [
+  "implementation_name == 'cpython' and sys_platform == 'linux' and platform_machine == 'x86_64'",
+]

--- a/tooling/clrs-generator/uv.lock
+++ b/tooling/clrs-generator/uv.lock
@@ -1,0 +1,794 @@
+version = 1
+revision = 3
+requires-python = "==3.13.*"
+resolution-markers = [
+    "implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+]
+supported-markers = [
+    "implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+]
+required-markers = [
+    "implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+]
+
+[options]
+exclude-newer = "2026-08-31T13:22:50Z"
+
+[[package]]
+name = "absl-py"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/4f/d79676ab82f2e42fc3611618139f13a9c4c31d0cff4b486982047679a802/absl_py-2.5.0.tar.gz", hash = "sha256:0c996f25c0490700fadabe6351630f6111534fa0ae252cc6d2014ea3b141135f", size = 118119, upload-time = "2026-07-03T10:57:48.157Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/0a/a10b45aab35b175aded078a462dc8d0c698f5b13946e7cb0869097b78bb6/absl_py-2.5.0-py3-none-any.whl", hash = "sha256:0f17b89f2a4eaaedc4f28c622998aa690564b3012a396a4ffad0821007fe03ba", size = 137410, upload-time = "2026-07-03T10:57:46.735Z" },
+]
+
+[[package]]
+name = "array-record"
+version = "0.8.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "absl-py" },
+    { name = "etils", extra = ["epath"] },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/6d/5575a1d64cffecb72de5743b35a1532b1801a0350b9b45f277090d02b3c2/array_record-0.8.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:13df1aec9b38afe98973bf5fe3cf523f83ca904b0423d85319930877145b8f28", size = 4995837, upload-time = "2025-11-13T16:15:40.973Z" },
+]
+
+[[package]]
+name = "astunparse"
+version = "1.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+    { name = "wheel" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/af/4182184d3c338792894f34a62672919db7ca008c89abee9b564dd34d8029/astunparse-1.6.3.tar.gz", hash = "sha256:5ad93a8456f0d084c3456d059fd9a92cce667963232cbf763eac3bc5b7940872", size = 18290, upload-time = "2019-12-22T18:12:13.129Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/03/13dde6512ad7b4557eb792fbcf0c653af6076b81e5941d36ec61f7ce6028/astunparse-1.6.3-py2.py3-none-any.whl", hash = "sha256:c2652417f2c8b5bb325c885ae329bdf3f86424075c4fd1a128674bc6fba4b8e8", size = 12732, upload-time = "2019-12-22T18:12:11.297Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.7.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/3f/143b048436775b0f76ac3eec145c019e8173ccc2885c8f20319b996d5e83/charset_normalizer-3.5.1.tar.gz", hash = "sha256:6117b84ea48435e5356dc737f5121485c30920ba43375fa7b434fd753df0eac3", size = 171764, upload-time = "2026-08-15T08:20:44.807Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/af/63240b0c0248c075c2535a1f1bd992821d8251b9f173abc13329661d09e4/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62b55f6722735a6c472f88361cde6640608773d9443cebdbb51abf436a1fcdd3", size = 250638, upload-time = "2026-08-15T08:17:46.496Z" },
+    { url = "https://files.pythonhosted.org/packages/90/c6/b09e05e6db7f64338e0dc067c79577b1138da86c1e38369096851d96be88/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fd0350afdc3aabd5576f60ea109228bd5538139713c7b094c5cd27c73a98bc6f", size = 252618, upload-time = "2026-08-15T08:17:57.025Z" },
+    { url = "https://files.pythonhosted.org/packages/76/4e/362d4f9fdcdf5556fb2aa3ce7d4a58ebce03ed1ff03aa1d9aca8d02f13f3/charset_normalizer-3.5.1-cp313-cp313-pyemscripten_2025_0_wasm32.whl", hash = "sha256:9d9a0dc7cbe9bec24c3f767c9122c41fe5a1bc43f47cd099d00d393e09769de4", size = 140362, upload-time = "2026-08-15T08:17:58.425Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2f/fe3f187327aac18e2d54e9d2b08e15d27bf9b642d9e51c219f130fc34d1a/charset_normalizer-3.5.1-cp37-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a6dac12ff6b846103483683f60c5f8fee205121adc58ffd87e90a90a3af69e99", size = 253057, upload-time = "2026-08-15T08:19:52.654Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c2/a7379b840292d0c1ab9fbd17d1f3967aa81794dc95bc74be8999d7fedcf7/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e199fb99720074809a7720f1c0b4d919eea8b87e88713e0f8f602f7bef543d9d", size = 254846, upload-time = "2026-08-15T08:20:10.727Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/61/d01fc49b8dea277640b55a9e15960dbca9fdc8c9fde18e572d39c59f4019/charset_normalizer-3.5.1-py3-none-any.whl", hash = "sha256:6df0ec430f9a831772c23ca5a224cba36517a58a84bb32c32bb59a9fa67c47f6", size = 68658, upload-time = "2026-08-15T08:20:43.306Z" },
+]
+
+[[package]]
+name = "chex"
+version = "0.1.92"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "absl-py" },
+    { name = "jax" },
+    { name = "jaxlib" },
+    { name = "numpy" },
+    { name = "toolz" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/71/7b2c28cd5ba2743e7cd4d1262d73cdc83c3dce395f56fd52c0ff50947514/chex-0.1.92.tar.gz", hash = "sha256:fa8beff1124204ae466a6eb13cb91ae3c24322a1c7216946aee93d031e2f1996", size = 91863, upload-time = "2026-06-12T14:28:37.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/42/5d8282d6dc4cd9971f865eb5cc767d180d1564475826e43150d1ea1dba51/chex-0.1.92-py3-none-any.whl", hash = "sha256:f34989d9bff7954edfab09fba7757e3d62404da34577bff0d253599ec5b4f93d", size = 102275, upload-time = "2026-06-12T14:28:36.579Z" },
+]
+
+[[package]]
+name = "dm-haiku"
+version = "0.0.17"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "absl-py" },
+    { name = "jmp" },
+    { name = "numpy" },
+    { name = "tabulate" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6b/1c/0968ff6092ff510dca8dfb8ce14c4fcb6059dd680ee15e46410de993415d/dm_haiku-0.0.17.tar.gz", hash = "sha256:6daa56f3b54f43675713ef7525d1dec7327f2512b57cc2b12104f76f6d7cf581", size = 265004, upload-time = "2026-07-27T09:46:52.571Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/82/7045ad957defb3bfc28b89c748a1874c73f37b9337963b52d6de48ca4648/dm_haiku-0.0.17-py3-none-any.whl", hash = "sha256:aa1394276adf59d695c910810ad90febb741503a83c32b022ce1162483904bbb", size = 377007, upload-time = "2026-07-27T09:46:51.365Z" },
+]
+
+[[package]]
+name = "dm-tree"
+version = "0.1.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "absl-py" },
+    { name = "attrs" },
+    { name = "numpy" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/66/a3ec619d22b6baffa5ab853e8dc6ec9d0c837127948af59bb15b988d7312/dm_tree-0.1.10.tar.gz", hash = "sha256:22f37b599e01cc3402a17f79c257a802aebd8d326de05b54657650845956208a", size = 35748, upload-time = "2026-03-31T17:35:39.03Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/23/bd3e75cbff06a464339d32667d740acf49812b027142a013b54d2c4d830a/dm_tree-0.1.10-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6d7134c0805294c640b94d85cc725084f0c5087bcda5a7fb38eeb7f479ecc37c", size = 186187, upload-time = "2026-03-31T17:35:23.495Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/da/f8811666d61b6829ba1c2716c4119039428dd86078eddd120354aaf26a3b/dm_tree-0.1.10-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6d4237da7b072fff1e93db109ab545f00d2b978ead35e85e7a84908e15197826", size = 187013, upload-time = "2026-03-31T17:35:27.969Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
+name = "einops"
+version = "0.8.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/77/850bef8d72ffb9219f0b1aac23fbc1bf7d038ee6ea666f331fa273031aa2/einops-0.8.2.tar.gz", hash = "sha256:609da665570e5e265e27283aab09e7f279ade90c4f01bcfca111f3d3e13f2827", size = 56261, upload-time = "2026-01-26T04:13:17.638Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/09/f8d8f8f31e4483c10a906437b4ce31bdf3d6d417b73fe33f1a8b59e34228/einops-0.8.2-py3-none-any.whl", hash = "sha256:54058201ac7087911181bfec4af6091bb59380360f069276601256a76af08193", size = 65638, upload-time = "2026-01-26T04:13:18.546Z" },
+]
+
+[[package]]
+name = "etils"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/ce/6e067242fde898841922ac6fc82b0bb2fe35c38e995880bdffdfbe30182a/etils-1.14.0.tar.gz", hash = "sha256:8136e7f4c4173cd0af0ca5481c4475152f0b8686192951eefa60ee8711e1ede4", size = 108127, upload-time = "2026-03-04T17:41:36.291Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/3d/589663aeeacd59bb2f3e8596bfd3e81cf0fb18d70bb433199041f469771b/etils-1.14.0-py3-none-any.whl", hash = "sha256:b5df7341f54dbe1405a4450b2741207b4a8c279780402b45f87202b94dfc52b4", size = 172934, upload-time = "2026-03-04T17:41:35.01Z" },
+]
+
+[package.optional-dependencies]
+edc = [
+    { name = "typing-extensions" },
+]
+enp = [
+    { name = "einops" },
+    { name = "numpy" },
+    { name = "typing-extensions" },
+]
+epath = [
+    { name = "fsspec" },
+    { name = "typing-extensions" },
+    { name = "zipp" },
+]
+epy = [
+    { name = "typing-extensions" },
+]
+etree = [
+    { name = "absl-py" },
+    { name = "einops" },
+    { name = "numpy" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+
+[[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", size = 26661, upload-time = "2025-12-19T23:16:13.622Z" },
+]
+
+[[package]]
+name = "fsspec"
+version = "2026.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/78/f34251dadb8f3921264a1d9b8946f5e542014ee2614b285261b4e40e6775/fsspec-2026.7.0.tar.gz", hash = "sha256:c803c40f4cf860b49dea58ee3e1c33cb9c790520e233537e1340049f89b82a88", size = 317040, upload-time = "2026-07-28T16:34:51.052Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/3c/6a2bf344106328fd04963664a60b9bb6496fc25df8e962fcdc1367285fb9/fsspec-2026.7.0-py3-none-any.whl", hash = "sha256:b57ddbafedfaef7018c1ecab32aa200a9d7ca26b77965f64e48b70061249d279", size = 206583, upload-time = "2026-07-28T16:34:49.538Z" },
+]
+
+[[package]]
+name = "gast"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/f6/e73969782a2ecec280f8a176f2476149dd9dba69d5f8779ec6108a7721e6/gast-0.7.0.tar.gz", hash = "sha256:0bb14cd1b806722e91ddbab6fb86bba148c22b40e7ff11e248974e04c8adfdae", size = 33630, upload-time = "2025-11-29T15:30:05.266Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/33/f1c6a276de27b7d7339a34749cc33fa87f077f921969c47185d34a887ae2/gast-0.7.0-py3-none-any.whl", hash = "sha256:99cbf1365633a74099f69c59bd650476b96baa5ef196fec88032b00b31ba36f7", size = 22966, upload-time = "2025-11-29T15:30:03.983Z" },
+]
+
+[[package]]
+name = "google-pasta"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/35/4a/0bd53b36ff0323d10d5f24ebd67af2de10a1117f5cf4d7add90df92756f1/google-pasta-0.2.0.tar.gz", hash = "sha256:c9f2c8dfc8f96d0d5808299920721be30c9eec37f2389f28904f454565c8a16e", size = 40430, upload-time = "2020-03-13T18:57:50.34Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/de/c648ef6835192e6e2cc03f40b19eeda4382c49b5bafb43d88b931c4c74ac/google_pasta-0.2.0-py3-none-any.whl", hash = "sha256:b32482794a366b5366a32c92a9a9201b107821889935a02b3e51f6b432ea84ed", size = 57471, upload-time = "2020-03-13T18:57:48.872Z" },
+]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.75.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/90/fb8f1c84537fbf210c1f53a53ae473a805f6599c5a40b93c1bbadd211f7a/googleapis_common_protos-1.75.2.tar.gz", hash = "sha256:8829a3d1e4508c5b7b9a6b9525f7fccff611f8531644579a76466c29295d4bb2", size = 154083, upload-time = "2026-08-25T19:19:13.028Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/5b/1c9e55363c3b1890a98cae813de5b4ea327845756cd8fb7ee690140c7eac/googleapis_common_protos-1.75.2-py3-none-any.whl", hash = "sha256:6b83302f554ea93a0f48409c7fc2050f954bcbcddb7e3a9c76d4a823cb22920e", size = 307002, upload-time = "2026-08-25T19:18:08.927Z" },
+]
+
+[[package]]
+name = "grpcio"
+version = "1.83.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/b1/46539f5050d7c316a13396d185451f95084a74ddc68b12d818595bef0377/grpcio-1.83.1.tar.gz", hash = "sha256:9cee6fcbf2eb57c4b49451787bfa87be8efc1ca02a0b327dd4b54d44502e362b", size = 13445033, upload-time = "2026-08-28T07:09:11.464Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/ec/bd798654b06fb42a92b57d1dc1b530084fa89ed442806fcd0a833a36f9b3/grpcio-1.83.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:55656318d5dd387077396dffb929171ca3966e24bfead9a6c5dba9f889062cb4", size = 7042942, upload-time = "2026-08-28T07:08:36.208Z" },
+    { url = "https://files.pythonhosted.org/packages/35/4e/82835483e2f812494be865e7965c0d626cb9e71ab0d83a420d75aea4ad67/grpcio-1.83.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:65c5a7210911ffe0f67b1cdc5308f9854b6d1f1b345e3e49ab7cac1ba50fa346", size = 7980060, upload-time = "2026-08-28T07:08:42.434Z" },
+]
+
+[[package]]
+name = "h5py"
+version = "3.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/57/dfb3c5c3f1bf5f5ef2e59a22dec4ff1f3d7408b55bfcefcfb0ea69ef21c6/h5py-3.14.0.tar.gz", hash = "sha256:2372116b2e0d5d3e5e705b7f663f7c8d96fa79a4052d250484ef91d24d6a08f4", size = 424323, upload-time = "2025-06-06T14:06:15.01Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/ec/86f59025306dcc6deee5fda54d980d077075b8d9889aac80f158bd585f1b/h5py-3.14.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d90e6445ab7c146d7f7981b11895d70bc1dd91278a4f9f9028bc0c95e4a53f13", size = 4921632, upload-time = "2025-06-06T14:05:43.464Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/f7/abb373e5757eaec4b922b92f97ec8d6d7e057cf06778247604fbc4e7c3f3/idna-3.19.tar.gz", hash = "sha256:5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15", size = 215237, upload-time = "2026-08-18T05:14:24.27Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl", hash = "sha256:815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4", size = 68550, upload-time = "2026-08-18T05:14:22.343Z" },
+]
+
+[[package]]
+name = "immutabledict"
+version = "4.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/e6/718471048fea0366c3e3d1df3acfd914ca66d571cdffcf6d37bbcd725708/immutabledict-4.3.1.tar.gz", hash = "sha256:f844a669106cfdc73f47b1a9da003782fb17dc955a54c80972e0d93d1c63c514", size = 7806, upload-time = "2026-02-15T10:32:34.668Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/ce/f9018bf69ae91b273b6391a095e7c93fa5e1617f25b6ba81ad4b20c9df10/immutabledict-4.3.1-py3-none-any.whl", hash = "sha256:c9facdc0ff30fdb8e35bd16532026cac472a549e182c94fa201b51b25e4bf7bf", size = 5000, upload-time = "2026-02-15T10:32:33.672Z" },
+]
+
+[[package]]
+name = "jax"
+version = "0.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jaxlib" },
+    { name = "ml-dtypes" },
+    { name = "numpy" },
+    { name = "opt-einsum" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/aa/c3b6ac3863a490661e255d2356802b54d57b533460fa221d30743d81a6c1/jax-0.11.1.tar.gz", hash = "sha256:43e0d45b1dac002eca04c2de73298395225dd0d4651e3f573a540eaa18abfd80", size = 2864119, upload-time = "2026-08-17T20:31:29.938Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/f4/5f9a286e1eeca9faa8b83885edccf63ab2f1b22e17f6a5ea66ac86b1afe4/jax-0.11.1-py3-none-any.whl", hash = "sha256:72ed60bf85a0b53d0f5b5cd61e37a8b25f369f6f88481feb98ab489894861a82", size = 3302513, upload-time = "2026-08-17T20:29:00.294Z" },
+]
+
+[[package]]
+name = "jaxlib"
+version = "0.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ml-dtypes" },
+    { name = "numpy" },
+    { name = "scipy" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/28/ef1371618e784880e68c2ab5277d5ccbaf518a2a5ec9ec05ef90a9ee7d1b/jaxlib-0.11.1-cp313-cp313-manylinux_2_27_x86_64.whl", hash = "sha256:7ebe86a7b891fcda83e7f634a677d285681a7b80b3ec9ed435536078a8371acf", size = 87901562, upload-time = "2026-08-17T20:30:28.873Z" },
+]
+
+[[package]]
+name = "jmp"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/b0/e90fbbffef4b345329c878a69f0336d3edc5a1f9fcba193931aca2132d62/jmp-0.0.4.tar.gz", hash = "sha256:5dfeb0fd7c7a9f72a70fff0aab9d0cbfae32a809c02f4037ff3485ceb33e1730", size = 18582, upload-time = "2023-01-30T12:47:13.634Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/e5/cce82de2831e5aff9332d8d624bb57188f1b2af6ccf6979caf898a8a4348/jmp-0.0.4-py3-none-any.whl", hash = "sha256:6aa7adbddf2bd574b28c7faf6e81a735eb11f53386447896909c6968dc36807d", size = 18274, upload-time = "2023-01-30T12:47:11.931Z" },
+]
+
+[[package]]
+name = "keras"
+version = "3.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "absl-py" },
+    { name = "h5py" },
+    { name = "ml-dtypes" },
+    { name = "namex" },
+    { name = "numpy" },
+    { name = "optree" },
+    { name = "packaging" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/a6/4cebb4196f4e6284b35e68dc17dda9a4111a2e2bf21db8211de12881ef89/keras-3.15.1.tar.gz", hash = "sha256:92ae7c1dd7f61041953dc2d42253181ee099086f0b58ae36fcf98147a6f08a29", size = 1919818, upload-time = "2026-07-29T18:20:13.909Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/b3/c9b848bbdba18e765a8051917c0cc82585b64278ce87895f2e521a27438f/keras-3.15.1-py3-none-any.whl", hash = "sha256:836460e480930acbd19bb7a17e62f9ecad40e8a9af9a651fc8d0586a96d27e20", size = 2398595, upload-time = "2026-07-29T18:20:12.345Z" },
+]
+
+[[package]]
+name = "libclang"
+version = "18.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/5c/ca35e19a4f142adffa27e3d652196b7362fa612243e2b916845d801454fc/libclang-18.1.1.tar.gz", hash = "sha256:a1214966d08d73d971287fc3ead8dfaf82eb07fb197680d8b3859dbbbbf78250", size = 39612, upload-time = "2024-03-17T16:04:37.434Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/fc/716c1e62e512ef1c160e7984a73a5fc7df45166f2ff3f254e71c58076f7c/libclang-18.1.1-py2.py3-none-manylinux2010_x86_64.whl", hash = "sha256:c533091d8a3bbf7460a00cb6c1a71da93bffe148f172c7d03b1c31fbf8aa2a0b", size = 24515943, upload-time = "2024-03-17T16:03:45.942Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/c2/de1db8c6d413597076a4259cea409b83459b2db997c003578affdd32bf66/libclang-18.1.1-py2.py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:69f8eb8f65c279e765ffd28aaa7e9e364c776c17618af8bff22a8df58677ff4f", size = 24921494, upload-time = "2024-03-17T16:14:20.132Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "ml-collections"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "absl-py" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b8/f8/1a9ae6696dbb6bc9c44ddf5c5e84710d77fe9a35a57e8a06722e1836a4a6/ml_collections-1.1.0.tar.gz", hash = "sha256:0ac1ac6511b9f1566863e0bb0afad0c64e906ea278ad3f4d2144a55322671f6f", size = 61356, upload-time = "2025-04-17T08:25:02.247Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/8a/18d4ff2c7bd83f30d6924bd4ad97abf418488c3f908dea228d6f0961ad68/ml_collections-1.1.0-py3-none-any.whl", hash = "sha256:23b6fa4772aac1ae745a96044b925a5746145a70734f087eaca6626e92c05cbc", size = 76707, upload-time = "2025-04-17T08:24:59.038Z" },
+]
+
+[[package]]
+name = "ml-dtypes"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/72/307d7c4bd0600601c7133fba5cb78af7db968152951c1cd473abb1cda782/ml_dtypes-0.6.0.tar.gz", hash = "sha256:5e60251d32ced5598972e4d5e06a2f044341f9291402551a3f6f0ec44f9299b0", size = 3032327, upload-time = "2026-08-13T14:14:40.215Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/a5/da8ae6c6f1babe4b68e3e55d43d39b529e29774f10e0910671a6b8c86eb8/ml_dtypes-0.6.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:26b1f1fa4f0435a2946859823f6e2bf06796f1e9f10f5a05b08a5e3c8f46ff69", size = 410169, upload-time = "2026-08-13T14:14:11.036Z" },
+]
+
+[[package]]
+name = "namex"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/c0/ee95b28f029c73f8d49d8f52edaed02a1d4a9acb8b69355737fdb1faa191/namex-0.1.0.tar.gz", hash = "sha256:117f03ccd302cc48e3f5c58a296838f6b89c83455ab8683a1e85f2a430aa4306", size = 6649, upload-time = "2025-05-26T23:17:38.918Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/bc/465daf1de06409cdd4532082806770ee0d8d7df434da79c76564d0f69741/namex-0.1.0-py3-none-any.whl", hash = "sha256:e2012a474502f1e2251267062aae3114611f07df4224b6e06334c57b0f2ce87c", size = 5905, upload-time = "2025-05-26T23:17:37.695Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/80/db0b4559e57ec36362bedbb05530a87fafbcb6067708c946967a41d449e7/numpy-2.5.2.tar.gz", hash = "sha256:d482d171c406ae88c5b19cad3b6a1c4c5209f886ab74bc44c2c865c23f52d860", size = 20773161, upload-time = "2026-08-09T13:48:27.962Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/44/59a1eb68e773c4098d107ef34a0dbdeca501d72ffcfbff9a7707343921ce/numpy-2.5.2-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29b86ff8a6cc556b47ec6b64b194815cc80e6bf5eedcc6cddfd65318cb0b4eee", size = 16709995, upload-time = "2026-08-09T13:45:43.661Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/9f/02e371638ebf19b66d46231e4be52999e87f32d1961b113bc45656608b22/numpy-2.5.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b9727f472d2f3888053b8a75ab0cb94745a9de224bb5846dbadc0092101bc71d", size = 18465609, upload-time = "2026-08-09T13:45:50.808Z" },
+]
+
+[[package]]
+name = "opt-einsum"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/b9/2ac072041e899a52f20cf9510850ff58295003aa75525e58343591b0cbfb/opt_einsum-3.4.0.tar.gz", hash = "sha256:96ca72f1b886d148241348783498194c577fa30a8faac108586b14f1ba4473ac", size = 63004, upload-time = "2024-09-26T14:33:24.483Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/cd/066e86230ae37ed0be70aae89aabf03ca8d9f39c8aea0dec8029455b5540/opt_einsum-3.4.0-py3-none-any.whl", hash = "sha256:69bb92469f86a1565195ece4ac0323943e83477171b91d24c35afe028a90d7cd", size = 71932, upload-time = "2024-09-26T14:33:23.039Z" },
+]
+
+[[package]]
+name = "optax"
+version = "0.2.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "absl-py" },
+    { name = "jax" },
+    { name = "jaxlib" },
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8c/f9/e3d11ae6f298ee941a0690e353a323d158ba5dedc436e75621c310845c5c/optax-0.2.8.tar.gz", hash = "sha256:5b225b35066fc3eebaa4d798f1b4173b4d57d1a480610908981f8343b50af0b0", size = 301193, upload-time = "2026-03-20T23:30:05.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/69/6a93d8600c339d7687a05857c7907bd4dd8cf88691a5ea106d7a50af90a1/optax-0.2.8-py3-none-any.whl", hash = "sha256:e3ca2d36c99daab1800ae9dbc0545034382d6bc780b24d969e1b0df65fa31cb4", size = 402960, upload-time = "2026-03-20T23:30:03.886Z" },
+]
+
+[[package]]
+name = "optree"
+version = "0.20.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/e2/89ef1e5ef78ffd22c1d1e66d884c33850e051a11780209c35503a02855a3/optree-0.20.0.tar.gz", hash = "sha256:c7403eb0f2b2a060a97803a8f52904212df85ed6cff4b0eeed9cc6e38c2cf88d", size = 244699, upload-time = "2026-08-20T11:38:46.956Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/b2/696029cd979f5429ec25c12767734bf0e13175d3341a2aeac59127d00ca0/optree-0.20.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d1034c2cc02ec12ed413727664f015a681e2eea551e05640951b05b06c07f084", size = 490769, upload-time = "2026-08-20T11:36:57.538Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/4d/1397e819e720cd94586d4c2fd654c23a4185c2cff28a71f250b794fac23f/optree-0.20.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9a789aaf500d8cee51897c6eb4ccc5c095e00c8115ac0b74d3ddd361bd3d69d0", size = 506623, upload-time = "2026-08-20T11:37:11.085Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
+]
+
+[[package]]
+name = "promise"
+version = "2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cf/9c/fb5d48abfe5d791cd496e4242ebcf87a4bb2e0c3dcd6e0ae68c11426a528/promise-2.3.tar.gz", hash = "sha256:dfd18337c523ba4b6a58801c164c1904a9d4d1b1747c7d5dbf45b693a49d93d0", size = 19534, upload-time = "2019-12-18T07:31:43.07Z" }
+
+[[package]]
+name = "protobuf"
+version = "7.36.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/e7/0553e21d25ca4d9f573135775348a372c3ec34a93a71d5f297c3bac38341/protobuf-7.36.0.tar.gz", hash = "sha256:e8e09cb0d794c6687926fa558a8a6e72aa10edb997d5ca61da0765f12a3e00ea", size = 510034, upload-time = "2026-08-20T16:34:01.071Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/f8/bd5804695ba400e423c33fd4d9f58c28d86633d5ba1945c36ff3967d98cb/protobuf-7.36.0-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:70f5ec8eb0da81a44360c0dc0beac99a0d78071d21956a7076bae8bd2051841b", size = 340439, upload-time = "2026-08-20T16:33:56.992Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c3/629999e78d46c1115c11886d51c6bd68c17ce4a944f1ea3e153a91316a33/protobuf-7.36.0-py3-none-any.whl", hash = "sha256:53374d53fc29a67f7dbbf0ade47d7526a0f0137bf0f9c90e48d8a60790ef748c", size = 177024, upload-time = "2026-08-20T16:34:00.053Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+]
+
+[[package]]
+name = "pyarrow"
+version = "25.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/e3/27f57f80141379d60defe6703eb50a707325706f07fedfd1312c7a751995/pyarrow-25.0.1.tar.gz", hash = "sha256:9150a83248bfed9813ea3c3af74c3856c1984d444aa28e58bf7733b9750ddf6a", size = 1201653, upload-time = "2026-08-10T12:40:53.904Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/d6/33a411115b61dbfc16ad6ad73e71730f6fea654ee3667673bc53ab0e2fe7/pyarrow-25.0.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:0befcf816e45a1af33ac775a9970b749e4868a230c7372f0ae5e932bee27039f", size = 50104452, upload-time = "2026-08-10T12:39:04.579Z" },
+    { url = "https://files.pythonhosted.org/packages/98/9e/a112df5cfd5a68cb1d9fc31cfe38c28d5aec9f10865ce37ecef2e4450873/pyarrow-25.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6943e2fe7954d29d84de45d29d34c8dc36ce96570e67d89aa9976e650a4a9138", size = 53144784, upload-time = "2026-08-10T12:39:20.503Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.21.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/2e/ced460408999b33da6b31b0021b0f37d329e202d4169aeb164493778f25b/pygments-2.21.0.tar.gz", hash = "sha256:610ca751c9bc2492b38eb9a38a7fbc93edbbb2d7182edaf34e66ae493dee5c8c", size = 5005329, upload-time = "2026-08-17T08:02:48.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl", hash = "sha256:2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9", size = 1250147, upload-time = "2026-08-17T08:02:44.912Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.18.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7e/74/66de6258867beb2ef08f35f9f2ac017a52cacd5081714d239ff1a442d458/scipy-1.18.1.tar.gz", hash = "sha256:52c4b7422442aba924d03ad4019852b08a92e64ea187b933135687bfe2747307", size = 30781235, upload-time = "2026-08-21T23:28:50.599Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/48/6450ed9243315322bbc19ac57b9b70d66a20bf1d38d124c96bc4bf6af9ea/scipy-1.18.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fdaf5ea890a6183d0565f51a61799d67081bd5b1cf03c5f4b3fd3732108625c9", size = 35312578, upload-time = "2026-08-21T23:25:00.44Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/4e/3c45c33e00a77996c4b1cb707929f833ba7b1d522ee29f882512c330676d/scipy-1.18.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e3b417bf8c2c7c16e8f58ad91db17783ec911ac16e7b50eb6eab6e809b4f5b07", size = 37457323, upload-time = "2026-08-21T23:25:12.483Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "84.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/44/f5da03a8ef95d369145c5bb53050e7877c9f3d312e128605fd9504829143/setuptools-84.0.0.tar.gz", hash = "sha256:f4695c21257f0d9b537ec2692c941d02ee143b7cc1276941349a546573b2ef73", size = 1168449, upload-time = "2026-08-08T18:27:58.365Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/9c/c510029fc6ef33a6275cd2c5d3cecd6613dfd6aa401d57c54f1c18852ccf/setuptools-84.0.0-py3-none-any.whl", hash = "sha256:51a52592b3b99e102b609654876bd65f19f999935166d1352678931132b0c670", size = 818216, upload-time = "2026-08-08T18:27:56.719Z" },
+]
+
+[[package]]
+name = "simple-parsing"
+version = "0.1.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docstring-parser" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/78/137540f597d7937cc9a14681341e7584838aa2697aeeb62adcecc4868581/simple_parsing-0.1.9.tar.gz", hash = "sha256:0ff184ebaa6606420989ddbcb5650b21c62e2a59ec5388bc76c3343bda872cde", size = 256330, upload-time = "2026-07-27T21:16:42.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/de/95277ceb670f0076d0d9ee06ade551d236e4989e2853e15a369bd7c67e5f/simple_parsing-0.1.9-py3-none-any.whl", hash = "sha256:398c6b2c3d6ee3b865a6b8d7413999ee7b373de3c5a047f0b12b03b705d52e16", size = 113702, upload-time = "2026-07-27T21:16:41.828Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "tabulate"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/58/8c37dea7bbf769b20d58e7ace7e5edfe65b849442b00ffcdd56be88697c6/tabulate-0.10.0.tar.gz", hash = "sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d", size = 91754, upload-time = "2026-03-04T18:55:34.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl", hash = "sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3", size = 39814, upload-time = "2026-03-04T18:55:31.284Z" },
+]
+
+[[package]]
+name = "tensorflow"
+version = "2.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "absl-py" },
+    { name = "astunparse" },
+    { name = "flatbuffers" },
+    { name = "gast" },
+    { name = "google-pasta" },
+    { name = "grpcio" },
+    { name = "h5py" },
+    { name = "keras" },
+    { name = "libclang" },
+    { name = "ml-dtypes" },
+    { name = "numpy" },
+    { name = "opt-einsum" },
+    { name = "packaging" },
+    { name = "protobuf" },
+    { name = "requests" },
+    { name = "setuptools" },
+    { name = "six" },
+    { name = "termcolor" },
+    { name = "typing-extensions" },
+    { name = "wrapt" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/6c/10d075ffc09754c7f10e749ba3c9d46dd809fb007990c7f788128044180c/tensorflow-2.21.0-cp313-cp313-manylinux_2_27_x86_64.whl", hash = "sha256:e9d8da8dcab9650efb45f032ba70af2f016f907e6e0c6bda29dd101bba945406", size = 572881074, upload-time = "2026-03-06T17:25:14.453Z" },
+]
+
+[[package]]
+name = "tensorflow-metadata"
+version = "1.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "absl-py" },
+    { name = "googleapis-common-protos" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/85/8c/f82ce771571deed4c69d2b053038385fb7ff7cdca4762cc8f7114b95b4f3/tensorflow_metadata-1.21.0.tar.gz", hash = "sha256:2108ed8ea40df9ac4f7c506a62e9ecf5dcd40678b3308dcee2ec9e0e59d60609", size = 24577, upload-time = "2026-06-09T06:52:43.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/d1/6542ead3ba68ba54a6dbd9a3952514fac9c082b6f8ee860110fdf4c8f366/tensorflow_metadata-1.21.0-py3-none-any.whl", hash = "sha256:0520806bf3bdd9157333203a3aa0e8afde2a97cc619f15ba622603dc6c898d1f", size = 30212, upload-time = "2026-06-09T06:52:42.685Z" },
+]
+
+[[package]]
+name = "termcolor"
+version = "3.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/79/cf31d7a93a8fdc6aa0fbb665be84426a8c5a557d9240b6239e9e11e35fc5/termcolor-3.3.0.tar.gz", hash = "sha256:348871ca648ec6a9a983a13ab626c0acce02f515b9e1983332b17af7979521c5", size = 14434, upload-time = "2025-12-29T12:55:21.882Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/d1/8bb87d21e9aeb323cc03034f5eaf2c8f69841e40e4853c2627edf8111ed3/termcolor-3.3.0-py3-none-any.whl", hash = "sha256:cf642efadaf0a8ebbbf4bc7a31cec2f9b5f21a9f726f4ccbb08192c9c26f43a5", size = 7734, upload-time = "2025-12-29T12:55:20.718Z" },
+]
+
+[[package]]
+name = "tfds-nightly"
+version = "4.9.9.dev202510250044"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "absl-py" },
+    { name = "array-record" },
+    { name = "dm-tree" },
+    { name = "etils", extra = ["edc", "enp", "epath", "epy", "etree"] },
+    { name = "immutabledict" },
+    { name = "numpy" },
+    { name = "promise" },
+    { name = "protobuf" },
+    { name = "psutil" },
+    { name = "pyarrow" },
+    { name = "requests" },
+    { name = "simple-parsing" },
+    { name = "tensorflow-metadata" },
+    { name = "termcolor" },
+    { name = "toml" },
+    { name = "tqdm" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4a/b6/960a7800582d5a4c472afbbf786e4fb6421fe495695ea6a71ab95ff0f88c/tfds_nightly-4.9.9.dev202510250044.tar.gz", hash = "sha256:785f44308caf952f64bd1eae1e810cc61d72f9143d0f6dfaeebd61f6b8610180", size = 3954779, upload-time = "2025-10-25T00:45:38.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/e2/8b6a66a15777ca2a730bc38881e1d7dbc70807ee09e91094f42335676dbf/tfds_nightly-4.9.9.dev202510250044-py3-none-any.whl", hash = "sha256:aa1b56746733af6cebc614bd5f01179e9f46151320cc823973a7eed20b41b32c", size = 5335857, upload-time = "2025-10-25T00:45:32.998Z" },
+]
+
+[[package]]
+name = "toml"
+version = "0.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253, upload-time = "2020-11-01T01:40:22.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588, upload-time = "2020-11-01T01:40:20.672Z" },
+]
+
+[[package]]
+name = "toolz"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/d6/114b492226588d6ff54579d95847662fc69196bdeec318eb45393b24c192/toolz-1.1.0.tar.gz", hash = "sha256:27a5c770d068c110d9ed9323f24f1543e83b2f300a687b7891c1a6d56b697b5b", size = 52613, upload-time = "2025-10-17T04:03:21.661Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl", hash = "sha256:15ccc861ac51c53696de0a5d6d4607f99c210739caf987b5d2054f3efed429d8", size = 58093, upload-time = "2025-10-17T04:03:20.435Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.70.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/3b/6c24bec5be5e743ffd99576daa5cc077722fc7d5bbc00bd133fa0c698dc6/tqdm-4.70.0.tar.gz", hash = "sha256:55b0b0dbd97462d06ebee91e4dac24ed4d4702be82b24f07e6c1d27e08cea220", size = 795438, upload-time = "2026-07-27T11:33:15.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/1c/01bfd571a64e7f270e6bab5e33777debe0edc56759233ce84f27dec92d14/tqdm-4.70.0-py3-none-any.whl", hash = "sha256:7f585706bfddbdebf89daac705b2dfcc16890130727d3197ca62c732b4310953", size = 80184, upload-time = "2026-07-27T11:33:13.167Z" },
+]
+
+[[package]]
+name = "twenty-watts-clrs-generator"
+version = "0.0.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "absl-py" },
+    { name = "attrs" },
+    { name = "chex" },
+    { name = "dm-haiku" },
+    { name = "jax" },
+    { name = "jaxlib" },
+    { name = "ml-collections" },
+    { name = "numpy" },
+    { name = "opt-einsum" },
+    { name = "optax" },
+    { name = "six" },
+    { name = "tensorflow" },
+    { name = "tfds-nightly" },
+    { name = "toolz" },
+    { name = "tqdm" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "absl-py", specifier = ">=2.1.0" },
+    { name = "attrs", specifier = ">=24.2.0" },
+    { name = "chex", specifier = ">=0.1.86" },
+    { name = "dm-haiku", specifier = ">=0.0.12" },
+    { name = "jax", specifier = "==0.11.1" },
+    { name = "jaxlib", specifier = "==0.11.1" },
+    { name = "ml-collections", specifier = ">=0.1.1" },
+    { name = "numpy", specifier = "==2.5.2" },
+    { name = "opt-einsum", specifier = ">=3.3.0" },
+    { name = "optax", specifier = ">=0.2.3" },
+    { name = "six", specifier = ">=1.16.0" },
+    { name = "tensorflow", specifier = "==2.21.0" },
+    { name = "tfds-nightly", specifier = ">=4.9.6.dev202409060044" },
+    { name = "toolz", specifier = ">=0.12.1" },
+    { name = "tqdm", specifier = "==4.70.0" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "wheel"
+version = "0.48.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/20/50ed6bdf27dec98b568a8ae25dc599f35baa3d9709f9e83fd1edb56b9a90/wheel-0.48.0.tar.gz", hash = "sha256:94800765601e9171bf5d58d066e640662842bcedcbab982b2c90787a2c987322", size = 66471, upload-time = "2026-08-11T22:02:27.327Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/29/69cfbb602cd91690c55d38ba9fe53e6a7e76a6fa647bf38f19c138d25449/wheel-0.48.0-py3-none-any.whl", hash = "sha256:3217dcc807155e45db462d7ef2431f5ddda0d7273b700d05a67b271ceb1287ab", size = 33320, upload-time = "2026-08-11T22:02:26.1Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ba/8dc25478ed234dacc7d83c671634f347d0bdfb65bf0502f41879cf2f15a9/wrapt-2.4.0.tar.gz", hash = "sha256:7082fc1f94b020ac275870c4af71b09cff22876fe6e9c4c0ad01ea21d217b288", size = 161179, upload-time = "2026-08-30T04:41:51.424Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/a3/a3b5cde1cd06e04b6e95134eb3187a0a7da607a530e7795b221d4e4fa819/wrapt-2.4.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6436e2bda993a3eb69a1b317fc831c8ebcafb5704c390859ebd49f81218c4bbb", size = 225787, upload-time = "2026-08-30T04:40:02.715Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/0e/974a60672ad507d39a3d8a1c6351ef37fe65b07240d000ceba5d2b83e9e9/wrapt-2.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:3d5e5eb76fb87e62752af751d2dcd9d1cd986b12037d2e1363d109ba716029e8", size = 214654, upload-time = "2026-08-30T04:40:10.923Z" },
+    { url = "https://files.pythonhosted.org/packages/79/c8/fafe0002f572ced999c792cfe8b05d39269c63d8193d15d25bd828bcad7a/wrapt-2.4.0-py3-none-any.whl", hash = "sha256:18aabd9301d06026f5900538051773d6f87f65ae02cdc60de482df978513dc0a", size = 73713, upload-time = "2026-08-30T04:41:49.805Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238, upload-time = "2026-05-18T20:08:57.045Z" },
+]

--- a/tooling/internal/clrsfixture/image_contract.go
+++ b/tooling/internal/clrsfixture/image_contract.go
@@ -22,7 +22,6 @@ var (
 	}
 	lockedGeneratorBlockers = []string{
 		"checksum_closed_build_context",
-		"exact_dependency_lock",
 		"pinned_upstream_license_material",
 		"image_bound_spdx_sbom",
 		"no_network_runtime_smoke",
@@ -71,7 +70,7 @@ func (contract GeneratorImageContract) Validate(
 	if err := validateGeneratorBuilder(contract.Builder); err != nil {
 		return err
 	}
-	if err := validateMissingGeneratorBuildEvidence(contract, source.License); err != nil {
+	if err := validateGeneratorBuildEvidence(contract, source.License); err != nil {
 		return err
 	}
 	if err := validateGeneratorRuntime(contract.Runtime, generation.Output); err != nil {
@@ -121,11 +120,14 @@ func validateGeneratorBuilder(builder GeneratorBuilder) error {
 	return nil
 }
 
-func validateMissingGeneratorBuildEvidence(contract GeneratorImageContract, sourceLicense LicenseIdentity) error {
+func validateGeneratorBuildEvidence(contract GeneratorImageContract, sourceLicense LicenseIdentity) error {
 	lock := contract.DependencyLock
-	if lock.State != "missing" || lock.Path != "tooling/clrs-generator/uv.lock" || lock.SHA256 != "" ||
-		lock.PackageCount != 0 || lock.ArtifactCount != 0 {
-		return errors.New("generator dependency lock must remain explicitly missing")
+	if lock.State != "locked" || lock.ProjectPath != trackedGeneratorProjectPath ||
+		!lowerHex(lock.ProjectSHA256, 64) || lock.Path != trackedGeneratorDependencyLockPath ||
+		!lowerHex(lock.SHA256, 64) || lock.PackageCount <= 0 ||
+		lock.PackageCount > contract.Limits.DependencyPackageCount || lock.ArtifactCount <= 0 ||
+		lock.ArtifactCount > contract.Limits.DependencyArtifactCount {
+		return errors.New("generator dependency lock metadata is invalid")
 	}
 	context := contract.BuildContext
 	if context.State != "missing" || context.DockerfilePath != "tooling/clrs-generator/Dockerfile" ||

--- a/tooling/internal/clrsfixture/image_dependency.go
+++ b/tooling/internal/clrsfixture/image_dependency.go
@@ -1,0 +1,281 @@
+package clrsfixture
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	maximumGeneratorProjectBytes        = 64 << 10
+	maximumGeneratorDependencyLockBytes = 16 << 20
+	lockedGeneratorPackageCount         = 62
+	lockedGeneratorArtifactCount        = 135
+	generatorResolutionMarker           = "implementation_name == 'cpython' and platform_machine == 'x86_64' and sys_platform == 'linux'"
+)
+
+func validateGeneratorDependencyFiles(
+	metadata GeneratorDependencyLock,
+	projectBody, lockBody []byte,
+	input GeneratorLockInput,
+	limits GeneratorImageLimits,
+) error {
+	if metadata.PackageCount != lockedGeneratorPackageCount || metadata.ArtifactCount != lockedGeneratorArtifactCount {
+		return errors.New("generator dependency lock counts differ from the reviewed graph")
+	}
+	if rawSHA256(projectBody) != metadata.ProjectSHA256 || rawSHA256(lockBody) != metadata.SHA256 {
+		return errors.New("generator dependency project or lock digest is invalid")
+	}
+	wantProject, err := renderGeneratorProject(input)
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(projectBody, wantProject) {
+		return errors.New("generator pyproject does not match the reviewed lock input")
+	}
+	packages, artifacts, artifactBytes, err := inspectGeneratorDependencyLock(lockBody, input)
+	if err != nil {
+		return err
+	}
+	if packages != metadata.PackageCount || artifacts != metadata.ArtifactCount {
+		return fmt.Errorf(
+			"generator dependency lock contains %d packages and %d artifacts, want %d and %d",
+			packages,
+			artifacts,
+			metadata.PackageCount,
+			metadata.ArtifactCount,
+		)
+	}
+	if artifactBytes > limits.DependencyArtifactBytes {
+		return fmt.Errorf(
+			"generator dependency lock records %d artifact bytes, limit %d",
+			artifactBytes,
+			limits.DependencyArtifactBytes,
+		)
+	}
+	return nil
+}
+
+func renderGeneratorProject(input GeneratorLockInput) ([]byte, error) {
+	pythonRequirement, err := generatorPythonRequirement(input.Python.Version)
+	if err != nil {
+		return nil, err
+	}
+	pinned := make(map[string]string, len(input.SelectedCandidates))
+	for _, candidate := range input.SelectedCandidates {
+		name := canonicalGeneratorPackageName(candidate.Name)
+		if name == "" || pinned[name] != "" {
+			return nil, errors.New("generator selected requirements contain a duplicate or empty name")
+		}
+		pinned[name] = candidate.Requirement
+	}
+
+	requirements := make([]string, 0, len(input.UpstreamRequirements.Constraints)+len(input.SupplementalRequirements))
+	seen := make(map[string]bool, cap(requirements))
+	for _, constraint := range input.UpstreamRequirements.Constraints {
+		name, suffix, err := splitGeneratorRequirement(constraint)
+		if err != nil {
+			return nil, err
+		}
+		name = canonicalGeneratorPackageName(name)
+		requirement := name + suffix
+		if selected := pinned[name]; selected != "" {
+			requirement = selected
+		}
+		if seen[name] {
+			return nil, fmt.Errorf("generator project requirement %q is repeated", name)
+		}
+		seen[name] = true
+		requirements = append(requirements, requirement)
+	}
+	for _, supplemental := range input.SupplementalRequirements {
+		name, _, err := splitGeneratorRequirement(supplemental.Requirement)
+		if err != nil {
+			return nil, err
+		}
+		name = canonicalGeneratorPackageName(name)
+		if seen[name] {
+			return nil, fmt.Errorf("generator supplemental requirement %q duplicates an upstream requirement", name)
+		}
+		seen[name] = true
+		requirements = append(requirements, supplemental.Requirement)
+	}
+	for _, candidate := range input.SelectedCandidates {
+		name := canonicalGeneratorPackageName(candidate.Name)
+		if !seen[name] {
+			return nil, fmt.Errorf("generator selected requirement %q is absent from the project", name)
+		}
+	}
+
+	var body strings.Builder
+	body.WriteString("[project]\n")
+	body.WriteString("name = \"twenty-watts-clrs-generator\"\n")
+	body.WriteString("version = \"0.0.0\"\n")
+	fmt.Fprintf(&body, "requires-python = %s\n", strconv.Quote(pythonRequirement))
+	body.WriteString("dependencies = [\n")
+	for _, requirement := range requirements {
+		fmt.Fprintf(&body, "  %s,\n", strconv.Quote(requirement))
+	}
+	body.WriteString("]\n\n[tool.uv]\n")
+	body.WriteString("package = false\n")
+	body.WriteString("resolution = \"highest\"\n")
+	fmt.Fprintf(&body, "prerelease = %s\n", strconv.Quote(input.Resolver.Prerelease))
+	fmt.Fprintf(&body, "exclude-newer = %s\n", strconv.Quote(input.Resolver.ExcludeNewer))
+	body.WriteString("environments = [\n")
+	body.WriteString("  \"implementation_name == 'cpython' and sys_platform == 'linux' and platform_machine == 'x86_64'\",\n")
+	body.WriteString("]\n")
+	body.WriteString("required-environments = [\n")
+	body.WriteString("  \"implementation_name == 'cpython' and sys_platform == 'linux' and platform_machine == 'x86_64'\",\n")
+	body.WriteString("]\n")
+	return []byte(body.String()), nil
+}
+
+func inspectGeneratorDependencyLock(body []byte, input GeneratorLockInput) (int, int, int64, error) {
+	if len(body) == 0 || len(body) > maximumGeneratorDependencyLockBytes || body[len(body)-1] != '\n' || bytes.Contains(body, []byte{'\r'}) {
+		return 0, 0, 0, errors.New("generator uv lock has an invalid size or line encoding")
+	}
+	pythonRequirement, err := generatorPythonRequirement(input.Python.Version)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	prefix := fmt.Sprintf(
+		"version = 1\nrevision = 3\nrequires-python = %s\nresolution-markers = [\n    %s,\n]\nsupported-markers = [\n    %s,\n]\nrequired-markers = [\n    %s,\n]\n\n[options]\nexclude-newer = %s\n\n",
+		strconv.Quote(pythonRequirement),
+		strconv.Quote(generatorResolutionMarker),
+		strconv.Quote(generatorResolutionMarker),
+		strconv.Quote(generatorResolutionMarker),
+		strconv.Quote(input.Resolver.ExcludeNewer),
+	)
+	if !bytes.HasPrefix(body, []byte(prefix)) {
+		return 0, 0, 0, errors.New("generator uv lock header differs from the reviewed resolver boundary")
+	}
+	cutoff, err := time.Parse(time.RFC3339, input.Resolver.ExcludeNewer)
+	if err != nil {
+		return 0, 0, 0, errors.New("generator dependency cutoff is invalid")
+	}
+
+	packages := 0
+	artifacts := 0
+	var artifactBytes int64
+	for _, line := range strings.Split(string(body), "\n") {
+		switch {
+		case line == "[[package]]":
+			packages++
+		case strings.HasPrefix(line, "sdist = { url = \"") || strings.HasPrefix(line, "    { url = \""):
+			size, uploadTime, artifactErr := inspectGeneratorArtifact(line)
+			if artifactErr != nil {
+				return 0, 0, 0, artifactErr
+			}
+			if uploadTime.After(cutoff) {
+				return 0, 0, 0, errors.New("generator dependency artifact was uploaded after the resolution cutoff")
+			}
+			artifacts++
+			if size > limitsSafeAddend(artifactBytes) {
+				return 0, 0, 0, errors.New("generator dependency artifact byte sum overflows")
+			}
+			artifactBytes += size
+		}
+	}
+	for _, candidate := range input.SelectedCandidates {
+		identity := "name = " + strconv.Quote(canonicalGeneratorPackageName(candidate.Name)) + "\nversion = " + strconv.Quote(candidate.Version) + "\n"
+		artifact := "url = " + strconv.Quote(candidate.URL) + ", hash = " + strconv.Quote("sha256:"+candidate.SHA256) + ", size = " + strconv.FormatInt(candidate.SizeBytes, 10)
+		if !strings.Contains(string(body), identity) || !strings.Contains(string(body), artifact) {
+			return 0, 0, 0, fmt.Errorf("generator dependency lock is missing selected candidate %q", candidate.Name)
+		}
+	}
+	return packages, artifacts, artifactBytes, nil
+}
+
+func inspectGeneratorArtifact(line string) (int64, time.Time, error) {
+	artifactURL, ok := quotedGeneratorField(line, "url")
+	if !ok {
+		return 0, time.Time{}, errors.New("generator dependency artifact URL is malformed")
+	}
+	parsed, err := url.Parse(artifactURL)
+	if err != nil || parsed.Scheme != "https" || parsed.Host != "files.pythonhosted.org" || parsed.User != nil ||
+		parsed.RawQuery != "" || parsed.Fragment != "" || parsed.Path == "" {
+		return 0, time.Time{}, errors.New("generator dependency artifact URL is outside the locked PyPI host")
+	}
+	hash, ok := quotedGeneratorField(line, "hash")
+	if !ok || !strings.HasPrefix(hash, "sha256:") || !lowerHex(strings.TrimPrefix(hash, "sha256:"), 64) {
+		return 0, time.Time{}, errors.New("generator dependency artifact digest is invalid")
+	}
+	sizeText, ok := scalarGeneratorField(line, "size")
+	if !ok {
+		return 0, time.Time{}, errors.New("generator dependency artifact size is malformed")
+	}
+	size, err := strconv.ParseInt(sizeText, 10, 64)
+	if err != nil || size <= 0 {
+		return 0, time.Time{}, errors.New("generator dependency artifact size is invalid")
+	}
+	uploadText, ok := quotedGeneratorField(line, "upload-time")
+	if !ok {
+		return 0, time.Time{}, errors.New("generator dependency artifact upload time is malformed")
+	}
+	uploadTime, err := time.Parse(time.RFC3339Nano, uploadText)
+	if err != nil {
+		return 0, time.Time{}, errors.New("generator dependency artifact upload time is invalid")
+	}
+	return size, uploadTime, nil
+}
+
+func quotedGeneratorField(line, name string) (string, bool) {
+	prefix := name + " = \""
+	start := strings.Index(line, prefix)
+	if start < 0 {
+		return "", false
+	}
+	start += len(prefix)
+	end := strings.IndexByte(line[start:], '"')
+	if end < 0 {
+		return "", false
+	}
+	return line[start : start+end], true
+}
+
+func scalarGeneratorField(line, name string) (string, bool) {
+	prefix := name + " = "
+	start := strings.Index(line, prefix)
+	if start < 0 {
+		return "", false
+	}
+	start += len(prefix)
+	end := strings.IndexByte(line[start:], ',')
+	if end < 0 {
+		return "", false
+	}
+	return line[start : start+end], true
+}
+
+func splitGeneratorRequirement(requirement string) (string, string, error) {
+	boundary := strings.IndexAny(requirement, "<=>!~ ")
+	if boundary <= 0 {
+		return "", "", fmt.Errorf("generator requirement %q has no version boundary", requirement)
+	}
+	return requirement[:boundary], requirement[boundary:], nil
+}
+
+func generatorPythonRequirement(version string) (string, error) {
+	parts := strings.Split(version, ".")
+	if len(parts) != 3 {
+		return "", fmt.Errorf("generator Python version %q is invalid", version)
+	}
+	for _, part := range parts {
+		if part == "" || strings.Trim(part, "0123456789") != "" {
+			return "", fmt.Errorf("generator Python version %q is invalid", version)
+		}
+	}
+	return "==" + parts[0] + "." + parts[1] + ".*", nil
+}
+
+func canonicalGeneratorPackageName(name string) string {
+	return strings.ToLower(strings.ReplaceAll(name, "_", "-"))
+}
+
+func limitsSafeAddend(current int64) int64 {
+	return int64(^uint64(0)>>1) - current
+}

--- a/tooling/internal/clrsfixture/image_files.go
+++ b/tooling/internal/clrsfixture/image_files.go
@@ -16,10 +16,12 @@ import (
 )
 
 const (
-	trackedSourcePath        = "tooling/clrs-generator/upstream.json"
-	trackedGenerationPath    = "tooling/clrs-generator/contract.json"
-	trackedLockInputPath     = "tooling/clrs-generator/lock-input.json"
-	trackedImageContractPath = "tooling/clrs-generator/image-contract.json"
+	trackedSourcePath                  = "tooling/clrs-generator/upstream.json"
+	trackedGenerationPath              = "tooling/clrs-generator/contract.json"
+	trackedLockInputPath               = "tooling/clrs-generator/lock-input.json"
+	trackedImageContractPath           = "tooling/clrs-generator/image-contract.json"
+	trackedGeneratorProjectPath        = "tooling/clrs-generator/pyproject.toml"
+	trackedGeneratorDependencyLockPath = "tooling/clrs-generator/uv.lock"
 )
 
 // CheckGeneratorImageFoundation validates the complete committed foundation
@@ -49,7 +51,8 @@ func CheckGeneratorImageFoundation(repositoryRoot string) (GeneratorImageFoundat
 	if err != nil {
 		return GeneratorImageFoundation{}, err
 	}
-	if _, err := ParseGeneratorLockInput(lockBody, source); err != nil {
+	lockInput, err := ParseGeneratorLockInput(lockBody, source)
+	if err != nil {
 		return GeneratorImageFoundation{}, err
 	}
 	imageBody, err := readGeneratorFile(root, trackedImageContractPath, maximumGeneratorImageContractBytes)
@@ -63,8 +66,28 @@ func CheckGeneratorImageFoundation(repositoryRoot string) (GeneratorImageFoundat
 	if err := checkGeneratorBuilderAuthority(root, imageContract.Builder); err != nil {
 		return GeneratorImageFoundation{}, err
 	}
-	for _, missing := range []string{
+	projectBody, err := readGeneratorFile(root, imageContract.DependencyLock.ProjectPath, maximumGeneratorProjectBytes)
+	if err != nil {
+		return GeneratorImageFoundation{}, err
+	}
+	dependencyLockBody, err := readGeneratorFile(
+		root,
 		imageContract.DependencyLock.Path,
+		maximumGeneratorDependencyLockBytes,
+	)
+	if err != nil {
+		return GeneratorImageFoundation{}, err
+	}
+	if err := validateGeneratorDependencyFiles(
+		imageContract.DependencyLock,
+		projectBody,
+		dependencyLockBody,
+		lockInput,
+		imageContract.Limits,
+	); err != nil {
+		return GeneratorImageFoundation{}, err
+	}
+	for _, missing := range []string{
 		imageContract.BuildContext.DockerfilePath,
 		imageContract.BuildContext.WheelhouseManifestPath,
 	} {
@@ -75,12 +98,13 @@ func CheckGeneratorImageFoundation(repositoryRoot string) (GeneratorImageFoundat
 	sourceID, _ := source.Identity()
 	generationID, _ := generation.Identity(source)
 	return GeneratorImageFoundation{
-		Authority:           ResultAuthority,
-		State:               imageContract.State,
-		SourceID:            sourceID,
-		GenerationContract:  generationID,
-		LockInputSHA256:     rawSHA256(lockBody),
-		ImageContractSHA256: rawSHA256(imageBody),
+		Authority:            ResultAuthority,
+		State:                imageContract.State,
+		SourceID:             sourceID,
+		GenerationContract:   generationID,
+		LockInputSHA256:      rawSHA256(lockBody),
+		DependencyLockSHA256: rawSHA256(dependencyLockBody),
+		ImageContractSHA256:  rawSHA256(imageBody),
 	}, nil
 }
 

--- a/tooling/internal/clrsfixture/image_lock.go
+++ b/tooling/internal/clrsfixture/image_lock.go
@@ -141,10 +141,10 @@ func validateGeneratorPythonAndResolver(python GeneratorPython, resolver Generat
 		PythonSourceSHA256:     "1e66a7945a48390ee4c2a4268a0e4185884059a13c4aab6d148aa208deea4a76",
 	}
 	wantResolver := GeneratorResolver{
-		Name: "uv", Version: "0.12.7",
-		Image:      "ghcr.io/astral-sh/uv:0.12.7@sha256:95f2aa1fe59274951cfe9b0cbc7972e879ff1004bc8945d130a32eb0dbd85945",
-		Revision:   "61291a8ca5477a9ca653f14d2ac5665587c263fa",
-		Resolution: "highest-compatible", Prerelease: "if-necessary-or-explicit",
+		Name: "uv", Version: "0.12.9",
+		Image:      "ghcr.io/astral-sh/uv:0.12.9@sha256:8b940d3a9d65bed080436972241af2e21c84b5e8c9193f7014ed71479ee795ff",
+		Revision:   "9f928602938ac5cf1cd6b294a725833c16f5720e",
+		Resolution: "highest-compatible", Prerelease: "if-necessary", ExcludeNewer: "2026-08-31T13:22:50Z",
 	}
 	if python != wantPython || resolver != wantResolver {
 		return errors.New("generator Python or uv candidate differs from the reviewed Linux amd64 boundary")

--- a/tooling/internal/clrsfixture/image_model.go
+++ b/tooling/internal/clrsfixture/image_model.go
@@ -36,12 +36,13 @@ type GeneratorPython struct {
 }
 
 type GeneratorResolver struct {
-	Name       string `json:"name"`
-	Version    string `json:"version"`
-	Image      string `json:"image"`
-	Revision   string `json:"revision"`
-	Resolution string `json:"resolution"`
-	Prerelease string `json:"prerelease"`
+	Name         string `json:"name"`
+	Version      string `json:"version"`
+	Image        string `json:"image"`
+	Revision     string `json:"revision"`
+	Resolution   string `json:"resolution"`
+	Prerelease   string `json:"prerelease"`
+	ExcludeNewer string `json:"exclude_newer"`
 }
 
 type GeneratorRequirements struct {
@@ -66,8 +67,8 @@ type SupplementalRequirement struct {
 	Reason      string `json:"reason"`
 }
 
-// GeneratorImageContract is the non-executable blocked image state. Empty
-// evidence identities are intentional until the named acceptance is run.
+// GeneratorImageContract records closed construction inputs and the remaining
+// blocked image evidence. It never grants scientific result authority.
 type GeneratorImageContract struct {
 	SchemaVersion        int                      `json:"schema_version"`
 	Contract             string                   `json:"contract"`
@@ -80,7 +81,7 @@ type GeneratorImageContract struct {
 	GenerationContractID string                   `json:"generation_contract_id"`
 	LockInput            GeneratorFileBinding     `json:"lock_input"`
 	Builder              GeneratorBuilder         `json:"builder"`
-	DependencyLock       MissingDependencyLock    `json:"dependency_lock"`
+	DependencyLock       GeneratorDependencyLock  `json:"dependency_lock"`
 	BuildContext         MissingBuildContext      `json:"build_context"`
 	LicenseMaterial      MissingLicenseMaterial   `json:"license_material"`
 	ImageIdentity        MissingImageIdentity     `json:"image_identity"`
@@ -109,8 +110,10 @@ type GeneratorBuilder struct {
 	SourceDateEpoch       int64  `json:"source_date_epoch"`
 }
 
-type MissingDependencyLock struct {
+type GeneratorDependencyLock struct {
 	State         string `json:"state"`
+	ProjectPath   string `json:"project_path"`
+	ProjectSHA256 string `json:"project_sha256"`
 	Path          string `json:"path"`
 	SHA256        string `json:"sha256"`
 	PackageCount  int    `json:"package_count"`
@@ -231,10 +234,11 @@ type GeneratorImageAcceptance struct {
 // GeneratorImageFoundation is the offline validation result. It records
 // construction closure only and never carries scientific result authority.
 type GeneratorImageFoundation struct {
-	Authority           string
-	State               string
-	SourceID            SourceID
-	GenerationContract  ContractID
-	LockInputSHA256     string
-	ImageContractSHA256 string
+	Authority            string
+	State                string
+	SourceID             SourceID
+	GenerationContract   ContractID
+	LockInputSHA256      string
+	DependencyLockSHA256 string
+	ImageContractSHA256  string
 }

--- a/tooling/internal/clrsfixture/image_test.go
+++ b/tooling/internal/clrsfixture/image_test.go
@@ -10,8 +10,9 @@ import (
 )
 
 const (
-	expectedGeneratorLockInputSHA256 = "d7ff2963aa2f11e3cf001fc095520780539c85e4923448939c9ef9ede41eb827"
-	expectedGeneratorImageSHA256     = "a0da021036c924a8528ddda232bb0fab8ec7545b0819d5ad8b0bd0fc7467d197"
+	expectedGeneratorLockInputSHA256  = "ea0e8f7d2d3ce347e82cbdd0e956dceca3da27ee499b52e18a6f6010526a5a19"
+	expectedGeneratorDependencySHA256 = "1aff6ff0e589539e07b3ee75579803ebd66636ab35568661680a703ed38ab640"
+	expectedGeneratorImageSHA256      = "75ee2897e844d9509a504c09d80a8ffbbc3ad424a18d0556ee281233d419c51f"
 )
 
 func TestTrackedGeneratorImageFoundationIsClosedAndBlocked(t *testing.T) {
@@ -28,8 +29,14 @@ func TestTrackedGeneratorImageFoundationIsClosedAndBlocked(t *testing.T) {
 		t.Fatalf("foundation source/contract = %s/%s", foundation.SourceID, foundation.GenerationContract)
 	}
 	if foundation.LockInputSHA256 != expectedGeneratorLockInputSHA256 ||
+		foundation.DependencyLockSHA256 != expectedGeneratorDependencySHA256 ||
 		foundation.ImageContractSHA256 != expectedGeneratorImageSHA256 {
-		t.Fatalf("foundation lock/image hashes = %s/%s", foundation.LockInputSHA256, foundation.ImageContractSHA256)
+		t.Fatalf(
+			"foundation input/dependency/image hashes = %s/%s/%s",
+			foundation.LockInputSHA256,
+			foundation.DependencyLockSHA256,
+			foundation.ImageContractSHA256,
+		)
 	}
 }
 
@@ -50,7 +57,8 @@ func TestParseGeneratorLockInputRejectsCandidateOrSourceDrift(t *testing.T) {
 		"archive size":       strings.Replace(valid, `"archive_size_bytes": 5347008`, `"archive_size_bytes": 1`, 1),
 		"newer Python":       strings.Replace(valid, `"version": "3.13.15"`, `"version": "3.14.7"`, 1),
 		"mutable base":       strings.Replace(valid, `@sha256:c45a22ea000adfd9cda29364bbe7edd23001ce5cc2ad15857cfbf7766943b9ca`, ``, 1),
-		"resolver drift":     strings.Replace(valid, `"version": "0.12.7"`, `"version": "0.12.8"`, 1),
+		"resolver drift":     strings.Replace(valid, `"version": "0.12.9"`, `"version": "0.12.8"`, 1),
+		"cutoff drift":       strings.Replace(valid, `"exclude_newer": "2026-08-31T13:22:50Z"`, `"exclude_newer": "2026-09-01T00:00:00Z"`, 1),
 		"constraint drift":   strings.Replace(valid, `jax>=0.4.31`, `jax>=0.4.30`, 1),
 		"candidate drift":    strings.Replace(valid, `"requirement": "jax==0.11.1"`, `"requirement": "jax==0.11.0"`, 1),
 		"wheel digest":       strings.Replace(valid, lockedWheelCandidates[0].SHA256, strings.Repeat("b", 64), 1),
@@ -71,6 +79,85 @@ func TestParseGeneratorLockInputRejectsCandidateOrSourceDrift(t *testing.T) {
 	}
 }
 
+func TestRenderedGeneratorProjectMatchesTrackedInput(t *testing.T) {
+	t.Parallel()
+	source := trackedSourceRecord(t)
+	input, err := ParseGeneratorLockInput(trackedGeneratorFile(t, "lock-input.json"), source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	project, err := renderGeneratorProject(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(project, trackedGeneratorFile(t, "pyproject.toml")) {
+		t.Fatal("rendered generator pyproject differs from the tracked file")
+	}
+}
+
+func TestGeneratorDependencyValidationRejectsCoordinatedDrift(t *testing.T) {
+	t.Parallel()
+	source := trackedSourceRecord(t)
+	lockInputBody := trackedGeneratorFile(t, "lock-input.json")
+	input, err := ParseGeneratorLockInput(lockInputBody, source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	generation := trackedGenerationContract(t, source)
+	contract, err := ParseGeneratorImageContract(
+		trackedGeneratorFile(t, "image-contract.json"),
+		lockInputBody,
+		source,
+		generation,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	projectBody := trackedGeneratorFile(t, "pyproject.toml")
+	lockBody := string(trackedGeneratorFile(t, "uv.lock"))
+	tests := map[string]string{
+		"schema revision": strings.Replace(lockBody, "revision = 3", "revision = 2", 1),
+		"late artifact": strings.Replace(
+			lockBody,
+			"2026-07-03T10:57:48.157Z",
+			"2026-09-01T10:57:48.157Z",
+			1,
+		),
+		"selected version": strings.Replace(lockBody, "name = \"jax\"\nversion = \"0.11.1\"", "name = \"jax\"\nversion = \"0.11.0\"", 1),
+		"artifact removed": removeFirstGeneratorArtifactLine(t, lockBody),
+	}
+	for name, body := range tests {
+		name, body := name, body
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			metadata := contract.DependencyLock
+			metadata.SHA256 = rawSHA256([]byte(body))
+			if err := validateGeneratorDependencyFiles(
+				metadata,
+				projectBody,
+				[]byte(body),
+				input,
+				contract.Limits,
+			); err == nil {
+				t.Fatalf("generator dependency validation accepted %s", name)
+			}
+		})
+	}
+
+	tamperedProject := []byte("[project]\nname = \"tampered\"\n")
+	metadata := contract.DependencyLock
+	metadata.ProjectSHA256 = rawSHA256(tamperedProject)
+	if err := validateGeneratorDependencyFiles(
+		metadata,
+		tamperedProject,
+		[]byte(lockBody),
+		input,
+		contract.Limits,
+	); err == nil {
+		t.Fatal("generator dependency validation accepted coordinated pyproject drift")
+	}
+}
+
 func TestParseGeneratorImageContractRejectsPretendedAcceptance(t *testing.T) {
 	t.Parallel()
 	source := trackedSourceRecord(t)
@@ -86,7 +173,7 @@ func TestParseGeneratorImageContractRejectsPretendedAcceptance(t *testing.T) {
 		"wrong source":         strings.Replace(valid, contractSourceIdentity(t), "sha256:"+strings.Repeat("a", 64), 1),
 		"wrong contract":       strings.Replace(valid, expectedContractIdentity, "sha256:"+strings.Repeat("b", 64), 1),
 		"wrong lock digest":    strings.Replace(valid, expectedGeneratorLockInputSHA256, strings.Repeat("c", 64), 1),
-		"dependency admitted":  strings.Replace(valid, `"state": "missing"`, `"state": "locked"`, 1),
+		"dependency missing":   strings.Replace(valid, `"state": "locked"`, `"state": "missing"`, 1),
 		"networked install":    strings.Replace(valid, `"install_network": "none"`, `"install_network": "default"`, 1),
 		"licence SPDX":         strings.Replace(valid, `"spdx": "Apache-2.0"`, `"spdx": "MIT"`, 1),
 		"licence digest":       strings.Replace(valid, `"source_sha256": "cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30"`, `"source_sha256": "`+strings.Repeat("d", 64)+`"`, 1),
@@ -133,7 +220,7 @@ func TestParseGeneratorImageContractRejectsPretendedAcceptance(t *testing.T) {
 	}
 }
 
-func TestGeneratorImageFoundationRejectsSymlinkAndPrematureLock(t *testing.T) {
+func TestGeneratorImageFoundationRejectsSymlinkAndDependencyLockTamper(t *testing.T) {
 	t.Parallel()
 	root := copyGeneratorFoundation(t)
 	lockPath := filepath.Join(root, filepath.FromSlash(trackedLockInputPath))
@@ -157,8 +244,17 @@ func TestGeneratorImageFoundationRejectsSymlinkAndPrematureLock(t *testing.T) {
 	if err := os.WriteFile(uvLock, []byte("premature"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := CheckGeneratorImageFoundation(root); err == nil || !strings.Contains(err.Error(), "exists while its state is missing") {
-		t.Fatalf("CheckGeneratorImageFoundation premature-lock error = %v", err)
+	if _, err := CheckGeneratorImageFoundation(root); err == nil || !strings.Contains(err.Error(), "digest is invalid") {
+		t.Fatalf("CheckGeneratorImageFoundation dependency-lock error = %v", err)
+	}
+
+	root = copyGeneratorFoundation(t)
+	projectPath := filepath.Join(root, filepath.FromSlash(trackedGeneratorProjectPath))
+	if err := os.WriteFile(projectPath, []byte("[project]\nname = \"tampered\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := CheckGeneratorImageFoundation(root); err == nil || !strings.Contains(err.Error(), "digest is invalid") {
+		t.Fatalf("CheckGeneratorImageFoundation project error = %v", err)
 	}
 }
 
@@ -242,6 +338,8 @@ func copyGeneratorFoundation(t *testing.T) string {
 		trackedGenerationPath,
 		trackedLockInputPath,
 		trackedImageContractPath,
+		trackedGeneratorProjectPath,
+		trackedGeneratorDependencyLockPath,
 		"tooling/pdf-renderer/lock.json",
 	}
 	for _, relative := range paths {
@@ -258,4 +356,16 @@ func copyGeneratorFoundation(t *testing.T) string {
 		}
 	}
 	return root
+}
+
+func removeFirstGeneratorArtifactLine(t *testing.T, body string) string {
+	t.Helper()
+	lines := strings.SplitAfter(body, "\n")
+	for index, line := range lines {
+		if strings.HasPrefix(line, "sdist = { url = \"") || strings.HasPrefix(line, "    { url = \"") {
+			return strings.Join(append(lines[:index], lines[index+1:]...), "")
+		}
+	}
+	t.Fatal("tracked generator lock has no artifact line")
+	return ""
 }


### PR DESCRIPTION
## Summary

- pin the CLRS generator Python dependency graph with uv 0.12.9
- validate package identities, artifact hashes, PyPI hosts, upload cutoffs, and byte bounds in Go
- keep the image and experiment at `NO_RESULT`; this closes dependency resolution only, not public-image admission

## Verification

- offline lock reproduction produced the same lock SHA-256
- `go -C tooling test -race -count=1 ./internal/clrsfixture`
- `go -C tooling vet ./internal/clrsfixture`
- aggregate repository gate passed 721/723 checks; its sole failure was the temporary cross-worktree `node_modules` symlink, and the exact runtime-identity test passed after a clean `npm ci`
- independent local Qwen3-4B review found no actionable correctness or authority-boundary defect

Tracks #12.