### PR TITLE
feat(publication): reproduce PDF tools final image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,8 +48,21 @@ the exact diff; this file records why the project changed.
   lock, exact APK retention metadata, upstream source identities, the pinned
   Wolfi root recipe licence, five missing notice files, runtime containment and
   the deterministic final-layer design.
-  Recorded base-image checks remain `NO_RESULT`; final assembly, publication
+  Recorded construction checks remain `NO_RESULT`; source delivery, publication
   and exact-digest CI consumption stay open behind issue 20.
+- A local-only Go reproducer now runs the exact pinned apko assembler twice,
+  canonicalises the two SPDX relationship graphs, projects the base archives
+  into private OCI layouts and builds the final notice layer in two fresh
+  pinned BuildKit 0.32.2 instances. Their daemon networks, memory, PID, CPU,
+  parallelism and exact daemon-side entitlement are checked explicitly; the
+  final builds request no entitlement and use no cache or build network. It compares complete archives
+  and image identities, checks licence bytes, Poppler versions, configured
+  UID/GID, forbidden paths and runtime containment, then writes a bounded
+  atomic `NO_RESULT` receipt. It does not create a source
+  bundle, publish an image or admit a release digest. Runtime cleanup removes
+  only its random alias and leaves shared untagged digest content under Docker
+  cache management, so concurrent local reproductions cannot delete each
+  other's image.
 - Decision 0055 and a source-bound Go contract now freeze the CLRS-Text
   controller shakedown to six named task families, a bounded 48-example
   construction plan and explicit fixed-four-endpoint semantics for segment

--- a/public/downloads/book-manifest.json
+++ b/public/downloads/book-manifest.json
@@ -4,7 +4,7 @@
   "version": "0.3.0",
   "source_ref": "main",
   "pdf": "public/downloads/20-watts-was-enough-full-concept-book.pdf",
-  "source_digest": "72f8a709204364d9b8d1fd13c459c005fe09257891c1936ec14f0e61165b4d21",
+  "source_digest": "f6b590a377b254268d071a5e779d6bfcd1d8bebbfb4f33a0e6ffc9a18fb589ac",
   "source_files": [
     "app/book-content.ts",
     "app/components/book-edition.tsx",

--- a/scripts/book-pdf-semantic-baseline.json
+++ b/scripts/book-pdf-semantic-baseline.json
@@ -7,7 +7,7 @@
     "pdf": "public/downloads/20-watts-was-enough-full-concept-book.pdf",
     "manifest": "public/downloads/book-manifest.json",
     "pdf_sha256": "a3bd7e9fb4982e5fd63d07b301a3dfa7152b1d64dd7c744c9fcf4ceebaa422c8",
-    "manifest_sha256": "24adf9768c54601c87528ab5c0fc5c5913a95662f4a843b3f214e4e79c71e529",
+    "manifest_sha256": "2f07d6af5e6db08ed0f1e162642c62ccc9f69ba34a439a7b9aa597eefab18421",
     "size_bytes": 12780003,
     "pages": 412,
     "page_size_name": "A4",
@@ -18,7 +18,7 @@
     "pdf_version": "1.4",
     "tagged": true,
     "source_ref": "main",
-    "source_digest": "72f8a709204364d9b8d1fd13c459c005fe09257891c1936ec14f0e61165b4d21",
+    "source_digest": "f6b590a377b254268d071a5e779d6bfcd1d8bebbfb4f33a0e6ffc9a18fb589ac",
     "version": "0.3.0"
   },
   "tools": {

--- a/tooling/cmd/20w/main.go
+++ b/tooling/cmd/20w/main.go
@@ -52,6 +52,7 @@ func usage(writer io.Writer) {
 	fmt.Fprintln(writer, "  20w experiment package-node-image --artifact <id> --output <directory> [--root <repository>]")
 	fmt.Fprintln(writer, "  20w publication render-pdf [--root <repository>] [--ref main|vMAJOR.MINOR.PATCH] [--revision <commit>] [--check]")
 	fmt.Fprintln(writer, "  20w publication verify-pdf-tools [--root <repository>]")
+	fmt.Fprintln(writer, "  20w publication reproduce-pdf-tools-image --receipt <new.json> [--root <repository>]")
 	fmt.Fprintln(writer, "  20w publication verify-pdf-reproducibility --receipt <new.json> [--root <repository>] [--ref main|vMAJOR.MINOR.PATCH]")
 	fmt.Fprintln(writer, "  20w publication verify-public-transport [--root <repository>] [--check]")
 	fmt.Fprintln(writer, "  20w translation export-candidate --source <concept-or-math.md> --language <code> --output <new.json> [--root <repository>]")
@@ -133,6 +134,9 @@ func run(arguments []string, stdout, stderr io.Writer) int {
 		}
 		if len(arguments) >= 2 && arguments[1] == "verify-pdf-tools" {
 			return runPublicationVerifyPDFTools(arguments[2:], stdout, stderr)
+		}
+		if len(arguments) >= 2 && arguments[1] == "reproduce-pdf-tools-image" {
+			return runPublicationReproducePDFToolsImage(arguments[2:], stdout, stderr)
 		}
 		if len(arguments) >= 2 && arguments[1] == "verify-pdf-reproducibility" {
 			return runPublicationVerifyPDFReproducibility(arguments[2:], stdout, stderr)

--- a/tooling/cmd/20w/pdf_tools.go
+++ b/tooling/cmd/20w/pdf_tools.go
@@ -1,9 +1,13 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"io"
+	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/lusoris/20-watts-was-enough/tooling/internal/pdftools"
 )
@@ -27,6 +31,37 @@ func runPublicationVerifyPDFTools(arguments []string, stdout, stderr io.Writer) 
 		result.Notices,
 		result.RetainedBytes,
 		result.LockSHA256,
+	)
+	return 0
+}
+
+func runPublicationReproducePDFToolsImage(arguments []string, stdout, stderr io.Writer) int {
+	flags := flag.NewFlagSet("publication reproduce-pdf-tools-image", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	root := flags.String("root", ".", "repository root")
+	receipt := flags.String("receipt", "", "new repository-relative NO_RESULT receipt")
+	if err := flags.Parse(arguments); err != nil || flags.NArg() != 0 || *receipt == "" {
+		if *receipt == "" {
+			fmt.Fprintln(stderr, "publication reproduce-pdf-tools-image requires --receipt <new.json>")
+		}
+		return 2
+	}
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	result, err := pdftools.ReproduceFinalImage(ctx, pdftools.ReproductionOptions{
+		RepositoryRoot: *root,
+		ReceiptPath:    *receipt,
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "Reproduce local PDF-tools final image: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(
+		stdout,
+		"Local PDF-tools construction passed under %s; final manifest %s; retained %s.\n",
+		result.Authority,
+		result.FinalBuilds[0].Manifest,
+		*receipt,
 	)
 	return 0
 }

--- a/tooling/cmd/20w/pdf_tools_test.go
+++ b/tooling/cmd/20w/pdf_tools_test.go
@@ -28,3 +28,13 @@ func TestRunPublicationVerifyPDFToolsRejectsUnexpectedArguments(t *testing.T) {
 		t.Fatalf("run() exit = %d, want 2", exit)
 	}
 }
+
+func TestRunPublicationReproducePDFToolsImageRequiresNewReceipt(t *testing.T) {
+	t.Parallel()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exit := run([]string{"publication", "reproduce-pdf-tools-image"}, &stdout, &stderr)
+	if exit != 2 || !strings.Contains(stderr.String(), "requires --receipt") {
+		t.Fatalf("run() exit/stdout/stderr = %d/%q/%q", exit, stdout.String(), stderr.String())
+	}
+}

--- a/tooling/internal/pdftools/check.go
+++ b/tooling/internal/pdftools/check.go
@@ -12,58 +12,86 @@ import (
 
 const contractRelativePath = "tooling/pdf-tools/contract.json"
 
+type checkedAuthority struct {
+	root             string
+	contract         Contract
+	contractSHA256   string
+	lockSHA256       string
+	renderer         pdfrender.Configuration
+	packages         int
+	notices          int
+	retainedAPKBytes int64
+}
+
 // Check validates the complete committed PDF-tools authority without network or containers.
 func Check(repositoryRoot string) (Result, error) {
-	root, err := cleanRoot(repositoryRoot)
+	authority, err := checkAuthority(repositoryRoot)
 	if err != nil {
 		return Result{}, err
+	}
+	return Result{
+		ContractSHA256: authority.contractSHA256,
+		LockSHA256:     authority.lockSHA256,
+		Packages:       authority.packages,
+		Notices:        authority.notices,
+		RetainedBytes:  authority.retainedAPKBytes,
+	}, nil
+}
+
+func checkAuthority(repositoryRoot string) (checkedAuthority, error) {
+	root, err := cleanRoot(repositoryRoot)
+	if err != nil {
+		return checkedAuthority{}, err
 	}
 	contractBody, err := readRelative(root, contractRelativePath, "PDF-tools contract", 64*1024)
 	if err != nil {
-		return Result{}, err
+		return checkedAuthority{}, err
 	}
 	contract, err := decodeCanonical[Contract](contractBody, 8, "PDF-tools contract")
 	if err != nil {
-		return Result{}, err
+		return checkedAuthority{}, err
 	}
 	if err := validateContract(contract); err != nil {
-		return Result{}, fmt.Errorf("validate PDF-tools contract: %w", err)
+		return checkedAuthority{}, fmt.Errorf("validate PDF-tools contract: %w", err)
 	}
 	configBody, err := checkConfig(root, contract)
 	if err != nil {
-		return Result{}, err
+		return checkedAuthority{}, err
 	}
 	locked, err := loadLock(root, contract, configBody)
 	if err != nil {
-		return Result{}, err
+		return checkedAuthority{}, err
 	}
 	retention, err := loadRetention(root, contract, locked)
 	if err != nil {
-		return Result{}, err
+		return checkedAuthority{}, err
 	}
 	if err := checkNoticesAndRecipe(root, contract); err != nil {
-		return Result{}, err
+		return checkedAuthority{}, err
 	}
 	renderer, err := pdfrender.Check(root)
 	if err != nil {
-		return Result{}, fmt.Errorf("validate notice-layer BuildKit authority: %w", err)
+		return checkedAuthority{}, fmt.Errorf("validate notice-layer BuildKit authority: %w", err)
 	}
 	buildKitAuthority, err := json.Marshal(struct {
 		Builder  pdfrender.Builder  `json:"builder"`
 		Exporter pdfrender.Exporter `json:"exporter"`
 	}{Builder: renderer.Lock.Builder, Exporter: renderer.Lock.Exporter})
 	if err != nil {
-		return Result{}, fmt.Errorf("encode notice-layer BuildKit authority: %w", err)
+		return checkedAuthority{}, fmt.Errorf("encode notice-layer BuildKit authority: %w", err)
 	}
 	if rawDigest(buildKitAuthority) != contract.NoticeLayer.BuildKitAuthoritySHA256 {
-		return Result{}, errors.New("notice-layer BuildKit authority digest does not match contract.json")
+		return checkedAuthority{}, errors.New("notice-layer BuildKit authority digest does not match contract.json")
 	}
-	return Result{
-		ContractSHA256: rawDigest(contractBody),
-		LockSHA256:     contract.Apko.LockSHA256,
-		Packages:       len(locked),
-		Notices:        len(contract.NoticeLayer.Entries),
-		RetainedBytes:  retention.TotalBytes,
+	return checkedAuthority{
+		root:             root,
+		contract:         contract,
+		contractSHA256:   rawDigest(contractBody),
+		lockSHA256:       contract.Apko.LockSHA256,
+		renderer:         renderer,
+		packages:         len(locked),
+		notices:          len(contract.NoticeLayer.Entries),
+		retainedAPKBytes: retention.TotalBytes,
 	}, nil
 }
 

--- a/tooling/internal/pdftools/contract.go
+++ b/tooling/internal/pdftools/contract.go
@@ -84,7 +84,11 @@ func validateApko(value Apko) error {
 }
 
 func validateBase(value BaseImage, limits Limits) error {
-	for _, digest := range []string{value.ArchiveSHA256, value.SPDXSHA256} {
+	for _, digest := range []string{
+		value.ArchiveSHA256,
+		value.SPDXCanonicalSHA256,
+		value.SPDXIndexCanonicalSHA256,
+	} {
 		if !rawDigestPattern.MatchString(digest) {
 			return errors.New("base archive or SPDX digest is invalid")
 		}
@@ -95,8 +99,14 @@ func validateBase(value BaseImage, limits Limits) error {
 		}
 	}
 	if value.ArchiveSize < 1_000_000 || value.ArchiveSize > limits.BaseArchiveBytes ||
-		value.SPDXSize < 10_000 || value.SPDXSize > 4*1024*1024 {
+		value.SPDXSize < 10_000 || value.SPDXSize > limits.SPDXBytes ||
+		value.SPDXCanonicalSize < 10_000 || value.SPDXCanonicalSize > limits.SPDXBytes ||
+		value.SPDXIndexCanonicalSize <= 0 || value.SPDXIndexCanonicalSize > limits.SPDXBytes {
 		return errors.New("base archive or SPDX size is outside its bound")
+	}
+	if value.SPDXPackages != 209 || value.SPDXPackages > limits.SPDXPackages ||
+		value.SPDXRelationships != 225 || value.SPDXRelationships > limits.SPDXRelationships {
+		return errors.New("base SPDX graph count is invalid")
 	}
 	return nil
 }
@@ -214,10 +224,30 @@ func validateDeliveryAndLimits(delivery SourceDelivery, apko Apko, limits Limits
 		limits.Packages >= delivery.APKCount && limits.Packages <= 256,
 		limits.NoticeBytes >= 64*1024 && limits.NoticeBytes <= 4*1024*1024,
 		limits.BaseArchiveBytes >= 32*1024*1024 && limits.BaseArchiveBytes <= 512*1024*1024,
+		limits.FinalArchiveBytes >= limits.BaseArchiveBytes && limits.FinalArchiveBytes <= 512*1024*1024,
 		limits.SourceBundleBytes >= 32*1024*1024 && limits.SourceBundleBytes <= 512*1024*1024,
+		limits.SPDXBytes >= 256*1024 && limits.SPDXBytes <= 16*1024*1024,
+		limits.SPDXPackages >= 209 && limits.SPDXPackages <= 4_096,
+		limits.SPDXRelationships >= 225 && limits.SPDXRelationships <= 16_384,
+		limits.APKControlBytes >= 1024*1024 && limits.APKControlBytes <= 64*1024*1024,
+		limits.APKDataBytes >= 64*1024*1024 && limits.APKDataBytes <= limits.SourceBundleBytes,
+		limits.APKIndexBytes >= 16*1024*1024 && limits.APKIndexBytes <= 512*1024*1024,
+		limits.HTTPResponseBytes >= 64*1024*1024 && limits.HTTPResponseBytes <= limits.SourceBundleBytes,
 		limits.LockSeconds >= 30 && limits.LockSeconds <= 600,
 		limits.BuildSeconds >= 60 && limits.BuildSeconds <= 1800,
+		limits.RuntimeSeconds >= 5 && limits.RuntimeSeconds <= 120,
 		limits.CapturedOutputBytes >= 64*1024 && limits.CapturedOutputBytes <= 16*1024*1024,
+		limits.ReceiptBytes >= 64*1024 && limits.ReceiptBytes <= 4*1024*1024,
+		limits.ApkoMemoryBytes >= 512*1024*1024 && limits.ApkoMemoryBytes <= 16*1024*1024*1024,
+		limits.ApkoPIDs >= 64 && limits.ApkoPIDs <= 2_048,
+		limits.ApkoTemporaryBytes >= 128*1024*1024 && limits.ApkoTemporaryBytes <= 8*1024*1024*1024,
+		limits.BuildKitMemoryBytes >= 512*1024*1024 && limits.BuildKitMemoryBytes <= 8*1024*1024*1024,
+		limits.BuildKitPIDs >= 64 && limits.BuildKitPIDs <= 1_024,
+		limits.BuildKitCPUPeriod >= 10_000 && limits.BuildKitCPUPeriod <= 1_000_000,
+		limits.BuildKitCPUQuota >= limits.BuildKitCPUPeriod && limits.BuildKitCPUQuota <= 8*limits.BuildKitCPUPeriod,
+		limits.RuntimeMemoryBytes >= 64*1024*1024 && limits.RuntimeMemoryBytes <= 2*1024*1024*1024,
+		limits.RuntimePIDs >= 16 && limits.RuntimePIDs <= 256,
+		limits.RuntimeTemporaryBytes >= 1024*1024 && limits.RuntimeTemporaryBytes <= 256*1024*1024,
 	}
 	if slices.Contains(checks, false) {
 		return errors.New("one or more PDF-tools resource limits are invalid")

--- a/tooling/internal/pdftools/docker_command.go
+++ b/tooling/internal/pdftools/docker_command.go
@@ -1,0 +1,365 @@
+package pdftools
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+)
+
+const maximumDockerWaitDelay = 5 * time.Second
+
+type dockerRequest struct {
+	operation   string
+	directory   string
+	timeout     time.Duration
+	output      int64
+	arguments   []string
+	files       []boundedDockerFile
+	directories []boundedDockerDirectory
+}
+
+type boundedDockerFile struct {
+	path    string
+	maximum int64
+	label   string
+}
+
+type boundedDockerDirectory struct {
+	path           string
+	maximum        int64
+	maximumEntries int
+	maximumDepth   int
+	label          string
+}
+
+type dockerResult struct {
+	stdout []byte
+	stderr []byte
+}
+
+type dockerExecutor interface {
+	run(context.Context, dockerRequest) (dockerResult, error)
+}
+
+type localDockerExecutor struct{}
+
+type boundedDockerOutput struct {
+	mutex    sync.Mutex
+	buffer   bytes.Buffer
+	limit    int64
+	written  int64
+	exceeded bool
+}
+
+func verifyLocalDockerEndpoint(
+	ctx context.Context,
+	executor dockerExecutor,
+	authority checkedAuthority,
+) error {
+	result, err := executor.run(ctx, dockerRequest{
+		operation: "verify local Docker endpoint",
+		directory: authority.root,
+		timeout:   30 * time.Second,
+		output:    authority.contract.Limits.CapturedOutputBytes,
+		arguments: []string{"context", "inspect", "default", "--format", "{{json .Endpoints.docker.Host}}"},
+	})
+	if err != nil {
+		return err
+	}
+	if len(result.stderr) != 0 {
+		return errors.New("Docker context inspection wrote unexpected stderr")
+	}
+	endpoint, err := decodeArtifactJSON[string](result.stdout, 4, "Docker endpoint")
+	if err != nil {
+		return err
+	}
+	if !strings.HasPrefix(endpoint, "unix://") && !strings.HasPrefix(endpoint, "npipe://") {
+		return errors.New("Docker default context is not a local Unix socket or Windows named pipe")
+	}
+	return nil
+}
+
+func (output *boundedDockerOutput) Write(body []byte) (int, error) {
+	output.mutex.Lock()
+	defer output.mutex.Unlock()
+	remaining := output.limit - output.written
+	accepted := int64(len(body))
+	if accepted > remaining {
+		accepted = remaining
+	}
+	if accepted > 0 {
+		_, _ = output.buffer.Write(body[:accepted])
+	}
+	output.written += int64(len(body))
+	if output.written > output.limit {
+		output.exceeded = true
+	}
+	return len(body), nil
+}
+
+func (output *boundedDockerOutput) result() ([]byte, bool) {
+	output.mutex.Lock()
+	defer output.mutex.Unlock()
+	return bytes.Clone(output.buffer.Bytes()), output.exceeded
+}
+
+func (localDockerExecutor) run(ctx context.Context, request dockerRequest) (dockerResult, error) {
+	if request.operation == "" || request.timeout <= 0 || request.output <= 0 || len(request.arguments) == 0 {
+		return dockerResult{}, errors.New("invalid bounded Docker request")
+	}
+	timeoutContext, timeoutCancel := context.WithTimeout(ctx, request.timeout)
+	defer timeoutCancel()
+	commandContext, commandCancel := context.WithCancelCause(timeoutContext)
+	defer commandCancel(nil)
+	stdout := &boundedDockerOutput{limit: request.output}
+	stderr := &boundedDockerOutput{limit: request.output}
+	dockerBinary, err := exec.LookPath("docker")
+	if err != nil {
+		return dockerResult{}, errors.New("Docker CLI is required for local PDF-tools reproduction")
+	}
+	arguments := append([]string{"--context", "default"}, request.arguments...)
+	command := exec.CommandContext(commandContext, dockerBinary, arguments...)
+	command.Dir = request.directory
+	command.Env = boundedDockerEnvironment()
+	command.Stdout = stdout
+	command.Stderr = stderr
+	command.WaitDelay = maximumDockerWaitDelay
+	monitorDone := make(chan error, 1)
+	go monitorBoundedDockerOutputs(commandContext, commandCancel, request.files, request.directories, monitorDone)
+	err = command.Run()
+	commandCause := context.Cause(commandContext)
+	commandCancel(nil)
+	monitorError := <-monitorDone
+	stdoutBody, stdoutExceeded := stdout.result()
+	stderrBody, stderrExceeded := stderr.result()
+	result := dockerResult{stdout: stdoutBody, stderr: stderrBody}
+	if monitorError != nil {
+		return result, fmt.Errorf("%s: %w", request.operation, monitorError)
+	}
+	if commandCause != nil {
+		return result, fmt.Errorf("%s: %w", request.operation, commandCause)
+	}
+	if stdoutExceeded || stderrExceeded {
+		return result, fmt.Errorf("%s: Docker output exceeds %d bytes per stream", request.operation, request.output)
+	}
+	if err != nil {
+		return result, dockerCommandFailure(request.operation, err, result)
+	}
+	return result, nil
+}
+
+func boundedDockerEnvironment() []string {
+	wanted := []string{"HOME", "PATH", "TEMP", "TMP", "USERPROFILE", "XDG_RUNTIME_DIR"}
+	if runtime.GOOS == "windows" {
+		wanted = append(wanted, "COMSPEC", "PATHEXT", "SYSTEMROOT")
+	}
+	environment := make([]string, 0, len(wanted)+3)
+	for _, name := range wanted {
+		if value := os.Getenv(name); value != "" && !strings.ContainsRune(value, '\x00') {
+			environment = append(environment, name+"="+value)
+		}
+	}
+	return append(environment, "LANG=C.UTF-8", "LC_ALL=C.UTF-8", "TZ=UTC")
+}
+
+func monitorBoundedDockerOutputs(
+	ctx context.Context,
+	cancel context.CancelCauseFunc,
+	files []boundedDockerFile,
+	directories []boundedDockerDirectory,
+	done chan<- error,
+) {
+	if len(files) == 0 && len(directories) == 0 {
+		done <- nil
+		return
+	}
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			done <- validateBoundedDockerOutputs(files, directories)
+			return
+		case <-ticker.C:
+			if err := validateBoundedDockerOutputs(files, directories); err != nil {
+				cancel(err)
+				done <- err
+				return
+			}
+		}
+	}
+}
+
+func validateBoundedDockerOutputs(files []boundedDockerFile, directories []boundedDockerDirectory) error {
+	for _, file := range files {
+		if file.path == "" || file.maximum <= 0 || file.label == "" {
+			return errors.New("invalid Docker output-file boundary")
+		}
+		information, err := os.Lstat(file.path)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("inspect bounded %s: %w", file.label, err)
+		}
+		if !information.Mode().IsRegular() || information.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("%s output is not a regular file", file.label)
+		}
+		if information.Size() > file.maximum {
+			return fmt.Errorf("%s output exceeds %d bytes", file.label, file.maximum)
+		}
+	}
+	for _, directory := range directories {
+		if err := validateBoundedDockerDirectory(directory); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateBoundedDockerDirectory(directory boundedDockerDirectory) error {
+	if directory.path == "" || directory.maximum <= 0 || directory.maximumEntries <= 0 ||
+		directory.maximumDepth <= 0 || directory.label == "" {
+		return errors.New("invalid Docker output-directory boundary")
+	}
+	var bytes int64
+	if _, err := os.Lstat(directory.path); errors.Is(err, os.ErrNotExist) {
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("inspect bounded %s: %w", directory.label, err)
+	}
+	err := walkBoundedTree(
+		directory.path,
+		directory.maximumEntries,
+		directory.maximumDepth,
+		func(_ string, _ string, information os.FileInfo) error {
+			if information.Mode().IsRegular() {
+				bytes += information.Size()
+				if bytes > directory.maximum {
+					return fmt.Errorf("%s output exceeds its aggregate-byte boundary", directory.label)
+				}
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("inspect bounded %s: %w", directory.label, err)
+	}
+	return nil
+}
+
+// walkBoundedTree enumerates directory entries in fixed-size batches so the
+// entry limit applies before a filesystem can force an unbounded ReadDir or
+// filepath.WalkDir allocation. The callback excludes root itself.
+func walkBoundedTree(
+	root string,
+	maximumEntries, maximumDepth int,
+	visit func(path, relative string, information os.FileInfo) error,
+) error {
+	if maximumEntries <= 0 || maximumDepth <= 0 || visit == nil {
+		return errors.New("invalid bounded filesystem traversal")
+	}
+	rootInformation, err := os.Lstat(root)
+	if err != nil {
+		return err
+	}
+	if !rootInformation.IsDir() || rootInformation.Mode()&os.ModeSymlink != 0 {
+		return errors.New("bounded filesystem root is not a real directory")
+	}
+	type pendingDirectory struct {
+		path        string
+		depth       int
+		information os.FileInfo
+	}
+	pending := []pendingDirectory{{path: root, depth: 0, information: rootInformation}}
+	entries := 0
+	for len(pending) > 0 {
+		directory := pending[len(pending)-1]
+		pending = pending[:len(pending)-1]
+		file, err := os.Open(directory.path)
+		if err != nil {
+			return err
+		}
+		opened, statError := file.Stat()
+		current, lstatError := os.Lstat(directory.path)
+		if statError != nil || lstatError != nil || !opened.IsDir() || !current.IsDir() ||
+			current.Mode()&os.ModeSymlink != 0 || !os.SameFile(directory.information, opened) ||
+			!os.SameFile(opened, current) {
+			_ = file.Close()
+			return errors.New("bounded filesystem directory changed before enumeration")
+		}
+		for {
+			batch, readError := file.ReadDir(64)
+			for _, entry := range batch {
+				entries++
+				depth := directory.depth + 1
+				if entries > maximumEntries || depth > maximumDepth {
+					_ = file.Close()
+					return errors.New("bounded filesystem exceeds its entry-count or path-depth boundary")
+				}
+				name := entry.Name()
+				if name == "" || name == "." || name == ".." || strings.ContainsAny(name, "/\\\x00") {
+					_ = file.Close()
+					return errors.New("bounded filesystem contains a non-canonical entry name")
+				}
+				path := filepath.Join(directory.path, name)
+				information, err := os.Lstat(path)
+				if err != nil {
+					_ = file.Close()
+					return err
+				}
+				if information.Mode()&os.ModeSymlink != 0 || (!information.IsDir() && !information.Mode().IsRegular()) {
+					_ = file.Close()
+					return errors.New("bounded filesystem contains an unsupported entry type")
+				}
+				relative, err := filepath.Rel(root, path)
+				if err != nil || relative == "." || filepath.IsAbs(relative) ||
+					strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+					_ = file.Close()
+					return errors.New("bounded filesystem entry escapes its root")
+				}
+				if err := visit(path, filepath.ToSlash(relative), information); err != nil {
+					_ = file.Close()
+					return err
+				}
+				if information.IsDir() {
+					pending = append(pending, pendingDirectory{path: path, depth: depth, information: information})
+				}
+			}
+			if errors.Is(readError, io.EOF) {
+				break
+			}
+			if readError != nil {
+				_ = file.Close()
+				return readError
+			}
+		}
+		if err := file.Close(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func dockerCommandFailure(operation string, err error, result dockerResult) error {
+	diagnostic := strings.TrimSpace(string(result.stderr))
+	if diagnostic == "" {
+		diagnostic = strings.TrimSpace(string(result.stdout))
+	}
+	if len(diagnostic) > 8*1024 {
+		diagnostic = diagnostic[:8*1024] + "..."
+	}
+	if diagnostic == "" {
+		return fmt.Errorf("%s: %w", operation, err)
+	}
+	return fmt.Errorf("%s: %w: %s", operation, err, diagnostic)
+}

--- a/tooling/internal/pdftools/final_archive.go
+++ b/tooling/internal/pdftools/final_archive.go
@@ -1,0 +1,451 @@
+package pdftools
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+	"time"
+)
+
+var ociBlobPathPattern = regexp.MustCompile(`^blobs/sha256/([0-9a-f]{64})$`)
+
+type inspectedFinalImage struct {
+	Identity imageIdentity
+	Layout   string
+	Manifest ociManifest
+	Config   ociImageConfig
+}
+
+func inspectFinalArchive(ctx context.Context, archivePath, layoutRoot string, contract Contract) (inspectedFinalImage, error) {
+	if _, err := os.Lstat(layoutRoot); !errors.Is(err, os.ErrNotExist) {
+		if err == nil {
+			return inspectedFinalImage{}, errors.New("final OCI inspection root already exists")
+		}
+		return inspectedFinalImage{}, fmt.Errorf("inspect final OCI inspection root: %w", err)
+	}
+	if err := os.Mkdir(layoutRoot, 0o700); err != nil {
+		return inspectedFinalImage{}, fmt.Errorf("create final OCI inspection root: %w", err)
+	}
+	archive, err := openBoundedRegular(archivePath, contract.Limits.FinalArchiveBytes, "final OCI archive")
+	if err != nil {
+		return inspectedFinalImage{}, err
+	}
+	defer archive.Close()
+	hasher := sha256.New()
+	counting := &countingReader{source: io.TeeReader(archive, hasher)}
+	paths, err := extractFinalOCITar(ctx, tar.NewReader(counting), layoutRoot, contract.Limits.FinalArchiveBytes)
+	if err != nil {
+		return inspectedFinalImage{}, err
+	}
+	if err := drainZeroTarPadding(ctx, counting, contract.Limits.FinalArchiveBytes-counting.count); err != nil {
+		return inspectedFinalImage{}, err
+	}
+	if counting.count <= 0 || counting.count > contract.Limits.FinalArchiveBytes {
+		return inspectedFinalImage{}, errors.New("final OCI archive exceeds its byte boundary")
+	}
+	if err := verifyOpenedRegular(archivePath, archive, counting.count, "final OCI archive"); err != nil {
+		return inspectedFinalImage{}, err
+	}
+	image, err := validateFinalOCILayout(layoutRoot, paths, contract)
+	if err != nil {
+		return inspectedFinalImage{}, err
+	}
+	image.Identity.ArchiveSHA256 = hex.EncodeToString(hasher.Sum(nil))
+	image.Identity.ArchiveSize = counting.count
+	return image, nil
+}
+
+func extractFinalOCITar(
+	ctx context.Context,
+	reader *tar.Reader,
+	root string,
+	maximumBytes int64,
+) (map[string]struct{}, error) {
+	paths := make(map[string]struct{})
+	var regularBytes int64
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		header, err := reader.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("read final OCI archive: %w", err)
+		}
+		name := strings.TrimSuffix(header.Name, "/")
+		if !validFinalOCIPath(name) || len(paths) >= 16 {
+			return nil, fmt.Errorf("final OCI archive path %q is not admitted", header.Name)
+		}
+		if _, duplicate := paths[name]; duplicate {
+			return nil, fmt.Errorf("final OCI archive repeats path %q", name)
+		}
+		paths[name] = struct{}{}
+		destination := filepath.Join(root, filepath.FromSlash(name))
+		if !hasExactReproductionTarMetadata(header, 0) {
+			return nil, fmt.Errorf(
+				"final OCI archive path %q has non-canonical metadata (uid=%d gid=%d uname=%q gname=%q mtime=%s atime=%s ctime=%s pax=%d xattrs=%d dev=%d:%d)",
+				name, header.Uid, header.Gid, header.Uname, header.Gname, header.ModTime.UTC().Format(time.RFC3339Nano),
+				header.AccessTime.UTC().Format(time.RFC3339Nano), header.ChangeTime.UTC().Format(time.RFC3339Nano),
+				len(header.PAXRecords), len(header.Xattrs), header.Devmajor, header.Devminor,
+			)
+		}
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if (header.Name != name && header.Name != name+"/") || name != "blobs" && name != "blobs/sha256" ||
+				header.Size != 0 || header.Mode != 0o755 || header.Uid != 0 || header.Gid != 0 || header.Linkname != "" {
+				return nil, fmt.Errorf("final OCI archive directory %q is not admitted", name)
+			}
+			if err := os.MkdirAll(destination, 0o755); err != nil {
+				return nil, fmt.Errorf("create final OCI directory: %w", err)
+			}
+		case tar.TypeReg:
+			if header.Name != name || header.Size <= 0 || header.Size > maximumBytes ||
+				header.Mode != exactFinalOCIFileMode(name) ||
+				header.Uid != 0 || header.Gid != 0 || header.Linkname != "" {
+				return nil, fmt.Errorf(
+					"final OCI archive file %q has invalid shape (size=%d mode=%#o uid=%d gid=%d link=%q)",
+					name, header.Size, header.Mode, header.Uid, header.Gid, header.Linkname,
+				)
+			}
+			regularBytes += header.Size
+			if regularBytes > maximumBytes {
+				return nil, errors.New("final OCI archive regular bytes exceed their aggregate boundary")
+			}
+			if err := os.MkdirAll(filepath.Dir(destination), 0o755); err != nil {
+				return nil, fmt.Errorf("create final OCI blob directory: %w", err)
+			}
+			if err := extractExactTarFile(destination, reader, header.Size); err != nil {
+				return nil, err
+			}
+		default:
+			return nil, fmt.Errorf("final OCI archive entry %q is not a regular file or directory", name)
+		}
+	}
+	return paths, nil
+}
+
+func exactFinalOCIFileMode(name string) int64 {
+	if name == "index.json" {
+		return 0o644
+	}
+	return 0o444
+}
+
+func hasExactReproductionTarMetadata(header *tar.Header, sourceDateEpoch int64) bool {
+	return header.Uname == "" && header.Gname == "" && header.Devmajor == 0 && header.Devminor == 0 &&
+		len(header.PAXRecords) == 0 && len(header.Xattrs) == 0 &&
+		header.ModTime.Equal(time.Unix(sourceDateEpoch, 0)) &&
+		header.AccessTime.IsZero() && header.ChangeTime.IsZero()
+}
+
+func drainZeroTarPadding(ctx context.Context, reader io.Reader, maximum int64) error {
+	if maximum < 0 {
+		return errors.New("final OCI archive exceeds its byte boundary")
+	}
+	buffer := make([]byte, 128*1024)
+	var read int64
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		count, err := reader.Read(buffer)
+		if count > 0 {
+			read += int64(count)
+			if read > maximum {
+				return errors.New("final OCI archive padding exceeds its byte boundary")
+			}
+			if !allZero(buffer[:count]) {
+				return errors.New("final OCI archive contains non-zero bytes after its tar terminator")
+			}
+		}
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("read final OCI archive padding: %w", err)
+		}
+	}
+}
+
+func allZero(body []byte) bool {
+	for _, value := range body {
+		if value != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func validFinalOCIPath(name string) bool {
+	return name == "oci-layout" || name == "index.json" || name == "blobs" || name == "blobs/sha256" ||
+		ociBlobPathPattern.MatchString(name)
+}
+
+func extractExactTarFile(path string, reader io.Reader, size int64) (returnError error) {
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	if err != nil {
+		return fmt.Errorf("create extracted OCI file: %w", err)
+	}
+	complete := false
+	defer func() {
+		_ = file.Close()
+		if !complete {
+			_ = os.Remove(path)
+		}
+	}()
+	written, err := io.CopyN(file, reader, size)
+	if err != nil || written != size {
+		return errors.New("final OCI archive file ended before its declared size")
+	}
+	if err := file.Sync(); err != nil {
+		return fmt.Errorf("sync extracted OCI file: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close extracted OCI file: %w", err)
+	}
+	complete = true
+	return nil
+}
+
+func validateFinalOCILayout(root string, paths map[string]struct{}, contract Contract) (inspectedFinalImage, error) {
+	layoutBody, err := readTemporaryFile(filepath.Join(root, "oci-layout"), 1024, "OCI layout version")
+	if err != nil {
+		return inspectedFinalImage{}, err
+	}
+	if !bytes.Equal(layoutBody, []byte("{\"imageLayoutVersion\":\"1.0.0\"}")) {
+		return inspectedFinalImage{}, errors.New("final archive OCI layout version is invalid")
+	}
+	indexBody, err := readTemporaryFile(filepath.Join(root, "index.json"), 64*1024, "final OCI index")
+	if err != nil {
+		return inspectedFinalImage{}, err
+	}
+	index, err := decodeArtifactJSON[ociIndex](indexBody, 8, "final OCI index")
+	if err != nil {
+		return inspectedFinalImage{}, err
+	}
+	if index.SchemaVersion != 2 || index.MediaType != ociIndexMediaType || len(index.Manifests) != 1 {
+		return inspectedFinalImage{}, errors.New("final OCI index is not one image manifest")
+	}
+	descriptor := index.Manifests[0]
+	if descriptor.MediaType != ociManifestMediaType || !digestPattern.MatchString(descriptor.Digest) ||
+		descriptor.Size <= 0 || descriptor.Size > 64*1024 || descriptor.Platform == nil ||
+		*descriptor.Platform != (ociPlatform{Architecture: "amd64", OS: "linux"}) || descriptor.ArtifactType != "" ||
+		!validFinalIndexAnnotations(descriptor.Annotations, contract) || len(index.Annotations) != 0 {
+		return inspectedFinalImage{}, errors.New("final OCI index descriptor is invalid")
+	}
+	manifestBody, err := readDescriptorBlob(root, descriptor, "final OCI manifest")
+	if err != nil {
+		return inspectedFinalImage{}, err
+	}
+	manifest, err := decodeArtifactJSON[ociManifest](manifestBody, 8, "final OCI manifest")
+	if err != nil {
+		return inspectedFinalImage{}, err
+	}
+	if err := validateFinalManifest(manifest, contract); err != nil {
+		return inspectedFinalImage{}, err
+	}
+	configBody, err := readDescriptorBlob(root, manifest.Config, "final OCI config")
+	if err != nil {
+		return inspectedFinalImage{}, err
+	}
+	config, err := decodeArtifactJSON[ociImageConfig](configBody, 8, "final OCI config")
+	if err != nil {
+		return inspectedFinalImage{}, err
+	}
+	if err := validateFinalConfig(config, manifest, contract); err != nil {
+		return inspectedFinalImage{}, err
+	}
+	for _, layer := range manifest.Layers {
+		if _, err := readDescriptorBlob(root, layer, "final OCI layer"); err != nil {
+			return inspectedFinalImage{}, err
+		}
+	}
+	if err := validateFinalOCIPaths(paths, descriptor, manifest); err != nil {
+		return inspectedFinalImage{}, err
+	}
+	layers := make([]string, len(manifest.Layers))
+	for index, layer := range manifest.Layers {
+		layers[index] = layer.Digest
+	}
+	return inspectedFinalImage{
+		Identity: imageIdentity{
+			ManifestDigest: descriptor.Digest,
+			ConfigDigest:   manifest.Config.Digest,
+			LayerDigests:   layers,
+			LayerDiffIDs:   slices.Clone(config.RootFS.DiffIDs),
+		},
+		Layout:   root,
+		Manifest: manifest,
+		Config:   config,
+	}, nil
+}
+
+func validateFinalManifest(manifest ociManifest, contract Contract) error {
+	if manifest.SchemaVersion != 2 || manifest.MediaType != ociManifestMediaType || len(manifest.Layers) != 2 ||
+		manifest.Config.MediaType != ociConfigMediaType || !digestPattern.MatchString(manifest.Config.Digest) ||
+		manifest.Config.Size <= 0 || manifest.Config.Size > 64*1024 || manifest.Config.Platform != nil ||
+		manifest.Config.ArtifactType != "" || len(manifest.Config.Annotations) != 0 || len(manifest.Annotations) != 0 {
+		return errors.New("final OCI manifest shape is invalid")
+	}
+	for index, layer := range manifest.Layers {
+		if layer.MediaType != ociLayerMediaType || !digestPattern.MatchString(layer.Digest) ||
+			layer.Size <= 0 || layer.Size > contract.Limits.FinalArchiveBytes || layer.Platform != nil ||
+			layer.ArtifactType != "" {
+			return fmt.Errorf("final OCI layer %d descriptor is invalid", index+1)
+		}
+	}
+	if manifest.Layers[0].Digest != contract.BaseImage.LayerDigest ||
+		manifest.Layers[0].Digest == manifest.Layers[1].Digest || len(manifest.Layers[0].Annotations) != 0 ||
+		!equalStringMap(manifest.Layers[1].Annotations, map[string]string{
+			"buildkit/rewritten-timestamp": decimalInt64(contract.SourceDateEpoch),
+		}) {
+		return errors.New("final OCI manifest does not preserve one exact base layer plus one notice layer")
+	}
+	return nil
+}
+
+func validateFinalConfig(config ociImageConfig, manifest ociManifest, contract Contract) error {
+	created := expectedImageAnnotations(contract)["org.opencontainers.image.created"]
+	if config.Architecture != "amd64" || config.OS != "linux" ||
+		config.Author != "github.com/chainguard-dev/apko" || config.Created != created || config.RootFS.Type != "layers" ||
+		len(config.RootFS.DiffIDs) != 2 || config.RootFS.DiffIDs[0] != contract.BaseImage.LayerDiffID ||
+		!digestPattern.MatchString(config.RootFS.DiffIDs[1]) || config.Config.User != "65532" ||
+		!equalStringMap(config.Config.Labels, expectedImageAnnotations(contract)) ||
+		!slices.Equal(config.Config.Env, []string{"PATH=/usr/bin", "SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt"}) {
+		return errors.New("final OCI config does not preserve the base runtime identity")
+	}
+	if len(config.History) != 2 || config.History[0].Author != "apko" || config.History[0].Created != created ||
+		config.History[0].CreatedBy != "apko" || config.History[0].Comment != "This is an apko single-layer image" ||
+		config.History[0].EmptyLayer || config.History[1].Author != "" || config.History[1].Created != created ||
+		config.History[1].CreatedBy != "COPY --chown=0:0 notices/ /usr/share/licenses/poppler/ # buildkit" ||
+		config.History[1].Comment != "buildkit.dockerfile.v0" || config.History[1].EmptyLayer {
+		return errors.New("final OCI config does not contain exactly one notice-copy history entry")
+	}
+	if manifest.Config.Digest == contract.BaseImage.ConfigDigest {
+		return errors.New("final OCI config identity did not change after the notice layer")
+	}
+	return nil
+}
+
+func validFinalIndexAnnotations(values map[string]string, contract Contract) bool {
+	created := time.Unix(contract.SourceDateEpoch, 0).UTC().Format(time.RFC3339)
+	return equalStringMap(values, map[string]string{
+		"org.opencontainers.image.created": created,
+	})
+}
+
+func readDescriptorBlob(root string, descriptor ociDescriptor, label string) ([]byte, error) {
+	if !digestPattern.MatchString(descriptor.Digest) || descriptor.Size <= 0 {
+		return nil, fmt.Errorf("%s descriptor is invalid", label)
+	}
+	path := filepath.Join(root, "blobs", "sha256", strings.TrimPrefix(descriptor.Digest, "sha256:"))
+	body, err := readTemporaryFile(path, descriptor.Size, label)
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(body)) != descriptor.Size || digestRaw(body) != strings.TrimPrefix(descriptor.Digest, "sha256:") {
+		return nil, fmt.Errorf("%s bytes differ from their descriptor", label)
+	}
+	return body, nil
+}
+
+func readTemporaryFile(path string, maximum int64, label string) ([]byte, error) {
+	file, err := openBoundedRegular(path, maximum, label)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	body, err := io.ReadAll(io.LimitReader(file, maximum+1))
+	if err != nil || int64(len(body)) > maximum {
+		return nil, fmt.Errorf("read bounded %s", label)
+	}
+	if err := verifyOpenedRegular(path, file, int64(len(body)), label); err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+
+func validateFinalOCIPaths(paths map[string]struct{}, manifestDescriptor ociDescriptor, manifest ociManifest) error {
+	wanted := map[string]struct{}{
+		"oci-layout":   {},
+		"index.json":   {},
+		"blobs":        {},
+		"blobs/sha256": {},
+	}
+	for _, descriptor := range append([]ociDescriptor{manifestDescriptor, manifest.Config}, manifest.Layers...) {
+		wanted["blobs/sha256/"+strings.TrimPrefix(descriptor.Digest, "sha256:")] = struct{}{}
+	}
+	if len(paths) != len(wanted) {
+		return errors.New("final OCI archive contains an unreferenced or missing path")
+	}
+	for path := range wanted {
+		if _, exists := paths[path]; !exists {
+			return fmt.Errorf("final OCI archive omits %s", path)
+		}
+	}
+	return nil
+}
+
+func equalRegularFiles(left, right string, maximum int64) (bool, error) {
+	leftFile, err := openBoundedRegular(left, maximum, "first compared archive")
+	if err != nil {
+		return false, err
+	}
+	defer leftFile.Close()
+	rightFile, err := openBoundedRegular(right, maximum, "second compared archive")
+	if err != nil {
+		return false, err
+	}
+	defer rightFile.Close()
+	leftInfo, leftStatError := leftFile.Stat()
+	rightInfo, rightStatError := rightFile.Stat()
+	if leftStatError != nil || rightStatError != nil {
+		return false, errors.New("inspect compared archive sizes")
+	}
+	if leftInfo.Size() != rightInfo.Size() {
+		return false, nil
+	}
+	leftBuffer := make([]byte, 128*1024)
+	rightBuffer := make([]byte, 128*1024)
+	remaining := leftInfo.Size()
+	for remaining > 0 {
+		chunk := int64(len(leftBuffer))
+		if chunk > remaining {
+			chunk = remaining
+		}
+		leftCount, leftError := io.ReadFull(leftFile, leftBuffer[:chunk])
+		rightCount, rightError := io.ReadFull(rightFile, rightBuffer[:chunk])
+		if leftError != nil || rightError != nil {
+			return false, errors.New("compared archive changed before its declared size")
+		}
+		if leftCount != rightCount || !bytes.Equal(leftBuffer[:leftCount], rightBuffer[:rightCount]) {
+			return false, nil
+		}
+		remaining -= int64(leftCount)
+	}
+	var leftExtra, rightExtra [1]byte
+	leftCount, leftError := leftFile.Read(leftExtra[:])
+	rightCount, rightError := rightFile.Read(rightExtra[:])
+	if leftCount != 0 || rightCount != 0 || !errors.Is(leftError, io.EOF) || !errors.Is(rightError, io.EOF) {
+		return false, errors.New("compared archive grew beyond its declared size")
+	}
+	if err := verifyOpenedRegular(left, leftFile, leftInfo.Size(), "first compared archive"); err != nil {
+		return false, err
+	}
+	if err := verifyOpenedRegular(right, rightFile, rightInfo.Size(), "second compared archive"); err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/tooling/internal/pdftools/final_archive_test.go
+++ b/tooling/internal/pdftools/final_archive_test.go
@@ -1,0 +1,89 @@
+package pdftools
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"testing"
+	"time"
+)
+
+func TestExtractFinalOCITarRequiresCanonicalOuterMetadata(t *testing.T) {
+	t.Parallel()
+	const epoch = int64(1_785_757_696)
+	mutations := map[string]func(*tar.Header){
+		"wrong mode": func(header *tar.Header) {
+			header.Mode = 0o644
+		},
+		"wrong timestamp": func(header *tar.Header) {
+			header.ModTime = time.Unix(epoch+1, 0)
+		},
+		"user name": func(header *tar.Header) {
+			header.Uname = "root"
+		},
+		"PAX record": func(header *tar.Header) {
+			header.PAXRecords = map[string]string{"comment": "unexpected"}
+		},
+	}
+
+	exact := finalOuterTarFixture(t, 0, nil)
+	if _, err := extractFinalOCITar(
+		context.Background(), tar.NewReader(bytes.NewReader(exact)), t.TempDir(), int64(len(exact)),
+	); err != nil {
+		t.Fatalf("exact outer metadata rejected: %v", err)
+	}
+	for name, mutate := range mutations {
+		name, mutate := name, mutate
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			body := finalOuterTarFixture(t, 0, mutate)
+			if _, err := extractFinalOCITar(
+				context.Background(), tar.NewReader(bytes.NewReader(body)), t.TempDir(), int64(len(body)),
+			); err == nil {
+				t.Fatalf("outer OCI tar accepted %s mutation", name)
+			}
+		})
+	}
+}
+
+func TestFinalIndexRequiresExactPinnedExporterAnnotation(t *testing.T) {
+	t.Parallel()
+	contract := Contract{SourceDateEpoch: 1_785_757_696}
+	created := time.Unix(contract.SourceDateEpoch, 0).UTC().Format(time.RFC3339)
+	if !validFinalIndexAnnotations(map[string]string{"org.opencontainers.image.created": created}, contract) {
+		t.Fatal("exact pinned exporter annotation was rejected")
+	}
+	for _, annotations := range []map[string]string{
+		nil,
+		{},
+		{"org.opencontainers.image.created": created, "unexpected": "value"},
+	} {
+		if validFinalIndexAnnotations(annotations, contract) {
+			t.Fatalf("non-exact exporter annotations were accepted: %#v", annotations)
+		}
+	}
+}
+
+func finalOuterTarFixture(t *testing.T, epoch int64, mutate func(*tar.Header)) []byte {
+	t.Helper()
+	body := []byte("{\"imageLayoutVersion\":\"1.0.0\"}\n")
+	header := tar.Header{
+		Name: "oci-layout", Typeflag: tar.TypeReg, Mode: 0o444,
+		Uid: 0, Gid: 0, Size: int64(len(body)), ModTime: time.Unix(epoch, 0),
+	}
+	if mutate != nil {
+		mutate(&header)
+	}
+	var archive bytes.Buffer
+	writer := tar.NewWriter(&archive)
+	if err := writer.WriteHeader(&header); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := writer.Write(body); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return archive.Bytes()
+}

--- a/tooling/internal/pdftools/image_archive.go
+++ b/tooling/internal/pdftools/image_archive.go
@@ -1,0 +1,497 @@
+package pdftools
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/lusoris/20-watts-was-enough/tooling/internal/strictjson"
+)
+
+const (
+	ociConfigMediaType   = "application/vnd.oci.image.config.v1+json"
+	ociIndexMediaType    = "application/vnd.oci.image.index.v1+json"
+	ociLayerMediaType    = "application/vnd.oci.image.layer.v1.tar+gzip"
+	ociManifestMediaType = "application/vnd.oci.image.manifest.v1+json"
+)
+
+type imageIdentity struct {
+	ArchiveSHA256  string
+	ArchiveSize    int64
+	ManifestDigest string
+	ConfigDigest   string
+	LayerDigests   []string
+	LayerDiffIDs   []string
+}
+
+type ociDescriptor struct {
+	MediaType    string            `json:"mediaType"`
+	Digest       string            `json:"digest"`
+	Size         int64             `json:"size"`
+	Annotations  map[string]string `json:"annotations,omitempty"`
+	Platform     *ociPlatform      `json:"platform,omitempty"`
+	ArtifactType string            `json:"artifactType,omitempty"`
+}
+
+type ociPlatform struct {
+	Architecture string `json:"architecture"`
+	OS           string `json:"os"`
+}
+
+type ociIndex struct {
+	SchemaVersion int               `json:"schemaVersion"`
+	MediaType     string            `json:"mediaType"`
+	Manifests     []ociDescriptor   `json:"manifests"`
+	Annotations   map[string]string `json:"annotations,omitempty"`
+}
+
+type ociManifest struct {
+	SchemaVersion int               `json:"schemaVersion"`
+	MediaType     string            `json:"mediaType"`
+	Config        ociDescriptor     `json:"config"`
+	Layers        []ociDescriptor   `json:"layers"`
+	Annotations   map[string]string `json:"annotations,omitempty"`
+}
+
+type ociImageConfig struct {
+	Architecture string `json:"architecture"`
+	Author       string `json:"author"`
+	Created      string `json:"created"`
+	History      []struct {
+		Author     string `json:"author"`
+		Created    string `json:"created"`
+		CreatedBy  string `json:"created_by"`
+		Comment    string `json:"comment"`
+		EmptyLayer bool   `json:"empty_layer,omitempty"`
+	} `json:"history"`
+	OS     string `json:"os"`
+	RootFS struct {
+		Type    string   `json:"type"`
+		DiffIDs []string `json:"diff_ids"`
+	} `json:"rootfs"`
+	Config struct {
+		Env    []string          `json:"Env"`
+		Labels map[string]string `json:"Labels"`
+		User   string            `json:"User"`
+	} `json:"config"`
+}
+
+type dockerArchiveEntry struct {
+	Config   string   `json:"Config"`
+	RepoTags []string `json:"RepoTags"`
+	Layers   []string `json:"Layers"`
+}
+
+func projectBaseArchive(ctx context.Context, archivePath, layoutRoot string, authority checkedAuthority) (imageIdentity, error) {
+	contract := authority.contract
+	if _, err := os.Lstat(layoutRoot); !errors.Is(err, os.ErrNotExist) {
+		if err == nil {
+			return imageIdentity{}, errors.New("base OCI projection root already exists")
+		}
+		return imageIdentity{}, fmt.Errorf("inspect base OCI projection root: %w", err)
+	}
+	if err := os.Mkdir(layoutRoot, 0o700); err != nil {
+		return imageIdentity{}, fmt.Errorf("create base OCI projection root: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Join(layoutRoot, "blobs", "sha256"), 0o700); err != nil {
+		return imageIdentity{}, fmt.Errorf("create base OCI layout: %w", err)
+	}
+	archive, err := openBoundedRegular(archivePath, contract.Limits.BaseArchiveBytes, "apko Docker archive")
+	if err != nil {
+		return imageIdentity{}, err
+	}
+	defer archive.Close()
+	hasher := sha256.New()
+	counting := &countingReader{source: io.TeeReader(archive, hasher)}
+	reader := tar.NewReader(counting)
+	small, err := projectBaseTarEntries(ctx, reader, layoutRoot, contract)
+	if err != nil {
+		return imageIdentity{}, err
+	}
+	remaining := contract.Limits.BaseArchiveBytes - counting.count
+	if remaining < 0 {
+		return imageIdentity{}, errors.New("apko Docker archive exceeds the base archive boundary")
+	}
+	if _, err := io.Copy(io.Discard, io.LimitReader(counting, remaining+1)); err != nil {
+		return imageIdentity{}, fmt.Errorf("finish hashing apko Docker archive: %w", err)
+	}
+	if counting.count > contract.Limits.BaseArchiveBytes {
+		return imageIdentity{}, errors.New("apko Docker archive grew beyond the base archive boundary")
+	}
+	archiveSHA := hex.EncodeToString(hasher.Sum(nil))
+	if counting.count != contract.BaseImage.ArchiveSize || archiveSHA != contract.BaseImage.ArchiveSHA256 {
+		return imageIdentity{}, errors.New("apko Docker archive bytes differ from the committed base identity")
+	}
+	if err := verifyOpenedRegular(archivePath, archive, counting.count, "apko Docker archive"); err != nil {
+		return imageIdentity{}, err
+	}
+	if err := writeOCILayoutFile(layoutRoot, contract.SourceDateEpoch); err != nil {
+		return imageIdentity{}, err
+	}
+	identity, err := validateProjectedBase(layoutRoot, small, contract)
+	if err != nil {
+		return imageIdentity{}, err
+	}
+	identity.ArchiveSHA256 = archiveSHA
+	identity.ArchiveSize = counting.count
+	return identity, nil
+}
+
+type projectedSmallFiles struct {
+	dockerManifest []byte
+	index          []byte
+	manifest       []byte
+	config         []byte
+}
+
+func projectBaseTarEntries(ctx context.Context, reader *tar.Reader, layoutRoot string, contract Contract) (projectedSmallFiles, error) {
+	base := contract.BaseImage
+	wanted := map[string]string{
+		"manifest.json":     "docker",
+		"index.json":        "index",
+		base.ManifestDigest: "manifest",
+		base.ConfigDigest:   "config",
+		strings.TrimPrefix(base.LayerDigest, "sha256:") + ".tar.gz": "layer",
+	}
+	seen := make(map[string]bool, len(wanted))
+	var files projectedSmallFiles
+	for {
+		if err := ctx.Err(); err != nil {
+			return files, err
+		}
+		header, err := reader.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return files, fmt.Errorf("read apko Docker archive: %w", err)
+		}
+		role, admitted := wanted[header.Name]
+		if !admitted || seen[header.Name] || header.Typeflag != tar.TypeReg || header.Size <= 0 ||
+			header.Mode != 0o644 || header.Uid != 0 || header.Gid != 0 {
+			return files, fmt.Errorf("apko Docker archive entry %q is not admitted", header.Name)
+		}
+		seen[header.Name] = true
+		if err := projectBaseTarEntry(reader, header.Size, role, layoutRoot, contract, &files); err != nil {
+			return files, err
+		}
+	}
+	if len(seen) != len(wanted) {
+		return files, errors.New("apko Docker archive omits one or more exact entries")
+	}
+	return files, nil
+}
+
+func projectBaseTarEntry(reader io.Reader, size int64, role, layoutRoot string, contract Contract, files *projectedSmallFiles) error {
+	if size > contract.Limits.BaseArchiveBytes {
+		return errors.New("apko Docker archive entry exceeds the base archive boundary")
+	}
+	if role == "layer" {
+		destination := filepath.Join(layoutRoot, "blobs", "sha256", strings.TrimPrefix(contract.BaseImage.LayerDigest, "sha256:"))
+		return writeExactStream(destination, reader, size, contract.BaseImage.LayerDigest, contract.SourceDateEpoch)
+	}
+	if size > 64*1024 {
+		return fmt.Errorf("apko Docker archive %s metadata exceeds 65536 bytes", role)
+	}
+	body, err := io.ReadAll(io.LimitReader(reader, size+1))
+	if err != nil || int64(len(body)) != size {
+		return fmt.Errorf("read apko Docker archive %s metadata", role)
+	}
+	var destination string
+	switch role {
+	case "docker":
+		files.dockerManifest = body
+		return nil
+	case "index":
+		files.index = body
+		destination = filepath.Join(layoutRoot, "index.json")
+	case "manifest":
+		files.manifest = body
+		destination = filepath.Join(layoutRoot, "blobs", "sha256", strings.TrimPrefix(contract.BaseImage.ManifestDigest, "sha256:"))
+	case "config":
+		files.config = body
+		destination = filepath.Join(layoutRoot, "blobs", "sha256", strings.TrimPrefix(contract.BaseImage.ConfigDigest, "sha256:"))
+	default:
+		return errors.New("unknown apko Docker archive projection role")
+	}
+	return writeExactBytes(destination, body, contract.SourceDateEpoch)
+}
+
+func validateProjectedBase(layoutRoot string, files projectedSmallFiles, contract Contract) (imageIdentity, error) {
+	base := contract.BaseImage
+	if digestRaw(files.manifest) != strings.TrimPrefix(base.ManifestDigest, "sha256:") ||
+		digestRaw(files.config) != strings.TrimPrefix(base.ConfigDigest, "sha256:") {
+		return imageIdentity{}, errors.New("apko OCI manifest or config bytes do not match their names")
+	}
+	dockerManifest, err := decodeArtifactJSON[[]dockerArchiveEntry](files.dockerManifest, 5, "apko Docker manifest")
+	if err != nil {
+		return imageIdentity{}, err
+	}
+	wantDocker := []dockerArchiveEntry{{
+		Config:   base.ConfigDigest,
+		RepoTags: []string{"index.docker.io/library/pdf-tools:26.08.0-r0-amd64"},
+		Layers:   []string{strings.TrimPrefix(base.LayerDigest, "sha256:") + ".tar.gz"},
+	}}
+	if !slices.EqualFunc(dockerManifest, wantDocker, equalDockerArchiveEntry) {
+		return imageIdentity{}, errors.New("apko Docker manifest differs from its exact single-platform projection")
+	}
+	index, err := decodeArtifactJSON[ociIndex](files.index, 8, "apko OCI index")
+	if err != nil {
+		return imageIdentity{}, err
+	}
+	manifest, err := decodeArtifactJSON[ociManifest](files.manifest, 8, "apko OCI manifest")
+	if err != nil {
+		return imageIdentity{}, err
+	}
+	config, err := decodeArtifactJSON[ociImageConfig](files.config, 8, "apko OCI config")
+	if err != nil {
+		return imageIdentity{}, err
+	}
+	if err := validateBaseOCI(index, manifest, config, int64(len(files.manifest)), int64(len(files.config)), contract); err != nil {
+		return imageIdentity{}, err
+	}
+	layerPath := filepath.Join(layoutRoot, "blobs", "sha256", strings.TrimPrefix(base.LayerDigest, "sha256:"))
+	if err := verifyBlobFile(layerPath, manifest.Layers[0]); err != nil {
+		return imageIdentity{}, err
+	}
+	return imageIdentity{
+		ManifestDigest: base.ManifestDigest,
+		ConfigDigest:   base.ConfigDigest,
+		LayerDigests:   []string{base.LayerDigest},
+		LayerDiffIDs:   []string{base.LayerDiffID},
+	}, nil
+}
+
+func validateBaseOCI(index ociIndex, manifest ociManifest, config ociImageConfig, manifestSize, configSize int64, contract Contract) error {
+	base := contract.BaseImage
+	annotations := expectedImageAnnotations(contract)
+	if index.SchemaVersion != 2 || index.MediaType != ociIndexMediaType || len(index.Manifests) != 1 ||
+		!equalStringMap(index.Annotations, annotations) {
+		return errors.New("apko OCI index identity or annotations are invalid")
+	}
+	descriptor := index.Manifests[0]
+	if descriptor.MediaType != ociManifestMediaType || descriptor.Digest != base.ManifestDigest || descriptor.Size != manifestSize ||
+		descriptor.Platform == nil || *descriptor.Platform != (ociPlatform{Architecture: "amd64", OS: "linux"}) ||
+		descriptor.ArtifactType != ociConfigMediaType || len(descriptor.Annotations) != 0 {
+		return errors.New("apko OCI index descriptor is invalid")
+	}
+	if manifest.SchemaVersion != 2 || manifest.MediaType != ociManifestMediaType || len(manifest.Layers) != 1 ||
+		!equalStringMap(manifest.Annotations, annotations) {
+		return errors.New("apko OCI manifest identity or annotations are invalid")
+	}
+	if manifest.Config.MediaType != ociConfigMediaType || manifest.Config.Digest != base.ConfigDigest ||
+		manifest.Config.Size != configSize || manifest.Config.Platform != nil || manifest.Config.ArtifactType != "" ||
+		len(manifest.Config.Annotations) != 0 {
+		return errors.New("apko OCI config descriptor is invalid")
+	}
+	layer := manifest.Layers[0]
+	if layer.MediaType != ociLayerMediaType || layer.Digest != base.LayerDigest || layer.Size <= 0 ||
+		layer.Platform != nil || layer.ArtifactType != "" || len(layer.Annotations) != 0 {
+		return errors.New("apko OCI layer descriptor is invalid")
+	}
+	return validateBaseOCIConfig(config, contract)
+}
+
+func validateBaseOCIConfig(config ociImageConfig, contract Contract) error {
+	created := time.Unix(contract.SourceDateEpoch, 0).UTC().Format(time.RFC3339)
+	if config.Architecture != "amd64" || config.OS != "linux" || config.Author != "github.com/chainguard-dev/apko" ||
+		config.Created != created || config.RootFS.Type != "layers" ||
+		!slices.Equal(config.RootFS.DiffIDs, []string{contract.BaseImage.LayerDiffID}) ||
+		config.Config.User != "65532" ||
+		!slices.Equal(config.Config.Env, []string{"PATH=/usr/bin", "SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt"}) ||
+		!equalStringMap(config.Config.Labels, expectedImageAnnotations(contract)) {
+		return errors.New("apko OCI config differs from the committed runtime identity")
+	}
+	if len(config.History) != 1 || config.History[0].Author != "apko" || config.History[0].Created != created ||
+		config.History[0].CreatedBy != "apko" || config.History[0].Comment != "This is an apko single-layer image" ||
+		config.History[0].EmptyLayer {
+		return errors.New("apko OCI history differs from the deterministic base identity")
+	}
+	return nil
+}
+
+func expectedImageAnnotations(contract Contract) map[string]string {
+	return map[string]string{
+		"io.github.lusoris.20-watts-was-enough.image-name":       contract.Image,
+		"io.github.lusoris.20-watts-was-enough.poppler-version":  contract.Runtime.RequiredTools[0].Version,
+		"io.github.lusoris.20-watts-was-enough.result-authority": contract.ResultAuthority,
+		"org.opencontainers.image.created":                       time.Unix(contract.SourceDateEpoch, 0).UTC().Format(time.RFC3339),
+		"org.opencontainers.image.description":                   "Locked Poppler tools for bounded publication audits",
+		"org.opencontainers.image.source":                        "https://github.com/lusoris/20-watts-was-enough",
+		"org.opencontainers.image.title":                         "20 Watts Was Enough PDF tools",
+	}
+}
+
+func equalDockerArchiveEntry(left, right dockerArchiveEntry) bool {
+	return left.Config == right.Config && slices.Equal(left.RepoTags, right.RepoTags) && slices.Equal(left.Layers, right.Layers)
+}
+
+func equalStringMap(left, right map[string]string) bool {
+	return len(left) == len(right) && slices.EqualFunc(sortedMapPairs(left), sortedMapPairs(right), func(a, b string) bool { return a == b })
+}
+
+func sortedMapPairs(values map[string]string) []string {
+	pairs := make([]string, 0, len(values))
+	for key, value := range values {
+		pairs = append(pairs, key+"\x00"+value)
+	}
+	slices.Sort(pairs)
+	return pairs
+}
+
+func decodeArtifactJSON[T any](body []byte, depth int, label string) (T, error) {
+	var value T
+	if err := strictjson.Validate(body, depth); err != nil {
+		return value, fmt.Errorf("validate %s JSON: %w", label, err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&value); err != nil {
+		return value, fmt.Errorf("decode %s: %w", label, err)
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return value, fmt.Errorf("%s contains trailing JSON data", label)
+	}
+	return value, nil
+}
+
+type countingReader struct {
+	source io.Reader
+	count  int64
+}
+
+func (reader *countingReader) Read(body []byte) (int, error) {
+	count, err := reader.source.Read(body)
+	reader.count += int64(count)
+	return count, err
+}
+
+func openBoundedRegular(path string, maximum int64, label string) (*os.File, error) {
+	information, err := os.Lstat(path)
+	if err != nil || !information.Mode().IsRegular() || information.Mode()&os.ModeSymlink != 0 ||
+		information.Size() <= 0 || information.Size() > maximum {
+		return nil, fmt.Errorf("%s must be a regular non-symlink file between 1 and %d bytes", label, maximum)
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open %s: %w", label, err)
+	}
+	opened, err := file.Stat()
+	if err != nil || !os.SameFile(information, opened) || information.Mode() != opened.Mode() || information.Size() != opened.Size() {
+		_ = file.Close()
+		return nil, fmt.Errorf("%s changed before it was opened", label)
+	}
+	return file, nil
+}
+
+func verifyOpenedRegular(path string, file *os.File, size int64, label string) error {
+	opened, err := file.Stat()
+	current, currentErr := os.Lstat(path)
+	if err != nil || currentErr != nil || !opened.Mode().IsRegular() || !current.Mode().IsRegular() ||
+		!os.SameFile(opened, current) || opened.Mode() != current.Mode() || opened.Size() != size || current.Size() != size ||
+		!opened.ModTime().Equal(current.ModTime()) {
+		return fmt.Errorf("%s changed while it was read", label)
+	}
+	return nil
+}
+
+func writeExactStream(path string, source io.Reader, size int64, expectedDigest string, epoch int64) (returnError error) {
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	if err != nil {
+		return fmt.Errorf("create projected OCI blob: %w", err)
+	}
+	complete := false
+	defer func() {
+		_ = file.Close()
+		if !complete {
+			_ = os.Remove(path)
+		}
+	}()
+	hasher := sha256.New()
+	written, err := io.CopyN(io.MultiWriter(file, hasher), source, size)
+	if err != nil || written != size || "sha256:"+hex.EncodeToString(hasher.Sum(nil)) != expectedDigest {
+		return errors.New("projected OCI blob bytes differ from their descriptor")
+	}
+	if err := file.Sync(); err != nil {
+		return fmt.Errorf("sync projected OCI blob: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close projected OCI blob: %w", err)
+	}
+	if err := os.Chtimes(path, time.Unix(epoch, 0), time.Unix(epoch, 0)); err != nil {
+		return fmt.Errorf("normalize projected OCI blob timestamp: %w", err)
+	}
+	complete = true
+	return nil
+}
+
+func writeExactBytes(path string, body []byte, epoch int64) error {
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	if err != nil {
+		return fmt.Errorf("create projected OCI metadata: %w", err)
+	}
+	complete := false
+	defer func() {
+		_ = file.Close()
+		if !complete {
+			_ = os.Remove(path)
+		}
+	}()
+	if _, err := file.Write(body); err != nil {
+		return fmt.Errorf("write projected OCI metadata: %w", err)
+	}
+	if err := file.Sync(); err != nil {
+		return fmt.Errorf("sync projected OCI metadata: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close projected OCI metadata: %w", err)
+	}
+	if err := os.Chmod(path, 0o644); err != nil {
+		return fmt.Errorf("normalize projected OCI metadata mode: %w", err)
+	}
+	if err := os.Chtimes(path, time.Unix(epoch, 0), time.Unix(epoch, 0)); err != nil {
+		return fmt.Errorf("normalize projected OCI metadata timestamp: %w", err)
+	}
+	complete = true
+	return nil
+}
+
+func writeOCILayoutFile(root string, epoch int64) error {
+	if err := writeExactBytes(filepath.Join(root, "oci-layout"), []byte("{\"imageLayoutVersion\":\"1.0.0\"}\n"), epoch); err != nil {
+		return err
+	}
+	for _, directory := range []string{filepath.Join(root, "blobs"), filepath.Join(root, "blobs", "sha256"), root} {
+		if err := os.Chmod(directory, 0o755); err != nil {
+			return fmt.Errorf("normalize projected OCI directory mode: %w", err)
+		}
+		if err := os.Chtimes(directory, time.Unix(epoch, 0), time.Unix(epoch, 0)); err != nil {
+			return fmt.Errorf("normalize projected OCI directory timestamp: %w", err)
+		}
+	}
+	return nil
+}
+
+func verifyBlobFile(path string, descriptor ociDescriptor) error {
+	file, err := openBoundedRegular(path, descriptor.Size, "OCI blob")
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	hasher := sha256.New()
+	written, err := io.Copy(hasher, io.LimitReader(file, descriptor.Size+1))
+	if err != nil || written != descriptor.Size || "sha256:"+hex.EncodeToString(hasher.Sum(nil)) != descriptor.Digest {
+		return errors.New("OCI blob bytes differ from their descriptor")
+	}
+	return verifyOpenedRegular(path, file, written, "OCI blob")
+}

--- a/tooling/internal/pdftools/image_archive_test.go
+++ b/tooling/internal/pdftools/image_archive_test.go
@@ -1,0 +1,236 @@
+package pdftools
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+type testDockerArchiveEntry struct {
+	name     string
+	body     []byte
+	typeflag byte
+	mode     int64
+	uid      int
+	gid      int
+	linkname string
+}
+
+func TestProjectBaseArchiveValidatesAndProjectsExactClosedImage(t *testing.T) {
+	t.Parallel()
+	authority, archive := writeBaseArchiveFixture(t, nil)
+	layout := filepath.Join(t.TempDir(), "new-layout")
+	identity, err := projectBaseArchive(context.Background(), archive, layout, authority)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if identity.ArchiveSHA256 != authority.contract.BaseImage.ArchiveSHA256 ||
+		identity.ManifestDigest != authority.contract.BaseImage.ManifestDigest ||
+		!slices.Equal(identity.LayerDigests, []string{authority.contract.BaseImage.LayerDigest}) {
+		t.Fatalf("projected identity = %#v", identity)
+	}
+	for _, path := range []string{
+		"oci-layout", "index.json",
+		"blobs/sha256/" + strings.TrimPrefix(identity.ManifestDigest, "sha256:"),
+		"blobs/sha256/" + strings.TrimPrefix(identity.ConfigDigest, "sha256:"),
+		"blobs/sha256/" + strings.TrimPrefix(identity.LayerDigests[0], "sha256:"),
+	} {
+		if information, err := os.Lstat(filepath.Join(layout, filepath.FromSlash(path))); err != nil ||
+			!information.Mode().IsRegular() {
+			t.Fatalf("projected path %s: info=%v error=%v", path, information, err)
+		}
+	}
+}
+
+func TestProjectBaseArchiveRejectsArchiveMutationsPastOuterDigest(t *testing.T) {
+	t.Parallel()
+	tests := map[string]func(*[]testDockerArchiveEntry){
+		"extra": func(entries *[]testDockerArchiveEntry) {
+			*entries = append(*entries, testDockerArchiveEntry{name: "extra", body: []byte("x"), typeflag: tar.TypeReg, mode: 0o644})
+		},
+		"traversal": func(entries *[]testDockerArchiveEntry) {
+			(*entries)[0].name = "../manifest.json"
+		},
+		"duplicate": func(entries *[]testDockerArchiveEntry) {
+			*entries = append(*entries, (*entries)[0])
+		},
+		"symlink": func(entries *[]testDockerArchiveEntry) {
+			(*entries)[0].typeflag = tar.TypeSymlink
+			(*entries)[0].body = nil
+			(*entries)[0].linkname = "outside"
+		},
+		"setuid": func(entries *[]testDockerArchiveEntry) {
+			(*entries)[0].mode = 0o4644
+		},
+		"named config mismatch": func(entries *[]testDockerArchiveEntry) {
+			for index := range *entries {
+				if strings.HasPrefix((*entries)[index].name, "sha256:") && bytes.Contains((*entries)[index].body, []byte(`"architecture"`)) {
+					(*entries)[index].body = bytes.Replace((*entries)[index].body, []byte(`"amd64"`), []byte(`"arm64"`), 1)
+				}
+			}
+		},
+	}
+	for name, mutate := range tests {
+		name, mutate := name, mutate
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			authority, archive := writeBaseArchiveFixture(t, mutate)
+			if _, err := projectBaseArchive(context.Background(), archive, filepath.Join(t.TempDir(), "layout"), authority); err == nil {
+				t.Fatalf("projectBaseArchive() accepted %s", name)
+			}
+		})
+	}
+}
+
+func TestProjectBaseArchiveRejectsPreexistingProjectionRoot(t *testing.T) {
+	t.Parallel()
+	authority, archive := writeBaseArchiveFixture(t, nil)
+	root := t.TempDir()
+	outside := t.TempDir()
+	layout := filepath.Join(root, "layout")
+	if err := os.Symlink(outside, layout); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	if _, err := projectBaseArchive(context.Background(), archive, layout, authority); err == nil {
+		t.Fatal("projectBaseArchive() accepted a preexisting symlink projection root")
+	}
+	if entries, err := os.ReadDir(outside); err != nil || len(entries) != 0 {
+		t.Fatalf("outside projection entries = %v, error = %v", entries, err)
+	}
+}
+
+func writeBaseArchiveFixture(
+	t *testing.T,
+	mutate func(*[]testDockerArchiveEntry),
+) (checkedAuthority, string) {
+	t.Helper()
+	contract := Contract{
+		Image: "ghcr.io/lusoris/20-watts-was-enough-pdf-tools", Platform: "linux/amd64", ResultAuthority: "NO_RESULT",
+		SourceDateEpoch: 1_785_757_696,
+		Runtime:         Runtime{UID: 65532, GID: 65532, RequiredTools: []Tool{{Name: "pdfinfo", Version: "26.08.0"}}},
+		Limits:          Limits{BaseArchiveBytes: 8 * 1024 * 1024},
+	}
+	var expanded bytes.Buffer
+	tarWriter := tar.NewWriter(&expanded)
+	body := []byte("base\n")
+	if err := tarWriter.WriteHeader(&tar.Header{
+		Name: "usr/share/test", Typeflag: tar.TypeReg, Mode: 0o644, Size: int64(len(body)),
+		ModTime: time.Unix(contract.SourceDateEpoch, 0),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tarWriter.Write(body); err != nil {
+		t.Fatal(err)
+	}
+	if err := tarWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+	var compressed bytes.Buffer
+	gzipWriter := gzip.NewWriter(&compressed)
+	gzipWriter.Header.ModTime = time.Unix(0, 0)
+	if _, err := gzipWriter.Write(expanded.Bytes()); err != nil {
+		t.Fatal(err)
+	}
+	if err := gzipWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+	layerDigest := sha256.Sum256(compressed.Bytes())
+	diffID := sha256.Sum256(expanded.Bytes())
+	contract.BaseImage.LayerDigest = "sha256:" + hex.EncodeToString(layerDigest[:])
+	contract.BaseImage.LayerDiffID = "sha256:" + hex.EncodeToString(diffID[:])
+	created := time.Unix(contract.SourceDateEpoch, 0).UTC().Format(time.RFC3339)
+	configBody := mustJSON(t, map[string]any{
+		"architecture": "amd64",
+		"author":       "github.com/chainguard-dev/apko",
+		"created":      created,
+		"history": []map[string]any{{
+			"author": "apko", "created": created, "created_by": "apko", "comment": "This is an apko single-layer image",
+		}},
+		"os":     "linux",
+		"rootfs": map[string]any{"type": "layers", "diff_ids": []string{contract.BaseImage.LayerDiffID}},
+		"config": map[string]any{
+			"Env":    []string{"PATH=/usr/bin", "SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt"},
+			"Labels": expectedImageAnnotations(contract), "User": "65532",
+		},
+	})
+	configDigest := sha256.Sum256(configBody)
+	contract.BaseImage.ConfigDigest = "sha256:" + hex.EncodeToString(configDigest[:])
+	manifest := ociManifest{
+		SchemaVersion: 2, MediaType: ociManifestMediaType,
+		Config:      ociDescriptor{MediaType: ociConfigMediaType, Digest: contract.BaseImage.ConfigDigest, Size: int64(len(configBody))},
+		Layers:      []ociDescriptor{{MediaType: ociLayerMediaType, Digest: contract.BaseImage.LayerDigest, Size: int64(compressed.Len())}},
+		Annotations: expectedImageAnnotations(contract),
+	}
+	manifestBody := mustJSON(t, manifest)
+	manifestDigest := sha256.Sum256(manifestBody)
+	contract.BaseImage.ManifestDigest = "sha256:" + hex.EncodeToString(manifestDigest[:])
+	platform := ociPlatform{Architecture: "amd64", OS: "linux"}
+	indexBody := mustJSON(t, ociIndex{
+		SchemaVersion: 2, MediaType: ociIndexMediaType,
+		Manifests: []ociDescriptor{{
+			MediaType: ociManifestMediaType, Digest: contract.BaseImage.ManifestDigest, Size: int64(len(manifestBody)),
+			Platform: &platform, ArtifactType: ociConfigMediaType,
+		}},
+		Annotations: expectedImageAnnotations(contract),
+	})
+	dockerBody := mustJSON(t, []dockerArchiveEntry{{
+		Config:   contract.BaseImage.ConfigDigest,
+		RepoTags: []string{"index.docker.io/library/pdf-tools:26.08.0-r0-amd64"},
+		Layers:   []string{strings.TrimPrefix(contract.BaseImage.LayerDigest, "sha256:") + ".tar.gz"},
+	}})
+	entries := []testDockerArchiveEntry{
+		{name: "manifest.json", body: dockerBody, typeflag: tar.TypeReg, mode: 0o644},
+		{name: "index.json", body: indexBody, typeflag: tar.TypeReg, mode: 0o644},
+		{name: contract.BaseImage.ManifestDigest, body: manifestBody, typeflag: tar.TypeReg, mode: 0o644},
+		{name: contract.BaseImage.ConfigDigest, body: configBody, typeflag: tar.TypeReg, mode: 0o644},
+		{name: strings.TrimPrefix(contract.BaseImage.LayerDigest, "sha256:") + ".tar.gz", body: compressed.Bytes(), typeflag: tar.TypeReg, mode: 0o644},
+	}
+	if mutate != nil {
+		mutate(&entries)
+	}
+	var archive bytes.Buffer
+	archiveWriter := tar.NewWriter(&archive)
+	for _, entry := range entries {
+		if err := archiveWriter.WriteHeader(&tar.Header{
+			Name: entry.name, Typeflag: entry.typeflag, Mode: entry.mode,
+			Uid: entry.uid, Gid: entry.gid, Size: int64(len(entry.body)), Linkname: entry.linkname,
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if entry.typeflag == tar.TypeReg {
+			if _, err := archiveWriter.Write(entry.body); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	if err := archiveWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+	archiveDigest := sha256.Sum256(archive.Bytes())
+	contract.BaseImage.ArchiveSHA256 = hex.EncodeToString(archiveDigest[:])
+	contract.BaseImage.ArchiveSize = int64(archive.Len())
+	path := filepath.Join(t.TempDir(), "base.tar")
+	if err := os.WriteFile(path, archive.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return checkedAuthority{contract: contract}, path
+}
+
+func mustJSON(t *testing.T, value any) []byte {
+	t.Helper()
+	body, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return body
+}

--- a/tooling/internal/pdftools/layer.go
+++ b/tooling/internal/pdftools/layer.go
@@ -1,0 +1,369 @@
+package pdftools
+
+import (
+	"archive/tar"
+	"bufio"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	maximumLayerEntries   = 200_000
+	maximumLayerPathBytes = 64 * 1024 * 1024
+	maximumLayerPathLinks = 64
+)
+
+type layerFilesystemEntry struct {
+	typeflag byte
+	linkname string
+}
+
+type layerInspection struct {
+	Notices        []NoticeObservation
+	ForbiddenPaths []string
+	ManPages       []string
+}
+
+// NoticeObservation records one byte-exact notice retained by the final layer.
+type NoticeObservation struct {
+	Path      string `json:"path"`
+	SHA256    string `json:"sha256"`
+	SizeBytes int64  `json:"size_bytes"`
+	Mode      string `json:"mode"`
+	UID       int    `json:"uid"`
+	GID       int    `json:"gid"`
+}
+
+func inspectFinalLayers(ctx context.Context, image inspectedFinalImage, contract Contract) (layerInspection, error) {
+	if len(image.Manifest.Layers) != 2 || len(image.Config.RootFS.DiffIDs) != 2 {
+		return layerInspection{}, errors.New("final image does not expose exactly two inspectable layers")
+	}
+	base, err := inspectBaseLayer(ctx, image.Layout, image.Manifest.Layers[0], image.Config.RootFS.DiffIDs[0], contract)
+	if err != nil {
+		return layerInspection{}, err
+	}
+	notices, err := inspectNoticeLayer(ctx, image.Layout, image.Manifest.Layers[1], image.Config.RootFS.DiffIDs[1], contract)
+	if err != nil {
+		return layerInspection{}, err
+	}
+	base.Notices = notices
+	return base, nil
+}
+
+func inspectBaseLayer(ctx context.Context, layout string, descriptor ociDescriptor, diffID string, contract Contract) (layerInspection, error) {
+	wantedManPages := make(map[string]bool, len(contract.Runtime.ManPages))
+	for _, name := range contract.Runtime.ManPages {
+		wantedManPages["usr/share/man/man1/"+name] = false
+	}
+	forbidden := make(map[string]bool, len(contract.Runtime.ForbiddenPaths))
+	for _, name := range contract.Runtime.ForbiddenPaths {
+		forbidden[strings.TrimPrefix(name, "/")] = false
+	}
+	filesystem := make(map[string]layerFilesystemEntry)
+	directories := make(map[string]struct{})
+	var pathBytes int64
+	_, err := scanCompressedLayer(ctx, layout, descriptor, diffID, contract, func(header *tar.Header, reader io.Reader) error {
+		name, err := cleanLayerPath(header.Name)
+		if err != nil {
+			return err
+		}
+		if _, duplicate := filesystem[name]; duplicate {
+			return fmt.Errorf("base layer repeats path %s", name)
+		}
+		if len(header.Linkname) > 4_096 || strings.ContainsAny(header.Linkname, "\\\x00") {
+			return fmt.Errorf("base layer path %s has an invalid link target", name)
+		}
+		pathBytes += int64(len(name) + len(header.Linkname))
+		if pathBytes > maximumLayerPathBytes {
+			return errors.New("base layer paths exceed their aggregate byte boundary")
+		}
+		filesystem[name] = layerFilesystemEntry{typeflag: header.Typeflag, linkname: header.Linkname}
+		if header.Typeflag == tar.TypeDir {
+			directories[name] = struct{}{}
+		}
+		for ancestor := path.Dir(name); ancestor != "." && ancestor != "/"; ancestor = path.Dir(ancestor) {
+			directories[ancestor] = struct{}{}
+		}
+		if _, exists := wantedManPages[name]; exists {
+			if header.Typeflag != tar.TypeReg || header.Size <= 0 {
+				return fmt.Errorf("Poppler man page %s is not a regular retained file", name)
+			}
+			wantedManPages[name] = true
+		}
+		return nil
+	})
+	if err != nil {
+		return layerInspection{}, err
+	}
+	for name := range forbidden {
+		exists, err := layerPathExists(filesystem, directories, name)
+		if err != nil {
+			return layerInspection{}, fmt.Errorf("resolve forbidden base path %s: %w", name, err)
+		}
+		forbidden[name] = exists
+	}
+	result := layerInspection{}
+	for _, name := range contract.Runtime.ForbiddenPaths {
+		if forbidden[strings.TrimPrefix(name, "/")] {
+			result.ForbiddenPaths = append(result.ForbiddenPaths, name)
+		}
+	}
+	if len(result.ForbiddenPaths) != 0 {
+		return layerInspection{}, fmt.Errorf("base image contains forbidden paths: %s", strings.Join(result.ForbiddenPaths, ", "))
+	}
+	for _, name := range contract.Runtime.ManPages {
+		if !wantedManPages["usr/share/man/man1/"+name] {
+			return layerInspection{}, fmt.Errorf("base image omits Poppler man page %s", name)
+		}
+		result.ManPages = append(result.ManPages, name)
+	}
+	return result, nil
+}
+
+func layerPathExists(
+	filesystem map[string]layerFilesystemEntry,
+	directories map[string]struct{},
+	target string,
+) (bool, error) {
+	cleaned, err := cleanLayerPath(strings.TrimPrefix(target, "/"))
+	if err != nil {
+		return false, err
+	}
+	components := strings.Split(cleaned, "/")
+	links := 0
+	for {
+		for index := range components {
+			candidate := path.Join(components[:index+1]...)
+			entry, present := filesystem[candidate]
+			last := index == len(components)-1
+			if last {
+				_, directory := directories[candidate]
+				return present || directory, nil
+			}
+			if present && (entry.typeflag == tar.TypeSymlink || entry.typeflag == tar.TypeLink) {
+				links++
+				if links > maximumLayerPathLinks {
+					return false, errors.New("base layer link resolution exceeds its hop boundary")
+				}
+				linked := entry.linkname
+				if linked == "" {
+					return false, errors.New("base layer link target is empty")
+				}
+				if entry.typeflag == tar.TypeSymlink && !path.IsAbs(linked) {
+					linked = path.Join(path.Dir(candidate), linked)
+				} else {
+					linked = strings.TrimPrefix(linked, "/")
+				}
+				remaining := strings.Join(components[index+1:], "/")
+				linked = path.Clean(path.Join(linked, remaining))
+				if linked == "." || linked == ".." || strings.HasPrefix(linked, "../") || path.IsAbs(linked) {
+					return false, errors.New("base layer link target escapes its filesystem root")
+				}
+				components = strings.Split(linked, "/")
+				break
+			}
+			if present && entry.typeflag != tar.TypeDir {
+				return false, nil
+			}
+			if _, directory := directories[candidate]; !present && !directory {
+				return false, nil
+			}
+			if index == len(components)-1 {
+				return true, nil
+			}
+		}
+	}
+}
+
+func inspectNoticeLayer(ctx context.Context, layout string, descriptor ociDescriptor, diffID string, contract Contract) ([]NoticeObservation, error) {
+	wanted := make(map[string]NoticeEntry, len(contract.NoticeLayer.Entries))
+	for _, entry := range contract.NoticeLayer.Entries {
+		wanted[strings.TrimPrefix(entry.Destination, "/")] = entry
+	}
+	observed := make(map[string]NoticeObservation, len(wanted))
+	directories := make(map[string]struct{}, 4)
+	var total int64
+	_, err := scanCompressedLayer(ctx, layout, descriptor, diffID, contract, func(header *tar.Header, reader io.Reader) error {
+		name, err := cleanLayerPath(header.Name)
+		if err != nil {
+			return err
+		}
+		entry, expected := wanted[name]
+		if header.Typeflag == tar.TypeDir {
+			if !noticeAncestor(name) || header.Size != 0 || header.Mode != 0o755 || header.Uid != 0 ||
+				header.Gid != 0 || header.Linkname != "" ||
+				!hasExactReproductionTarMetadata(header, contract.SourceDateEpoch) {
+				return fmt.Errorf("notice layer contains unrelated directory %s", name)
+			}
+			if _, duplicate := directories[name]; duplicate {
+				return fmt.Errorf("notice layer repeats directory %s", name)
+			}
+			directories[name] = struct{}{}
+			return nil
+		}
+		if !expected || header.Typeflag != tar.TypeReg || header.Uid != 0 || header.Gid != 0 ||
+			header.Mode != 0o644 || header.Size != entry.Size || header.Linkname != "" ||
+			!hasExactReproductionTarMetadata(header, contract.SourceDateEpoch) {
+			return fmt.Errorf("notice layer entry %s differs from its exact file contract", name)
+		}
+		if _, duplicate := observed[name]; duplicate {
+			return fmt.Errorf("notice layer repeats %s", name)
+		}
+		hasher := sha256.New()
+		written, err := io.CopyN(hasher, reader, header.Size)
+		if err != nil || written != header.Size || hex.EncodeToString(hasher.Sum(nil)) != entry.SHA256 {
+			return fmt.Errorf("notice layer bytes for %s differ from the committed source", name)
+		}
+		total += written
+		if total > contract.Limits.NoticeBytes {
+			return errors.New("notice layer bytes exceed their aggregate boundary")
+		}
+		observed[name] = NoticeObservation{
+			Path: "/" + name, SHA256: entry.SHA256, SizeBytes: entry.Size,
+			Mode: "0644", UID: header.Uid, GID: header.Gid,
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(observed) != len(wanted) {
+		return nil, errors.New("notice layer omits one or more exact Poppler notice files")
+	}
+	if len(directories) != 4 {
+		return nil, errors.New("notice layer omits one or more exact ancestor directories")
+	}
+	result := make([]NoticeObservation, 0, len(contract.NoticeLayer.Entries))
+	for _, entry := range contract.NoticeLayer.Entries {
+		result = append(result, observed[strings.TrimPrefix(entry.Destination, "/")])
+	}
+	return result, nil
+}
+
+func scanCompressedLayer(
+	ctx context.Context,
+	layout string,
+	descriptor ociDescriptor,
+	diffID string,
+	contract Contract,
+	visit func(*tar.Header, io.Reader) error,
+) (int64, error) {
+	filePath := filepath.Join(layout, "blobs", "sha256", strings.TrimPrefix(descriptor.Digest, "sha256:"))
+	file, err := openBoundedRegular(filePath, contract.Limits.FinalArchiveBytes, "compressed OCI layer")
+	if err != nil {
+		return 0, err
+	}
+	defer file.Close()
+	compressedHasher := sha256.New()
+	compressedCounting := &countingReader{source: file}
+	compressedSource := io.TeeReader(compressedCounting, compressedHasher)
+	bufferedCompressed := bufio.NewReaderSize(compressedSource, 128*1024)
+	gzipReader, err := gzip.NewReader(bufferedCompressed)
+	if err != nil {
+		return 0, fmt.Errorf("open compressed OCI layer: %w", err)
+	}
+	defer gzipReader.Close()
+	gzipReader.Multistream(false)
+	expandedMaximum := 8 * contract.Limits.FinalArchiveBytes
+	uncompressedHasher := sha256.New()
+	boundedUncompressed := io.LimitReader(gzipReader, expandedMaximum+1)
+	counting := &countingReader{source: io.TeeReader(boundedUncompressed, uncompressedHasher)}
+	tarReader := tar.NewReader(counting)
+	entries := 0
+	for {
+		if err := ctx.Err(); err != nil {
+			return counting.count, err
+		}
+		header, err := tarReader.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			if counting.count > expandedMaximum {
+				return counting.count, errors.New("OCI layer exceeds its expanded-byte boundary")
+			}
+			return counting.count, fmt.Errorf("read OCI layer tar: %w", err)
+		}
+		entries++
+		if entries > maximumLayerEntries || counting.count > expandedMaximum {
+			return counting.count, errors.New("OCI layer exceeds its entry or expanded-byte boundary")
+		}
+		if err := visit(header, tarReader); err != nil {
+			return counting.count, err
+		}
+	}
+	if err := drainZeroLayerPadding(ctx, counting, expandedMaximum-counting.count); err != nil {
+		return counting.count, err
+	}
+	if counting.count > expandedMaximum ||
+		"sha256:"+hex.EncodeToString(uncompressedHasher.Sum(nil)) != diffID {
+		return counting.count, errors.New("expanded OCI layer differs from its config diff ID")
+	}
+	if err := gzipReader.Close(); err != nil {
+		return counting.count, fmt.Errorf("close compressed OCI layer: %w", err)
+	}
+	if err := drainZeroLayerPadding(ctx, bufferedCompressed, contract.Limits.FinalArchiveBytes-compressedCounting.count); err != nil {
+		return counting.count, errors.New("compressed OCI layer contains a second gzip member or non-zero trailing payload")
+	}
+	if compressedCounting.count != descriptor.Size ||
+		"sha256:"+hex.EncodeToString(compressedHasher.Sum(nil)) != descriptor.Digest {
+		return counting.count, errors.New("compressed OCI layer differs from its manifest digest")
+	}
+	if err := verifyOpenedRegular(filePath, file, compressedCounting.count, "compressed OCI layer"); err != nil {
+		return counting.count, err
+	}
+	return counting.count, nil
+}
+
+func drainZeroLayerPadding(ctx context.Context, reader io.Reader, maximum int64) error {
+	if maximum < 0 {
+		return errors.New("OCI layer padding exceeds its byte boundary")
+	}
+	buffer := make([]byte, 128*1024)
+	var read int64
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		count, err := reader.Read(buffer)
+		if count > 0 {
+			read += int64(count)
+			if read > maximum {
+				return errors.New("OCI layer padding exceeds its byte boundary")
+			}
+			if !allZero(buffer[:count]) {
+				return errors.New("OCI layer contains non-zero trailing payload")
+			}
+		}
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("read OCI layer padding: %w", err)
+		}
+	}
+}
+
+func cleanLayerPath(value string) (string, error) {
+	if value == "" || len(value) > 4_096 || strings.Contains(value, "\\") ||
+		strings.ContainsRune(value, '\x00') || path.IsAbs(value) {
+		return "", errors.New("OCI layer contains an invalid path")
+	}
+	cleaned := path.Clean(value)
+	if cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, "../") || cleaned != strings.TrimSuffix(value, "/") {
+		return "", fmt.Errorf("OCI layer path %q is not canonical", value)
+	}
+	return cleaned, nil
+}
+
+func noticeAncestor(value string) bool {
+	return value == "usr" || value == "usr/share" || value == "usr/share/licenses" || value == "usr/share/licenses/poppler"
+}

--- a/tooling/internal/pdftools/layer_test.go
+++ b/tooling/internal/pdftools/layer_test.go
@@ -1,0 +1,245 @@
+package pdftools
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+type noticeLayerMutation func(*[]tar.Header, map[string][]byte)
+
+func TestInspectNoticeLayerRequiresExactClosedInventory(t *testing.T) {
+	t.Parallel()
+	contract, descriptor, diffID, layout := writeNoticeLayerFixture(t, nil, nil)
+	observed, err := inspectNoticeLayer(context.Background(), layout, descriptor, diffID, contract)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(observed) != 2 || observed[0].Path != contract.NoticeLayer.Entries[0].Destination ||
+		observed[1].SHA256 != contract.NoticeLayer.Entries[1].SHA256 {
+		t.Fatalf("notice observations = %#v", observed)
+	}
+}
+
+func TestInspectNoticeLayerRejectsMetadataAndPayloadMutations(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		mutation noticeLayerMutation
+		trailing []byte
+	}{
+		{name: "repeated directory", mutation: func(headers *[]tar.Header, _ map[string][]byte) {
+			*headers = append((*headers)[:1], append([]tar.Header{(*headers)[0]}, (*headers)[1:]...)...)
+		}},
+		{name: "setuid notice", mutation: func(headers *[]tar.Header, _ map[string][]byte) {
+			(*headers)[4].Mode = 0o4644
+		}},
+		{name: "wrong timestamp", mutation: func(headers *[]tar.Header, _ map[string][]byte) {
+			(*headers)[4].ModTime = time.Unix(1_785_757_697, 0)
+		}},
+		{name: "user name metadata", mutation: func(headers *[]tar.Header, _ map[string][]byte) {
+			(*headers)[4].Uname = "root"
+		}},
+		{name: "extended metadata", mutation: func(headers *[]tar.Header, _ map[string][]byte) {
+			(*headers)[4].PAXRecords = map[string]string{"comment": "unexpected"}
+		}},
+		{name: "linked notice", mutation: func(headers *[]tar.Header, _ map[string][]byte) {
+			(*headers)[4].Typeflag = tar.TypeSymlink
+			(*headers)[4].Linkname = "../../outside"
+			(*headers)[4].Size = 0
+		}},
+		{name: "unrelated file", mutation: func(headers *[]tar.Header, bodies map[string][]byte) {
+			name := "usr/share/licenses/poppler/EXTRA"
+			*headers = append(*headers, tar.Header{Name: name, Typeflag: tar.TypeReg, Mode: 0o644, Size: 1})
+			bodies[name] = []byte("x")
+		}},
+		{name: "second gzip member", trailing: gzipMember(t, []byte("hidden"))},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			contract, descriptor, diffID, layout := writeNoticeLayerFixture(t, test.mutation, test.trailing)
+			if _, err := inspectNoticeLayer(context.Background(), layout, descriptor, diffID, contract); err == nil {
+				t.Fatalf("inspectNoticeLayer() accepted %s", test.name)
+			}
+		})
+	}
+}
+
+func TestLayerPathExistsResolvesAncestorLinks(t *testing.T) {
+	t.Parallel()
+	filesystem := map[string]layerFilesystemEntry{
+		"bin":     {typeflag: tar.TypeSymlink, linkname: "usr/bin"},
+		"sbin":    {typeflag: tar.TypeSymlink, linkname: "usr/bin"},
+		"usr":     {typeflag: tar.TypeDir},
+		"usr/bin": {typeflag: tar.TypeDir},
+	}
+	directories := map[string]struct{}{"usr": {}, "usr/bin": {}}
+	for _, target := range []string{"bin/sh", "sbin/apk"} {
+		exists, err := layerPathExists(filesystem, directories, target)
+		if err != nil || exists {
+			t.Fatalf("missing linked target %s = %t, %v", target, exists, err)
+		}
+	}
+	filesystem["usr/bin/sh"] = layerFilesystemEntry{typeflag: tar.TypeReg}
+	filesystem["usr/bin/apk"] = layerFilesystemEntry{typeflag: tar.TypeReg}
+	for _, target := range []string{"bin/sh", "sbin/apk"} {
+		exists, err := layerPathExists(filesystem, directories, target)
+		if err != nil || !exists {
+			t.Fatalf("present linked target %s = %t, %v", target, exists, err)
+		}
+	}
+}
+
+func TestLayerPathExistsRejectsLinkCycles(t *testing.T) {
+	t.Parallel()
+	filesystem := map[string]layerFilesystemEntry{
+		"bin": {typeflag: tar.TypeSymlink, linkname: "bin"},
+	}
+	if _, err := layerPathExists(filesystem, map[string]struct{}{}, "bin/sh"); err == nil {
+		t.Fatal("cyclic ancestor link was accepted")
+	}
+}
+
+func TestScanCompressedLayerHardBoundsExpandedBytes(t *testing.T) {
+	t.Parallel()
+	expanded := bytes.Repeat([]byte{0}, 64*1024)
+	compressed := gzipMember(t, expanded)
+	compressedDigest := sha256.Sum256(compressed)
+	expandedDigest := sha256.Sum256(expanded)
+	descriptor := ociDescriptor{
+		MediaType: ociLayerMediaType,
+		Digest:    "sha256:" + hex.EncodeToString(compressedDigest[:]),
+		Size:      int64(len(compressed)),
+	}
+	layout := t.TempDir()
+	blobRoot := filepath.Join(layout, "blobs", "sha256")
+	if err := os.MkdirAll(blobRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(blobRoot, strings.TrimPrefix(descriptor.Digest, "sha256:")), compressed, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	contract := Contract{Limits: Limits{FinalArchiveBytes: 4 * 1024}}
+	expandedBytes, err := scanCompressedLayer(
+		context.Background(), layout, descriptor,
+		"sha256:"+hex.EncodeToString(expandedDigest[:]), contract,
+		func(*tar.Header, io.Reader) error { return nil },
+	)
+	if err == nil || !strings.Contains(err.Error(), "byte boundary") || expandedBytes > 8*contract.Limits.FinalArchiveBytes+1 {
+		t.Fatalf("expanded gzip boundary = %d bytes, %v", expandedBytes, err)
+	}
+}
+
+func writeNoticeLayerFixture(
+	t *testing.T,
+	mutate noticeLayerMutation,
+	trailing []byte,
+) (Contract, ociDescriptor, string, string) {
+	t.Helper()
+	noticeBodies := map[string][]byte{
+		"usr/share/licenses/poppler/AUTHORS": []byte("authors\n"),
+		"usr/share/licenses/poppler/COPYING": []byte("licence\n"),
+	}
+	headers := []tar.Header{
+		{Name: "usr", Typeflag: tar.TypeDir, Mode: 0o755},
+		{Name: "usr/share", Typeflag: tar.TypeDir, Mode: 0o755},
+		{Name: "usr/share/licenses", Typeflag: tar.TypeDir, Mode: 0o755},
+		{Name: "usr/share/licenses/poppler", Typeflag: tar.TypeDir, Mode: 0o755},
+		{Name: "usr/share/licenses/poppler/AUTHORS", Typeflag: tar.TypeReg, Mode: 0o644, Size: int64(len(noticeBodies["usr/share/licenses/poppler/AUTHORS"]))},
+		{Name: "usr/share/licenses/poppler/COPYING", Typeflag: tar.TypeReg, Mode: 0o644, Size: int64(len(noticeBodies["usr/share/licenses/poppler/COPYING"]))},
+	}
+	for index := range headers {
+		headers[index].Uid = 0
+		headers[index].Gid = 0
+		headers[index].ModTime = time.Unix(1_785_757_696, 0)
+	}
+	if mutate != nil {
+		mutate(&headers, noticeBodies)
+	}
+	var expanded bytes.Buffer
+	tarWriter := tar.NewWriter(&expanded)
+	for index := range headers {
+		header := headers[index]
+		if err := tarWriter.WriteHeader(&header); err != nil {
+			t.Fatal(err)
+		}
+		if header.Typeflag == tar.TypeReg {
+			if _, err := tarWriter.Write(noticeBodies[header.Name]); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	if err := tarWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+	var compressed bytes.Buffer
+	gzipWriter, err := gzip.NewWriterLevel(&compressed, gzip.BestCompression)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gzipWriter.Header.ModTime = time.Unix(0, 0)
+	if _, err := gzipWriter.Write(expanded.Bytes()); err != nil {
+		t.Fatal(err)
+	}
+	if err := gzipWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+	compressed.Write(trailing)
+	compressedDigest := sha256.Sum256(compressed.Bytes())
+	expandedDigest := sha256.Sum256(expanded.Bytes())
+	descriptor := ociDescriptor{
+		MediaType: ociLayerMediaType,
+		Digest:    "sha256:" + hex.EncodeToString(compressedDigest[:]),
+		Size:      int64(compressed.Len()),
+	}
+	diffID := "sha256:" + hex.EncodeToString(expandedDigest[:])
+	layout := t.TempDir()
+	blobRoot := filepath.Join(layout, "blobs", "sha256")
+	if err := os.MkdirAll(blobRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(blobRoot, strings.TrimPrefix(descriptor.Digest, "sha256:")), compressed.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	entries := make([]NoticeEntry, 0, 2)
+	for _, name := range []string{"AUTHORS", "COPYING"} {
+		body := noticeBodies["usr/share/licenses/poppler/"+name]
+		digest := sha256.Sum256(body)
+		entries = append(entries, NoticeEntry{
+			Source:      "notices/" + name,
+			Destination: "/usr/share/licenses/poppler/" + name,
+			SHA256:      hex.EncodeToString(digest[:]),
+			Size:        int64(len(body)),
+		})
+	}
+	contract := Contract{
+		SourceDateEpoch: 1_785_757_696,
+		NoticeLayer:     NoticeLayer{Entries: entries},
+		Limits:          Limits{FinalArchiveBytes: 8 * 1024 * 1024, NoticeBytes: 1024 * 1024},
+	}
+	return contract, descriptor, diffID, layout
+}
+
+func gzipMember(t *testing.T, body []byte) []byte {
+	t.Helper()
+	var buffer bytes.Buffer
+	writer := gzip.NewWriter(&buffer)
+	if _, err := writer.Write(body); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buffer.Bytes()
+}

--- a/tooling/internal/pdftools/model.go
+++ b/tooling/internal/pdftools/model.go
@@ -39,14 +39,19 @@ type Apko struct {
 }
 
 type BaseImage struct {
-	ArchiveSHA256  string `json:"archive_sha256"`
-	ArchiveSize    int64  `json:"archive_size_bytes"`
-	ManifestDigest string `json:"manifest_digest"`
-	ConfigDigest   string `json:"config_digest"`
-	LayerDigest    string `json:"layer_digest"`
-	LayerDiffID    string `json:"layer_diff_id"`
-	SPDXSHA256     string `json:"spdx_sha256"`
-	SPDXSize       int64  `json:"spdx_size_bytes"`
+	ArchiveSHA256            string `json:"archive_sha256"`
+	ArchiveSize              int64  `json:"archive_size_bytes"`
+	ManifestDigest           string `json:"manifest_digest"`
+	ConfigDigest             string `json:"config_digest"`
+	LayerDigest              string `json:"layer_digest"`
+	LayerDiffID              string `json:"layer_diff_id"`
+	SPDXSize                 int64  `json:"spdx_size_bytes"`
+	SPDXCanonicalSHA256      string `json:"spdx_canonical_sha256"`
+	SPDXCanonicalSize        int64  `json:"spdx_canonical_size_bytes"`
+	SPDXPackages             int    `json:"spdx_packages"`
+	SPDXRelationships        int    `json:"spdx_relationships"`
+	SPDXIndexCanonicalSHA256 string `json:"spdx_index_canonical_sha256"`
+	SPDXIndexCanonicalSize   int64  `json:"spdx_index_canonical_size_bytes"`
 }
 
 type Runtime struct {
@@ -124,14 +129,34 @@ type SourceDelivery struct {
 }
 
 type Limits struct {
-	LockBytes           int64 `json:"lock_bytes"`
-	Packages            int   `json:"packages"`
-	NoticeBytes         int64 `json:"notice_bytes"`
-	BaseArchiveBytes    int64 `json:"base_archive_bytes"`
-	SourceBundleBytes   int64 `json:"source_bundle_bytes"`
-	LockSeconds         int   `json:"lock_seconds"`
-	BuildSeconds        int   `json:"build_seconds"`
-	CapturedOutputBytes int64 `json:"captured_output_bytes"`
+	LockBytes             int64 `json:"lock_bytes"`
+	Packages              int   `json:"packages"`
+	NoticeBytes           int64 `json:"notice_bytes"`
+	BaseArchiveBytes      int64 `json:"base_archive_bytes"`
+	FinalArchiveBytes     int64 `json:"final_archive_bytes"`
+	SourceBundleBytes     int64 `json:"source_bundle_bytes"`
+	SPDXBytes             int64 `json:"spdx_bytes"`
+	SPDXPackages          int   `json:"spdx_packages"`
+	SPDXRelationships     int   `json:"spdx_relationships"`
+	APKControlBytes       int64 `json:"apk_control_bytes"`
+	APKDataBytes          int64 `json:"apk_data_bytes"`
+	APKIndexBytes         int64 `json:"apk_index_bytes"`
+	HTTPResponseBytes     int64 `json:"http_response_bytes"`
+	LockSeconds           int   `json:"lock_seconds"`
+	BuildSeconds          int   `json:"build_seconds"`
+	RuntimeSeconds        int   `json:"runtime_seconds"`
+	CapturedOutputBytes   int64 `json:"captured_output_bytes"`
+	ReceiptBytes          int64 `json:"receipt_bytes"`
+	ApkoMemoryBytes       int64 `json:"apko_memory_bytes"`
+	ApkoPIDs              int   `json:"apko_pids"`
+	ApkoTemporaryBytes    int64 `json:"apko_temporary_bytes"`
+	BuildKitMemoryBytes   int64 `json:"buildkit_memory_bytes"`
+	BuildKitPIDs          int   `json:"buildkit_pids"`
+	BuildKitCPUPeriod     int64 `json:"buildkit_cpu_period"`
+	BuildKitCPUQuota      int64 `json:"buildkit_cpu_quota"`
+	RuntimeMemoryBytes    int64 `json:"runtime_memory_bytes"`
+	RuntimePIDs           int   `json:"runtime_pids"`
+	RuntimeTemporaryBytes int64 `json:"runtime_temporary_bytes"`
 }
 
 // Result is the bounded offline observation returned by Check.

--- a/tooling/internal/pdftools/receipt.go
+++ b/tooling/internal/pdftools/receipt.go
@@ -1,0 +1,579 @@
+package pdftools
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"runtime/debug"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/lusoris/20-watts-was-enough/tooling/internal/buildinfo"
+)
+
+const (
+	reproductionReceiptSchema        = 1
+	maximumComparatorExecutableBytes = int64(256 * 1024 * 1024)
+	maximumComparatorSourceEntries   = 16_384
+	maximumComparatorSourceDepth     = 32
+)
+
+// ReproductionReceipt is local construction evidence. Its explicit block
+// state prevents a successful comparison from becoming publication, release,
+// source-delivery, legal, or scientific authority.
+type ReproductionReceipt struct {
+	Schema           int                    `json:"schema"`
+	Status           string                 `json:"status"`
+	Scope            string                 `json:"scope"`
+	Authority        string                 `json:"authority"`
+	ScientificResult bool                   `json:"scientific_result"`
+	BlockState       ReproductionBlockState `json:"block_state"`
+	Contract         ReproductionContract   `json:"contract"`
+	Builders         ReproductionBuilders   `json:"builders"`
+	Comparator       ReproductionComparator `json:"comparator"`
+	Context          ReproductionContext    `json:"normalized_notice_context"`
+	BaseBuilds       []ReproductionBuild    `json:"base_builds"`
+	FinalBuilds      []ReproductionBuild    `json:"final_builds"`
+	Notices          []NoticeObservation    `json:"notices"`
+	ManPages         []string               `json:"man_pages"`
+	Runtime          *RuntimeObservation    `json:"runtime,omitempty"`
+	Comparison       ReproductionComparison `json:"comparison"`
+}
+
+type ReproductionComparator struct {
+	Version          string `json:"version"`
+	Revision         string `json:"revision"`
+	BuiltAt          string `json:"built_at"`
+	GoVersion        string `json:"go_version"`
+	OperatingSystem  string `json:"os"`
+	Architecture     string `json:"architecture"`
+	ExecutableSHA256 string `json:"executable_sha256"`
+	ExecutableBytes  int64  `json:"executable_bytes"`
+	VCSRevision      string `json:"vcs_revision"`
+	VCSModified      bool   `json:"vcs_modified"`
+	SourceSHA256     string `json:"source_sha256"`
+	SourceFiles      int    `json:"source_files"`
+}
+
+type ReproductionBlockState struct {
+	RemotePublication string `json:"remote_publication"`
+	DigestAdmission   string `json:"digest_admission"`
+	SourceBundle      string `json:"source_bundle"`
+	ScientificUse     string `json:"scientific_use"`
+	LegalConclusion   string `json:"legal_conclusion"`
+}
+
+type ReproductionContract struct {
+	SHA256          string `json:"sha256"`
+	ResultAuthority string `json:"result_authority"`
+	Platform        string `json:"platform"`
+}
+
+type ReproductionBuilders struct {
+	ApkoImage                  string   `json:"apko_image"`
+	ApkoVersion                string   `json:"apko_version"`
+	ApkoRevision               string   `json:"apko_revision"`
+	ApkoGoVersion              string   `json:"apko_go_version"`
+	ApkoTreeState              string   `json:"apko_tree_state"`
+	ApkoBuildDate              string   `json:"apko_build_date"`
+	ApkoRequestedNetwork       string   `json:"apko_requested_network"`
+	ApkoRequestedReadOnlyRoot  bool     `json:"apko_requested_read_only_root"`
+	ApkoRequestedCapabilities  string   `json:"apko_requested_capabilities"`
+	ApkoRequestedNoNewPrivs    bool     `json:"apko_requested_no_new_privileges"`
+	ApkoRequestedMemoryBytes   int64    `json:"apko_requested_memory_bytes"`
+	ApkoRequestedMemorySwap    int64    `json:"apko_requested_memory_swap_bytes"`
+	ApkoRequestedPIDs          int      `json:"apko_requested_pids"`
+	ApkoRequestedTemporary     int64    `json:"apko_requested_temporary_bytes"`
+	BuildxVersion              string   `json:"buildx_version"`
+	BuildxRevision             string   `json:"buildx_revision"`
+	BuildKitImage              string   `json:"buildkit_image"`
+	BuildKitVersion            string   `json:"buildkit_version"`
+	FreshBuildKits             int      `json:"fresh_buildkits"`
+	DaemonNetwork              string   `json:"buildkit_daemon_network"`
+	DaemonPrivileged           bool     `json:"buildkit_daemon_privileged"`
+	DaemonAllowedEntitlements  []string `json:"buildkit_daemon_allowed_insecure_entitlements"`
+	RequestedBuildEntitlements []string `json:"requested_build_entitlements"`
+	DaemonMemoryBytes          int64    `json:"buildkit_daemon_memory_bytes"`
+	DaemonPIDs                 int      `json:"buildkit_daemon_pids"`
+	DaemonCPUPeriod            int64    `json:"buildkit_daemon_cpu_period"`
+	DaemonCPUQuota             int64    `json:"buildkit_daemon_cpu_quota"`
+	DaemonMaximumParallelism   int      `json:"buildkit_daemon_maximum_parallelism"`
+	NoCache                    bool     `json:"no_cache"`
+	FinalNetwork               string   `json:"final_build_network"`
+	RemotePush                 bool     `json:"remote_push"`
+}
+
+type ReproductionContext struct {
+	SHA256           string `json:"sha256"`
+	Entries          int    `json:"entries"`
+	FileBytes        int64  `json:"file_bytes"`
+	DockerfileSHA256 string `json:"dockerfile_sha256"`
+	SourceDateEpoch  int64  `json:"source_date_epoch"`
+}
+
+type ReproductionBuild struct {
+	Sequence      int               `json:"sequence"`
+	ArchiveSHA256 string            `json:"archive_sha256"`
+	ArchiveBytes  int64             `json:"archive_bytes"`
+	Manifest      string            `json:"manifest_digest"`
+	Config        string            `json:"config_digest"`
+	Layers        []string          `json:"layer_digests"`
+	DiffIDs       []string          `json:"layer_diff_ids"`
+	SPDX          *ReproductionSPDX `json:"spdx,omitempty"`
+	SPDXIndex     *ReproductionSPDX `json:"spdx_index,omitempty"`
+}
+
+type ReproductionSPDX struct {
+	RawSHA256       string `json:"raw_sha256"`
+	RawBytes        int64  `json:"raw_bytes"`
+	CanonicalSHA256 string `json:"canonical_sha256"`
+	CanonicalBytes  int64  `json:"canonical_bytes"`
+	Packages        int    `json:"packages"`
+	Relationships   int    `json:"relationships"`
+}
+
+type ReproductionComparison struct {
+	BaseArchiveBytes     bool `json:"base_archive_bytes"`
+	BaseManifest         bool `json:"base_manifest"`
+	BaseConfig           bool `json:"base_config"`
+	BaseLayers           bool `json:"base_layers"`
+	BaseDiffIDs          bool `json:"base_diff_ids"`
+	SPDXCanonicalBytes   bool `json:"spdx_canonical_bytes"`
+	SPDXIndexCanonical   bool `json:"spdx_index_canonical_bytes"`
+	NoticeContextStable  bool `json:"notice_context_stable"`
+	FinalArchiveBytes    bool `json:"final_archive_bytes"`
+	FinalManifest        bool `json:"final_manifest"`
+	FinalConfig          bool `json:"final_config"`
+	FinalLayers          bool `json:"final_layers"`
+	FinalDiffIDs         bool `json:"final_diff_ids"`
+	NoticeFiles          bool `json:"notice_files"`
+	ManPages             bool `json:"man_pages"`
+	ForbiddenPathsAbsent bool `json:"forbidden_paths_absent"`
+	ConstructionMatch    bool `json:"construction_match"`
+	Runtime              bool `json:"runtime"`
+	AllMatch             bool `json:"all_match"`
+}
+
+func newReproductionReceipt(
+	authority checkedAuthority,
+	apkoBuilder apkoBuilderIdentity,
+	comparator ReproductionComparator,
+	contextIdentity noticeContextIdentity,
+	bases []baseBuild,
+	finals []finalBuild,
+	inspection layerInspection,
+	comparison ReproductionComparison,
+) ReproductionReceipt {
+	status := "construction-mismatch"
+	if comparison.AllMatch {
+		status = "local-construction-pass"
+	}
+	baseReceipts := make([]ReproductionBuild, len(bases))
+	for index, build := range bases {
+		baseReceipts[index] = reproductionBuildReceipt(build.Sequence, build.Image, &build.SPDX, &build.SPDXIndex)
+	}
+	finalReceipts := make([]ReproductionBuild, len(finals))
+	for index, build := range finals {
+		finalReceipts[index] = reproductionBuildReceipt(build.Sequence, build.Image.Identity, nil, nil)
+	}
+	builder := authority.renderer.Lock.Builder
+	return ReproductionReceipt{
+		Schema:           reproductionReceiptSchema,
+		Status:           status,
+		Scope:            "local-pdf-tools-final-image-reproduction",
+		Authority:        "NO_RESULT",
+		ScientificResult: false,
+		BlockState: ReproductionBlockState{
+			RemotePublication: "blocked",
+			DigestAdmission:   "blocked",
+			SourceBundle:      "not-produced",
+			ScientificUse:     "blocked",
+			LegalConclusion:   "not-made",
+		},
+		Contract: ReproductionContract{
+			SHA256:          authority.contractSHA256,
+			ResultAuthority: authority.contract.ResultAuthority,
+			Platform:        authority.contract.Platform,
+		},
+		Builders: ReproductionBuilders{
+			ApkoImage:                  authority.contract.Builder.Image,
+			ApkoVersion:                apkoBuilder.Version,
+			ApkoRevision:               apkoBuilder.Revision,
+			ApkoGoVersion:              apkoBuilder.GoVersion,
+			ApkoTreeState:              apkoBuilder.TreeState,
+			ApkoBuildDate:              apkoBuilder.BuildDate,
+			ApkoRequestedNetwork:       "docker-default",
+			ApkoRequestedReadOnlyRoot:  true,
+			ApkoRequestedCapabilities:  "drop-all",
+			ApkoRequestedNoNewPrivs:    true,
+			ApkoRequestedMemoryBytes:   authority.contract.Limits.ApkoMemoryBytes,
+			ApkoRequestedMemorySwap:    authority.contract.Limits.ApkoMemoryBytes,
+			ApkoRequestedPIDs:          authority.contract.Limits.ApkoPIDs,
+			ApkoRequestedTemporary:     authority.contract.Limits.ApkoTemporaryBytes,
+			BuildxVersion:              builder.BuildxVersion,
+			BuildxRevision:             builder.BuildxRevision,
+			BuildKitImage:              builder.BuildKitImage,
+			BuildKitVersion:            builder.BuildKitVersion,
+			FreshBuildKits:             reproductionBuildCount,
+			DaemonNetwork:              "none",
+			DaemonPrivileged:           true,
+			DaemonAllowedEntitlements:  []string{"network.host"},
+			RequestedBuildEntitlements: []string{},
+			DaemonMemoryBytes:          authority.contract.Limits.BuildKitMemoryBytes,
+			DaemonPIDs:                 authority.contract.Limits.BuildKitPIDs,
+			DaemonCPUPeriod:            authority.contract.Limits.BuildKitCPUPeriod,
+			DaemonCPUQuota:             authority.contract.Limits.BuildKitCPUQuota,
+			DaemonMaximumParallelism:   1,
+			NoCache:                    true,
+			FinalNetwork:               authority.contract.Runtime.Network,
+			RemotePush:                 false,
+		},
+		Comparator: comparator,
+		Context: ReproductionContext{
+			SHA256:           contextIdentity.SHA256,
+			Entries:          contextIdentity.Entries,
+			FileBytes:        contextIdentity.FileBytes,
+			DockerfileSHA256: contextIdentity.Dockerfile,
+			SourceDateEpoch:  authority.contract.SourceDateEpoch,
+		},
+		BaseBuilds:  baseReceipts,
+		FinalBuilds: finalReceipts,
+		Notices:     slices.Clone(inspection.Notices),
+		ManPages:    slices.Clone(inspection.ManPages),
+		Comparison:  comparison,
+	}
+}
+
+func currentComparatorIdentity(root string) (ReproductionComparator, error) {
+	path, err := os.Executable()
+	if err != nil {
+		return ReproductionComparator{}, fmt.Errorf("resolve PDF-tools comparator executable: %w", err)
+	}
+	file, err := openBoundedRegular(path, maximumComparatorExecutableBytes, "PDF-tools comparator executable")
+	if err != nil {
+		return ReproductionComparator{}, err
+	}
+	defer file.Close()
+	hasher := sha256.New()
+	written, err := io.Copy(hasher, io.LimitReader(file, maximumComparatorExecutableBytes+1))
+	if err != nil {
+		return ReproductionComparator{}, fmt.Errorf("hash PDF-tools comparator executable: %w", err)
+	}
+	if written > maximumComparatorExecutableBytes {
+		return ReproductionComparator{}, errors.New("PDF-tools comparator executable exceeds its byte boundary while hashing")
+	}
+	if err := verifyOpenedRegular(path, file, written, "PDF-tools comparator executable"); err != nil {
+		return ReproductionComparator{}, err
+	}
+	identity := buildinfo.Current()
+	vcsRevision, vcsModified, err := comparatorVCSIdentity(root)
+	if err != nil {
+		return ReproductionComparator{}, err
+	}
+	sourceSHA256, sourceFiles, err := comparatorSourceIdentity(root)
+	if err != nil {
+		return ReproductionComparator{}, err
+	}
+	return ReproductionComparator{
+		Version:          identity.Version,
+		Revision:         identity.Revision,
+		BuiltAt:          identity.BuiltAt,
+		GoVersion:        identity.GoVersion,
+		OperatingSystem:  identity.OperatingSys,
+		Architecture:     identity.Architecture,
+		ExecutableSHA256: hex.EncodeToString(hasher.Sum(nil)),
+		ExecutableBytes:  written,
+		VCSRevision:      vcsRevision,
+		VCSModified:      vcsModified,
+		SourceSHA256:     sourceSHA256,
+		SourceFiles:      sourceFiles,
+	}, nil
+}
+
+func comparatorVCSIdentity(root string) (string, bool, error) {
+	revisionBody, err := runBoundedGit(root, []string{"rev-parse", "--verify", "HEAD^{commit}"}, 1024)
+	if err != nil {
+		return "", false, err
+	}
+	revision := strings.TrimSpace(string(revisionBody))
+	if strings.Contains(revision, "\n") || !revisionPattern.MatchString(revision) {
+		return "", false, errors.New("PDF-tools comparator repository has no exact HEAD revision")
+	}
+	if information, available := debug.ReadBuildInfo(); available {
+		for _, setting := range information.Settings {
+			if setting.Key == "vcs.revision" && revisionPattern.MatchString(setting.Value) && setting.Value != revision {
+				return "", false, errors.New("PDF-tools comparator binary revision differs from repository HEAD")
+			}
+		}
+	}
+	status, err := runBoundedGit(root, []string{
+		"status", "--porcelain=v1", "--untracked-files=all", "--", "tooling",
+	}, 2*1024*1024)
+	if err != nil {
+		return "", false, err
+	}
+	return revision, len(status) != 0, nil
+}
+
+func runBoundedGit(root string, arguments []string, maximum int64) ([]byte, error) {
+	gitBinary, err := exec.LookPath("git")
+	if err != nil {
+		return nil, errors.New("Git is required to identify the local PDF-tools comparator")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	stdout := &boundedDockerOutput{limit: maximum}
+	stderr := &boundedDockerOutput{limit: 64 * 1024}
+	commandArguments := append([]string{"-C", root}, arguments...)
+	command := exec.CommandContext(ctx, gitBinary, commandArguments...)
+	command.Env = boundedDockerEnvironment()
+	command.Stdout = stdout
+	command.Stderr = stderr
+	command.WaitDelay = maximumDockerWaitDelay
+	err = command.Run()
+	stdoutBody, stdoutExceeded := stdout.result()
+	stderrBody, stderrExceeded := stderr.result()
+	if ctx.Err() != nil {
+		return nil, fmt.Errorf("identify PDF-tools comparator with Git: %w", ctx.Err())
+	}
+	if stdoutExceeded || stderrExceeded {
+		return nil, errors.New("Git comparator identity output exceeds its byte boundary")
+	}
+	if err != nil {
+		return nil, fmt.Errorf("identify PDF-tools comparator with Git: %w: %s", err, strings.TrimSpace(string(stderrBody)))
+	}
+	if len(stderrBody) != 0 {
+		return nil, errors.New("Git comparator identity wrote unexpected stderr")
+	}
+	return stdoutBody, nil
+}
+
+func comparatorSourceIdentity(root string) (string, int, error) {
+	toolingRoot := filepath.Join(root, "tooling")
+	type sourceFile struct {
+		relative string
+		body     []byte
+	}
+	files := make([]sourceFile, 0, 128)
+	var total int64
+	err := walkBoundedTree(
+		toolingRoot,
+		maximumComparatorSourceEntries,
+		maximumComparatorSourceDepth,
+		func(path string, _ string, information os.FileInfo) error {
+			if information.IsDir() {
+				return nil
+			}
+			name := filepath.Base(path)
+			if filepath.Ext(name) != ".go" && name != "go.mod" && name != "go.sum" {
+				return nil
+			}
+			if len(files) >= 4096 {
+				return errors.New("PDF-tools comparator source closure exceeds its file-count boundary")
+			}
+			relative, err := filepath.Rel(root, path)
+			if err != nil {
+				return err
+			}
+			relative = filepath.ToSlash(relative)
+			body, err := readRelative(root, relative, "PDF-tools comparator source "+relative, 4*1024*1024)
+			if err != nil {
+				return err
+			}
+			total += int64(len(body))
+			if total > 64*1024*1024 {
+				return errors.New("PDF-tools comparator source closure exceeds its byte boundary")
+			}
+			files = append(files, sourceFile{relative: relative, body: body})
+			return nil
+		},
+	)
+	if err != nil {
+		return "", 0, fmt.Errorf("hash PDF-tools comparator source closure: %w", err)
+	}
+	if len(files) == 0 {
+		return "", 0, errors.New("PDF-tools comparator source closure is empty")
+	}
+	slices.SortFunc(files, func(left, right sourceFile) int {
+		return strings.Compare(left.relative, right.relative)
+	})
+	digest := sha256.New()
+	for _, file := range files {
+		writeContextDigestField(digest, []byte(file.relative))
+		writeContextDigestField(digest, file.body)
+	}
+	return hex.EncodeToString(digest.Sum(nil)), len(files), nil
+}
+
+func reproductionBuildReceipt(sequence int, identity imageIdentity, spdx, spdxIndex *spdxIdentity) ReproductionBuild {
+	receipt := ReproductionBuild{
+		Sequence:      sequence,
+		ArchiveSHA256: identity.ArchiveSHA256,
+		ArchiveBytes:  identity.ArchiveSize,
+		Manifest:      identity.ManifestDigest,
+		Config:        identity.ConfigDigest,
+		Layers:        slices.Clone(identity.LayerDigests),
+		DiffIDs:       slices.Clone(identity.LayerDiffIDs),
+	}
+	if spdx != nil {
+		receipt.SPDX = reproductionSPDXReceipt(*spdx)
+	}
+	if spdxIndex != nil {
+		receipt.SPDXIndex = reproductionSPDXReceipt(*spdxIndex)
+	}
+	return receipt
+}
+
+func reproductionSPDXReceipt(identity spdxIdentity) *ReproductionSPDX {
+	return &ReproductionSPDX{
+		RawSHA256:       identity.RawSHA256,
+		RawBytes:        identity.RawSize,
+		CanonicalSHA256: identity.CanonicalSHA256,
+		CanonicalBytes:  identity.CanonicalSize,
+		Packages:        identity.Packages,
+		Relationships:   identity.Relationships,
+	}
+}
+
+func prepareReproductionReceiptPath(root, relative string) (string, error) {
+	if relative == "" || filepath.IsAbs(relative) || strings.ContainsAny(relative, "\\\n\r\x00") {
+		return "", errors.New("PDF-tools reproduction receipt must be a safe repository-relative JSON path")
+	}
+	clean := filepath.Clean(relative)
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) ||
+		filepath.Ext(clean) != ".json" {
+		return "", errors.New("PDF-tools reproduction receipt must be a safe repository-relative JSON path")
+	}
+	slash := filepath.ToSlash(clean)
+	allowed := slices.ContainsFunc([]string{
+		".workingdir2/evidence/publication/",
+		"build/evidence/",
+		"build/release-inputs/",
+	}, func(prefix string) bool { return strings.HasPrefix(slash, prefix) })
+	if !allowed {
+		return "", errors.New("PDF-tools reproduction receipt must be under publication or release evidence")
+	}
+	parent := filepath.Dir(clean)
+	if err := requireReproductionDirectory(root, parent); err != nil {
+		return "", err
+	}
+	destination := filepath.Join(root, clean)
+	if _, err := os.Lstat(destination); err == nil {
+		return "", errors.New("PDF-tools reproduction receipt already exists")
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", fmt.Errorf("inspect PDF-tools reproduction receipt: %w", err)
+	}
+	return destination, nil
+}
+
+func requireReproductionDirectory(root, relative string) error {
+	current := root
+	for _, component := range strings.Split(filepath.Clean(relative), string(filepath.Separator)) {
+		if component == "." || component == "" {
+			continue
+		}
+		current = filepath.Join(current, component)
+		information, err := os.Lstat(current)
+		if errors.Is(err, os.ErrNotExist) {
+			if err := os.Mkdir(current, 0o755); err != nil {
+				return fmt.Errorf("create PDF-tools receipt directory: %w", err)
+			}
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("inspect PDF-tools receipt directory: %w", err)
+		}
+		if !information.IsDir() || information.Mode()&os.ModeSymlink != 0 {
+			return errors.New("PDF-tools receipt directory must contain only real directories")
+		}
+	}
+	return nil
+}
+
+func writeReproductionReceipt(path string, receipt ReproductionReceipt, maximum int64) (returnError error) {
+	body, err := json.MarshalIndent(receipt, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode PDF-tools reproduction receipt: %w", err)
+	}
+	body = append(body, '\n')
+	if maximum <= 0 || int64(len(body)) > maximum {
+		return errors.New("PDF-tools reproduction receipt exceeds its byte boundary")
+	}
+	parent := filepath.Dir(path)
+	temporary, err := os.CreateTemp(parent, ".20w-pdf-tools-receipt-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temporary PDF-tools reproduction receipt: %w", err)
+	}
+	temporaryPath := temporary.Name()
+	published := false
+	var publishedInformation os.FileInfo
+	closed := false
+	defer func() {
+		if !closed {
+			if closeError := temporary.Close(); returnError == nil && closeError != nil {
+				returnError = fmt.Errorf("close temporary PDF-tools reproduction receipt: %w", closeError)
+			}
+		}
+		_ = os.Remove(temporaryPath)
+		if returnError != nil && published {
+			if current, err := os.Lstat(path); err == nil && publishedInformation != nil &&
+				current.Mode().IsRegular() && current.Mode()&os.ModeSymlink == 0 &&
+				os.SameFile(publishedInformation, current) {
+				_ = os.Remove(path)
+			}
+		}
+	}()
+	if err := temporary.Chmod(0o644); err != nil {
+		return fmt.Errorf("normalize temporary PDF-tools reproduction receipt: %w", err)
+	}
+	if _, err := temporary.Write(body); err != nil {
+		return fmt.Errorf("write temporary PDF-tools reproduction receipt: %w", err)
+	}
+	if err := temporary.Sync(); err != nil {
+		return fmt.Errorf("sync temporary PDF-tools reproduction receipt: %w", err)
+	}
+	if err := temporary.Close(); err != nil {
+		return fmt.Errorf("close temporary PDF-tools reproduction receipt: %w", err)
+	}
+	closed = true
+	if err := os.Link(temporaryPath, path); err != nil {
+		return fmt.Errorf("atomically publish new PDF-tools reproduction receipt: %w", err)
+	}
+	published = true
+	temporaryInfo, temporaryError := os.Lstat(temporaryPath)
+	finalInfo, finalError := os.Lstat(path)
+	if finalError == nil {
+		publishedInformation = finalInfo
+	}
+	if temporaryError != nil || finalError != nil || !finalInfo.Mode().IsRegular() ||
+		finalInfo.Mode()&os.ModeSymlink != 0 || !os.SameFile(temporaryInfo, finalInfo) || finalInfo.Size() != int64(len(body)) {
+		return errors.New("published PDF-tools reproduction receipt changed during atomic placement")
+	}
+	if err := os.Remove(temporaryPath); err != nil {
+		return fmt.Errorf("remove temporary PDF-tools reproduction receipt link: %w", err)
+	}
+	if runtime.GOOS != "windows" {
+		directory, err := os.Open(parent)
+		if err != nil {
+			return fmt.Errorf("open PDF-tools receipt directory for sync: %w", err)
+		}
+		if err := directory.Sync(); err != nil {
+			_ = directory.Close()
+			return fmt.Errorf("sync PDF-tools receipt directory: %w", err)
+		}
+		if err := directory.Close(); err != nil {
+			return fmt.Errorf("close PDF-tools receipt directory: %w", err)
+		}
+	}
+	published = false
+	return nil
+}

--- a/tooling/internal/pdftools/reproduce.go
+++ b/tooling/internal/pdftools/reproduce.go
@@ -1,0 +1,190 @@
+package pdftools
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"time"
+)
+
+// ReproductionOptions selects one local, non-publishing final-image
+// reproduction. ReceiptPath is a new repository-relative JSON file.
+type ReproductionOptions struct {
+	RepositoryRoot string
+	ReceiptPath    string
+}
+
+// ReproduceFinalImage builds and compares two complete local PDF-tools images.
+// It never pushes, publishes, assembles source-delivery material, or grants
+// scientific or release admission authority.
+func ReproduceFinalImage(
+	ctx context.Context,
+	options ReproductionOptions,
+) (_ ReproductionReceipt, returnError error) {
+	authority, err := checkAuthority(options.RepositoryRoot)
+	if err != nil {
+		return ReproductionReceipt{}, err
+	}
+	receiptPath, err := prepareReproductionReceiptPath(authority.root, options.ReceiptPath)
+	if err != nil {
+		return ReproductionReceipt{}, err
+	}
+	totalDuration := 6*time.Duration(authority.contract.Limits.BuildSeconds)*time.Second +
+		6*time.Duration(authority.contract.Limits.RuntimeSeconds)*time.Second + 5*time.Minute
+	reproductionContext, cancel := context.WithTimeout(ctx, totalDuration)
+	defer cancel()
+	temporaryRoot, err := os.MkdirTemp("", "20w-pdf-tools-reproduction-")
+	if err != nil {
+		return ReproductionReceipt{}, fmt.Errorf("create PDF-tools reproduction staging root: %w", err)
+	}
+	defer func() {
+		if removeError := os.RemoveAll(temporaryRoot); removeError != nil {
+			returnError = errors.Join(returnError, fmt.Errorf("remove PDF-tools reproduction staging root: %w", removeError))
+		}
+	}()
+	executor := localDockerExecutor{}
+	comparator, err := currentComparatorIdentity(authority.root)
+	if err != nil {
+		return ReproductionReceipt{}, err
+	}
+	if err := verifyLocalDockerEndpoint(reproductionContext, executor, authority); err != nil {
+		return ReproductionReceipt{}, err
+	}
+	if err := verifyBuildxIdentity(reproductionContext, executor, authority); err != nil {
+		return ReproductionReceipt{}, err
+	}
+	apkoBuilder, err := inspectApkoBuilderIdentity(reproductionContext, executor, authority)
+	if err != nil {
+		return ReproductionReceipt{}, err
+	}
+
+	bases := make([]baseBuild, 0, reproductionBuildCount)
+	for sequence := 1; sequence <= reproductionBuildCount; sequence++ {
+		build, err := runApkoBuild(reproductionContext, executor, authority, temporaryRoot, sequence)
+		if err != nil {
+			return ReproductionReceipt{}, err
+		}
+		if err := ensureAuthorityUnchanged(authority); err != nil {
+			return ReproductionReceipt{}, err
+		}
+		bases = append(bases, build)
+	}
+	baseArchiveEqual, err := equalRegularFiles(
+		bases[0].Archive, bases[1].Archive, authority.contract.Limits.BaseArchiveBytes,
+	)
+	if err != nil {
+		return ReproductionReceipt{}, err
+	}
+
+	contextRoot := filepath.Join(temporaryRoot, "notice-context")
+	if err := os.Mkdir(contextRoot, 0o700); err != nil {
+		return ReproductionReceipt{}, fmt.Errorf("create PDF-tools final-image context: %w", err)
+	}
+	contextIdentity, err := prepareNoticeContext(reproductionContext, contextRoot, authority)
+	if err != nil {
+		return ReproductionReceipt{}, err
+	}
+	finals := make([]finalBuild, 0, reproductionBuildCount)
+	inspections := make([]layerInspection, 0, reproductionBuildCount)
+	contextStable := true
+	for sequence := 1; sequence <= reproductionBuildCount; sequence++ {
+		build, err := runFinalBuild(
+			reproductionContext, executor, authority, bases[sequence-1], contextRoot, temporaryRoot, sequence,
+		)
+		if err != nil {
+			return ReproductionReceipt{}, err
+		}
+		currentContext, err := inspectNoticeContext(reproductionContext, contextRoot, authority.contract)
+		if err != nil {
+			return ReproductionReceipt{}, err
+		}
+		contextStable = contextStable && currentContext == contextIdentity
+		inspection, err := inspectFinalLayers(reproductionContext, build.Image, authority.contract)
+		if err != nil {
+			return ReproductionReceipt{}, err
+		}
+		finals = append(finals, build)
+		inspections = append(inspections, inspection)
+	}
+	finalArchiveEqual, err := equalRegularFiles(
+		finals[0].Archive, finals[1].Archive, authority.contract.Limits.FinalArchiveBytes,
+	)
+	if err != nil {
+		return ReproductionReceipt{}, err
+	}
+	comparison := compareReproduction(
+		bases, finals, inspections, baseArchiveEqual, finalArchiveEqual, contextStable,
+	)
+	receipt := newReproductionReceipt(authority, apkoBuilder, comparator, contextIdentity, bases, finals, inspections[0], comparison)
+	if !comparison.ConstructionMatch {
+		if err := ensureReproductionInputsUnchanged(authority, comparator); err != nil {
+			return ReproductionReceipt{}, err
+		}
+		if err := writeReproductionReceipt(receiptPath, receipt, authority.contract.Limits.ReceiptBytes); err != nil {
+			return ReproductionReceipt{}, err
+		}
+		return receipt, errors.New("PDF-tools final-image reproduction mismatch; inspect the retained NO_RESULT receipt")
+	}
+	runtimeObservation, err := inspectFinalRuntime(reproductionContext, executor, authority, finals[0])
+	if err != nil {
+		return ReproductionReceipt{}, err
+	}
+	comparison.Runtime = true
+	comparison.AllMatch = comparison.ConstructionMatch && comparison.Runtime
+	receipt = newReproductionReceipt(authority, apkoBuilder, comparator, contextIdentity, bases, finals, inspections[0], comparison)
+	receipt.Runtime = &runtimeObservation
+	if err := ensureReproductionInputsUnchanged(authority, comparator); err != nil {
+		return ReproductionReceipt{}, err
+	}
+	if err := writeReproductionReceipt(receiptPath, receipt, authority.contract.Limits.ReceiptBytes); err != nil {
+		return ReproductionReceipt{}, err
+	}
+	return receipt, nil
+}
+
+func ensureReproductionInputsUnchanged(authority checkedAuthority, comparator ReproductionComparator) error {
+	if err := ensureAuthorityUnchanged(authority); err != nil {
+		return err
+	}
+	current, err := currentComparatorIdentity(authority.root)
+	if err != nil || current != comparator {
+		return errors.New("PDF-tools comparator identity changed during local reproduction")
+	}
+	return nil
+}
+
+func compareReproduction(
+	bases []baseBuild,
+	finals []finalBuild,
+	inspections []layerInspection,
+	baseArchiveEqual, finalArchiveEqual, contextStable bool,
+) ReproductionComparison {
+	comparison := ReproductionComparison{
+		BaseArchiveBytes:     baseArchiveEqual,
+		BaseManifest:         bases[0].Image.ManifestDigest == bases[1].Image.ManifestDigest,
+		BaseConfig:           bases[0].Image.ConfigDigest == bases[1].Image.ConfigDigest,
+		BaseLayers:           slices.Equal(bases[0].Image.LayerDigests, bases[1].Image.LayerDigests),
+		BaseDiffIDs:          slices.Equal(bases[0].Image.LayerDiffIDs, bases[1].Image.LayerDiffIDs),
+		SPDXCanonicalBytes:   bytes.Equal(bases[0].SPDX.canonical, bases[1].SPDX.canonical),
+		SPDXIndexCanonical:   bytes.Equal(bases[0].SPDXIndex.canonical, bases[1].SPDXIndex.canonical),
+		NoticeContextStable:  contextStable,
+		FinalArchiveBytes:    finalArchiveEqual,
+		FinalManifest:        finals[0].Image.Identity.ManifestDigest == finals[1].Image.Identity.ManifestDigest,
+		FinalConfig:          finals[0].Image.Identity.ConfigDigest == finals[1].Image.Identity.ConfigDigest,
+		FinalLayers:          slices.Equal(finals[0].Image.Identity.LayerDigests, finals[1].Image.Identity.LayerDigests),
+		FinalDiffIDs:         slices.Equal(finals[0].Image.Identity.LayerDiffIDs, finals[1].Image.Identity.LayerDiffIDs),
+		NoticeFiles:          slices.Equal(inspections[0].Notices, inspections[1].Notices),
+		ManPages:             slices.Equal(inspections[0].ManPages, inspections[1].ManPages),
+		ForbiddenPathsAbsent: len(inspections[0].ForbiddenPaths) == 0 && len(inspections[1].ForbiddenPaths) == 0,
+	}
+	comparison.ConstructionMatch = comparison.BaseArchiveBytes && comparison.BaseManifest && comparison.BaseConfig &&
+		comparison.BaseLayers && comparison.BaseDiffIDs && comparison.SPDXCanonicalBytes &&
+		comparison.SPDXIndexCanonical && comparison.NoticeContextStable && comparison.FinalArchiveBytes &&
+		comparison.FinalManifest && comparison.FinalConfig && comparison.FinalLayers && comparison.FinalDiffIDs &&
+		comparison.NoticeFiles && comparison.ManPages && comparison.ForbiddenPathsAbsent
+	return comparison
+}

--- a/tooling/internal/pdftools/reproduction_build.go
+++ b/tooling/internal/pdftools/reproduction_build.go
@@ -1,0 +1,834 @@
+package pdftools
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const reproductionBuildCount = 2
+
+const buildKitContainerPrefix = "buildx_buildkit_"
+
+type baseBuild struct {
+	Sequence  int
+	Archive   string
+	Layout    string
+	Image     imageIdentity
+	SPDX      spdxIdentity
+	SPDXIndex spdxIdentity
+}
+
+type finalBuild struct {
+	Sequence int
+	Archive  string
+	Image    inspectedFinalImage
+}
+
+type reproductionBuilder struct {
+	Name      string
+	Node      string
+	Container string
+	Volume    string
+}
+
+type apkoBuilderIdentity struct {
+	Version   string
+	Revision  string
+	GoVersion string
+	TreeState string
+	BuildDate string
+}
+
+type apkoVersionOutput struct {
+	GitVersion   string `json:"gitVersion"`
+	GitCommit    string `json:"gitCommit"`
+	GitTreeState string `json:"gitTreeState"`
+	BuildDate    string `json:"buildDate"`
+	GoVersion    string `json:"goVersion"`
+	Compiler     string `json:"compiler"`
+	Platform     string `json:"platform"`
+}
+
+type buildKitContainerInspection struct {
+	Name  string `json:"Name"`
+	State struct {
+		Running bool `json:"Running"`
+	} `json:"State"`
+	Host struct {
+		NetworkMode string `json:"NetworkMode"`
+		Restart     struct {
+			Name string `json:"Name"`
+		} `json:"RestartPolicy"`
+		Privileged      bool                       `json:"Privileged"`
+		PublishAllPorts bool                       `json:"PublishAllPorts"`
+		PortBindings    map[string]json.RawMessage `json:"PortBindings"`
+		Memory          int64                      `json:"Memory"`
+		MemorySwap      int64                      `json:"MemorySwap"`
+		PIDsLimit       *int64                     `json:"PidsLimit"`
+		CPUPeriod       int64                      `json:"CpuPeriod"`
+		CPUQuota        int64                      `json:"CpuQuota"`
+	} `json:"HostConfig"`
+	Config struct {
+		Image      string   `json:"Image"`
+		Entrypoint []string `json:"Entrypoint"`
+		Command    []string `json:"Cmd"`
+	} `json:"Config"`
+	NetworkSettings struct {
+		Networks map[string]json.RawMessage `json:"Networks"`
+	} `json:"NetworkSettings"`
+	Mounts []struct {
+		Type        string `json:"Type"`
+		Name        string `json:"Name"`
+		Destination string `json:"Destination"`
+		ReadWrite   bool   `json:"RW"`
+	} `json:"Mounts"`
+}
+
+func inspectApkoBuilderIdentity(
+	ctx context.Context,
+	executor dockerExecutor,
+	authority checkedAuthority,
+) (_ apkoBuilderIdentity, returnError error) {
+	containerName, err := reproductionName("apko-version")
+	if err != nil {
+		return apkoBuilderIdentity{}, err
+	}
+	if err := requireOwnedContainerNameAvailable(executor, authority, containerName); err != nil {
+		return apkoBuilderIdentity{}, err
+	}
+	defer func() {
+		returnError = errors.Join(returnError, removeRuntimeContainer(executor, authority, containerName))
+	}()
+	result, err := executor.run(ctx, apkoVersionRequest(authority, containerName))
+	if err != nil {
+		return apkoBuilderIdentity{}, err
+	}
+	if len(result.stderr) != 0 {
+		return apkoBuilderIdentity{}, errors.New("pinned apko version probe wrote unexpected stderr")
+	}
+	return parseApkoBuilderIdentity(result.stdout, authority.contract.Builder, authority.contract.Platform)
+}
+
+func apkoVersionRequest(authority checkedAuthority, containerName string) dockerRequest {
+	contract := authority.contract
+	return dockerRequest{
+		operation: "observe pinned apko builder identity",
+		directory: authority.root,
+		timeout:   time.Duration(contract.Limits.RuntimeSeconds) * time.Second,
+		output:    contract.Limits.CapturedOutputBytes,
+		arguments: []string{
+			"run", "--rm", "--pull", "missing",
+			"--name", containerName,
+			"--platform", contract.Platform,
+			"--read-only",
+			"--network", "none",
+			"--cap-drop", "ALL",
+			"--security-opt", "no-new-privileges",
+			"--memory", decimalInt64(contract.Limits.RuntimeMemoryBytes),
+			"--memory-swap", decimalInt64(contract.Limits.RuntimeMemoryBytes),
+			"--pids-limit", strconv.Itoa(contract.Limits.RuntimePIDs),
+			"--ulimit", "core=0:0",
+			"--ulimit", "nofile=256:256",
+			"--tmpfs", dockerTmpfsValue("/tmp", contract.Limits.RuntimeTemporaryBytes),
+			"--env", "HOME=/tmp",
+			"--env", "LANG=C.UTF-8",
+			"--env", "LC_ALL=C.UTF-8",
+			"--env", "TZ=UTC",
+			contract.Builder.Image,
+			"version", "--json",
+		},
+	}
+}
+
+func parseApkoBuilderIdentity(body []byte, expected Builder, platform string) (apkoBuilderIdentity, error) {
+	value, err := decodeArtifactJSON[apkoVersionOutput](body, 4, "apko version")
+	if err != nil {
+		return apkoBuilderIdentity{}, err
+	}
+	buildDate, err := time.Parse(time.RFC3339, value.BuildDate)
+	if err != nil || buildDate.UTC().Format(time.RFC3339) != value.BuildDate {
+		return apkoBuilderIdentity{}, errors.New("apko build date is not canonical UTC RFC 3339")
+	}
+	if value.GitVersion != "v"+expected.Version || value.GitCommit != expected.Revision ||
+		value.GoVersion != "go"+expected.GoVersion || value.Compiler != "gc" || value.Platform != platform ||
+		(value.GitTreeState != "clean" && value.GitTreeState != "dirty") {
+		return apkoBuilderIdentity{}, errors.New("observed apko builder identity differs from contract.json")
+	}
+	return apkoBuilderIdentity{
+		Version: expected.Version, Revision: value.GitCommit, GoVersion: expected.GoVersion,
+		TreeState: value.GitTreeState, BuildDate: value.BuildDate,
+	}, nil
+}
+
+func runApkoBuild(
+	ctx context.Context,
+	executor dockerExecutor,
+	authority checkedAuthority,
+	temporaryRoot string,
+	sequence int,
+) (baseBuild, error) {
+	root := filepath.Join(temporaryRoot, fmt.Sprintf("base-%d", sequence))
+	sbomRoot := filepath.Join(root, "sbom")
+	layoutRoot := filepath.Join(temporaryRoot, fmt.Sprintf("base-%d-oci", sequence))
+	for _, directory := range []string{root, sbomRoot} {
+		if err := os.MkdirAll(directory, 0o700); err != nil {
+			return baseBuild{}, fmt.Errorf("create apko build staging directory: %w", err)
+		}
+		// The private 0700 temporaryRoot contains this bind mount. Its mounted
+		// directories need write and search permission for the capability-free
+		// container root, including daemons that remap container identities.
+		if err := os.Chmod(directory, 0o733); err != nil {
+			return baseBuild{}, fmt.Errorf("prepare apko output directory permissions: %w", err)
+		}
+	}
+	containerName, err := reproductionName("apko")
+	if err != nil {
+		return baseBuild{}, err
+	}
+	if err := requireOwnedContainerNameAvailable(executor, authority, containerName); err != nil {
+		return baseBuild{}, err
+	}
+	request, err := apkoBuildRequest(authority, root, containerName)
+	if err != nil {
+		return baseBuild{}, err
+	}
+	if _, err := executor.run(ctx, request); err != nil {
+		return baseBuild{}, errors.Join(err, removeRuntimeContainer(executor, authority, containerName))
+	}
+	if err := removeRuntimeContainer(executor, authority, containerName); err != nil {
+		return baseBuild{}, err
+	}
+	for _, directory := range []string{root, sbomRoot} {
+		if err := os.Chmod(directory, 0o700); err != nil {
+			return baseBuild{}, fmt.Errorf("close apko output directory permissions: %w", err)
+		}
+	}
+	if err := validateApkoOutputInventory(root); err != nil {
+		return baseBuild{}, err
+	}
+	archivePath := filepath.Join(root, "base.tar")
+	image, err := projectBaseArchive(ctx, archivePath, layoutRoot, authority)
+	if err != nil {
+		return baseBuild{}, err
+	}
+	spdxBody, err := readTemporaryFile(filepath.Join(sbomRoot, "sbom-x86_64.spdx.json"), authority.contract.Limits.SPDXBytes, "apko platform SPDX")
+	if err != nil {
+		return baseBuild{}, err
+	}
+	spdx, err := canonicalizeSPDX(
+		spdxBody,
+		authority.contract.Limits.SPDXBytes,
+		authority.contract.Limits.SPDXPackages,
+		authority.contract.Limits.SPDXRelationships,
+	)
+	if err != nil {
+		return baseBuild{}, fmt.Errorf("canonicalize apko platform SPDX: %w", err)
+	}
+	if err := validatePlatformSPDXIdentity(spdx, authority.contract.BaseImage); err != nil {
+		return baseBuild{}, err
+	}
+	indexBody, err := readTemporaryFile(filepath.Join(sbomRoot, "sbom-index.spdx.json"), authority.contract.Limits.SPDXBytes, "apko index SPDX")
+	if err != nil {
+		return baseBuild{}, err
+	}
+	indexSPDX, err := canonicalizeSPDX(
+		indexBody,
+		authority.contract.Limits.SPDXBytes,
+		authority.contract.Limits.SPDXPackages,
+		authority.contract.Limits.SPDXRelationships,
+	)
+	if err != nil {
+		return baseBuild{}, fmt.Errorf("canonicalize apko index SPDX: %w", err)
+	}
+	if indexSPDX.Packages != 2 || indexSPDX.Relationships != 1 ||
+		indexSPDX.CanonicalSHA256 != authority.contract.BaseImage.SPDXIndexCanonicalSHA256 ||
+		indexSPDX.CanonicalSize != authority.contract.BaseImage.SPDXIndexCanonicalSize {
+		return baseBuild{}, errors.New("apko index SPDX differs from the committed canonical graph")
+	}
+	return baseBuild{
+		Sequence: sequence, Archive: archivePath, Layout: layoutRoot, Image: image, SPDX: spdx, SPDXIndex: indexSPDX,
+	}, nil
+}
+
+func apkoBuildRequest(authority checkedAuthority, outputRoot, containerName string) (dockerRequest, error) {
+	contract := authority.contract
+	source := filepath.Join(authority.root, "tooling", "pdf-tools")
+	if err := validDockerMountSources(source, outputRoot); err != nil {
+		return dockerRequest{}, err
+	}
+	created := time.Unix(contract.SourceDateEpoch, 0).UTC().Format(time.RFC3339)
+	arguments := []string{
+		"run", "--rm", "--pull", "missing",
+		"--name", containerName,
+		"--platform", contract.Platform,
+		"--read-only",
+		"--cap-drop", "ALL",
+		"--security-opt", "no-new-privileges",
+		"--memory", decimalInt64(contract.Limits.ApkoMemoryBytes),
+		"--memory-swap", decimalInt64(contract.Limits.ApkoMemoryBytes),
+		"--pids-limit", strconv.Itoa(contract.Limits.ApkoPIDs),
+		"--ulimit", "core=0:0",
+		"--ulimit", "nofile=1024:1024",
+		"--tmpfs", dockerTmpfsValue("/tmp", contract.Limits.ApkoTemporaryBytes),
+		"--env", "HOME=/tmp",
+		"--env", "LANG=C.UTF-8",
+		"--env", "LC_ALL=C.UTF-8",
+		"--env", "SOURCE_DATE_EPOCH=" + decimalInt64(contract.SourceDateEpoch),
+		"--env", "TZ=UTC",
+		"--mount", dockerBindValue(source, "/work", true),
+		"--mount", dockerBindValue(outputRoot, "/output", false),
+		contract.Builder.Image,
+		"-C", "/work", "build",
+		"--arch", "amd64",
+		"--build-date", created,
+		"--lockfile", contract.Apko.Lock,
+		"--max-apk-control-size", decimalInt64(contract.Limits.APKControlBytes),
+		"--max-apk-data-size", decimalInt64(contract.Limits.APKDataBytes),
+		"--max-apkindex-decompressed-size", decimalInt64(contract.Limits.APKIndexBytes),
+		"--max-http-response-size", decimalInt64(contract.Limits.HTTPResponseBytes),
+		"--sbom-formats", "spdx",
+		"--sbom-path", "/output/sbom",
+		contract.Apko.Config,
+		contract.Apko.OutputTag,
+		"/output/base.tar",
+	}
+	return dockerRequest{
+		operation: "build locked PDF-tools apko base",
+		directory: authority.root,
+		timeout:   time.Duration(contract.Limits.BuildSeconds) * time.Second,
+		output:    contract.Limits.CapturedOutputBytes,
+		arguments: arguments,
+		files: []boundedDockerFile{{
+			path: filepath.Join(outputRoot, "base.tar"), maximum: contract.Limits.BaseArchiveBytes,
+			label: "apko Docker archive",
+		}},
+		directories: []boundedDockerDirectory{{
+			path: outputRoot, maximum: contract.Limits.BaseArchiveBytes + 2*contract.Limits.SPDXBytes,
+			maximumEntries: 8, maximumDepth: 2, label: "apko output inventory",
+		}},
+	}, nil
+}
+
+func validateApkoOutputInventory(root string) error {
+	entries, err := os.ReadDir(root)
+	if err != nil || len(entries) != 2 {
+		return errors.New("apko output must contain only base.tar and its SPDX directory")
+	}
+	wanted := map[string]bool{"base.tar": false, "sbom": false}
+	for _, entry := range entries {
+		if _, expected := wanted[entry.Name()]; !expected || entry.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("apko output contains unexpected path %q", entry.Name())
+		}
+		information, err := entry.Info()
+		if err != nil || (entry.Name() == "base.tar" && !information.Mode().IsRegular()) ||
+			(entry.Name() == "sbom" && !information.IsDir()) {
+			return fmt.Errorf("apko output path %q has an invalid type", entry.Name())
+		}
+		wanted[entry.Name()] = true
+	}
+	sbomEntries, err := os.ReadDir(filepath.Join(root, "sbom"))
+	if err != nil || len(sbomEntries) != 2 {
+		return errors.New("apko SPDX output must contain exactly index and linux-amd64 documents")
+	}
+	for _, entry := range sbomEntries {
+		information, informationError := entry.Info()
+		if informationError != nil || !information.Mode().IsRegular() || entry.Type()&os.ModeSymlink != 0 ||
+			(entry.Name() != "sbom-index.spdx.json" && entry.Name() != "sbom-x86_64.spdx.json") {
+			return fmt.Errorf("apko SPDX output contains unexpected path %q", entry.Name())
+		}
+	}
+	return nil
+}
+
+func validatePlatformSPDXIdentity(identity spdxIdentity, base BaseImage) error {
+	if identity.RawSize != base.SPDXSize || identity.CanonicalSHA256 != base.SPDXCanonicalSHA256 ||
+		identity.CanonicalSize != base.SPDXCanonicalSize || identity.Packages != base.SPDXPackages ||
+		identity.Relationships != base.SPDXRelationships {
+		return errors.New("apko platform SPDX differs from the committed canonical graph")
+	}
+	return nil
+}
+
+func runFinalBuild(
+	ctx context.Context,
+	executor dockerExecutor,
+	authority checkedAuthority,
+	base baseBuild,
+	contextRoot, temporaryRoot string,
+	sequence int,
+) (_ finalBuild, returnError error) {
+	builder, err := createReproductionBuilder(ctx, executor, authority, sequence)
+	if err != nil {
+		return finalBuild{}, err
+	}
+	builderActive := true
+	defer func() {
+		if builderActive {
+			returnError = errors.Join(returnError, removeReproductionBuilder(executor, authority, builder))
+		}
+	}()
+	buildRoot := filepath.Join(temporaryRoot, fmt.Sprintf("final-%d", sequence))
+	if err := os.MkdirAll(buildRoot, 0o700); err != nil {
+		return finalBuild{}, fmt.Errorf("create final image build root: %w", err)
+	}
+	archivePath := filepath.Join(buildRoot, "final.tar")
+	metadataPath := filepath.Join(buildRoot, "metadata.json")
+	request := finalBuildRequest(authority, base, contextRoot, builder.Name, archivePath, metadataPath, sequence)
+	result, err := executor.run(ctx, request)
+	if err != nil {
+		return finalBuild{}, err
+	}
+	if err := rejectBuildKitTimestampWarnings(result); err != nil {
+		return finalBuild{}, err
+	}
+	if err := removeReproductionBuilder(executor, authority, builder); err != nil {
+		return finalBuild{}, err
+	}
+	builderActive = false
+	if err := ensureAuthorityUnchanged(authority); err != nil {
+		return finalBuild{}, err
+	}
+	layout := filepath.Join(buildRoot, "inspection")
+	image, err := inspectFinalArchive(ctx, archivePath, layout, authority.contract)
+	if err != nil {
+		return finalBuild{}, err
+	}
+	if err := validateFinalBuildMetadata(metadataPath, image.Identity, authority.contract.Limits.CapturedOutputBytes); err != nil {
+		return finalBuild{}, err
+	}
+	return finalBuild{Sequence: sequence, Archive: archivePath, Image: image}, nil
+}
+
+func createReproductionBuilder(
+	ctx context.Context,
+	executor dockerExecutor,
+	authority checkedAuthority,
+	sequence int,
+) (reproductionBuilder, error) {
+	name, err := reproductionName(fmt.Sprintf("builder-%d", sequence))
+	if err != nil {
+		return reproductionBuilder{}, err
+	}
+	node := name + "-node"
+	builder := reproductionBuilder{
+		Name: name, Node: node,
+		Container: buildKitContainerPrefix + node,
+		Volume:    buildKitContainerPrefix + node + "_state",
+	}
+	present, err := reproductionBuilderPresent(executor, name, authority.contract.Limits.CapturedOutputBytes)
+	if err != nil {
+		return reproductionBuilder{}, err
+	}
+	if present {
+		return reproductionBuilder{}, errors.New("generated PDF-tools BuildKit builder name is already in use")
+	}
+	if err := requireOwnedContainerNameAvailable(executor, authority, builder.Container); err != nil {
+		return reproductionBuilder{}, err
+	}
+	volumePresent, err := reproductionVolumePresent(executor, authority, builder.Volume)
+	if err != nil {
+		return reproductionBuilder{}, err
+	}
+	if volumePresent {
+		return reproductionBuilder{}, errors.New("generated PDF-tools BuildKit volume name is already in use")
+	}
+	limits := authority.contract.Limits
+	_, err = executor.run(ctx, reproductionBuilderCreateRequest(authority, builder))
+	if err != nil {
+		return reproductionBuilder{}, errors.Join(err, removeReproductionBuilder(executor, authority, builder))
+	}
+	if _, err := executor.run(ctx, dockerRequest{
+		operation: "apply PDF-tools BuildKit PID boundary",
+		directory: authority.root,
+		timeout:   30 * time.Second,
+		output:    authority.contract.Limits.CapturedOutputBytes,
+		arguments: []string{"container", "update", "--pids-limit", strconv.Itoa(limits.BuildKitPIDs), builder.Container},
+	}); err != nil {
+		return reproductionBuilder{}, errors.Join(err, removeReproductionBuilder(executor, authority, builder))
+	}
+	if err := validateReproductionBuilder(ctx, executor, authority, builder); err != nil {
+		return reproductionBuilder{}, errors.Join(err, removeReproductionBuilder(executor, authority, builder))
+	}
+	return builder, nil
+}
+
+func reproductionBuilderCreateRequest(authority checkedAuthority, builder reproductionBuilder) dockerRequest {
+	lock := authority.renderer.Lock
+	limits := authority.contract.Limits
+	return dockerRequest{
+		operation: "create fresh pinned PDF-tools BuildKit builder",
+		directory: authority.root,
+		timeout:   time.Duration(authority.contract.Limits.BuildSeconds) * time.Second,
+		output:    authority.contract.Limits.CapturedOutputBytes,
+		arguments: []string{
+			"buildx", "create",
+			"--name", builder.Name,
+			"--node", builder.Node,
+			"--driver", "docker-container",
+			"--driver-opt", "image=" + lock.Builder.BuildKitImage,
+			"--driver-opt", "memory=" + decimalInt64(limits.BuildKitMemoryBytes),
+			"--driver-opt", "memory-swap=" + decimalInt64(limits.BuildKitMemoryBytes),
+			"--driver-opt", "cpu-period=" + decimalInt64(limits.BuildKitCPUPeriod),
+			"--driver-opt", "cpu-quota=" + decimalInt64(limits.BuildKitCPUQuota),
+			"--driver-opt", "network=none",
+			"--driver-opt", "restart-policy=no",
+			"--driver-opt", "default-load=false",
+			"--driver-opt", "provenance-add-gha=false",
+			"--buildkitd-flags", strings.Join(expectedBuildKitDaemonFlags(authority.contract), " "),
+			"--platform", authority.contract.Platform,
+			"--bootstrap",
+		},
+	}
+}
+
+func finalBuildRequest(
+	authority checkedAuthority,
+	base baseBuild,
+	contextRoot, builderName, archivePath, metadataPath string,
+	sequence int,
+) dockerRequest {
+	contract := authority.contract
+	return dockerRequest{
+		operation: fmt.Sprintf("build PDF-tools final image %d", sequence),
+		directory: authority.root,
+		timeout:   time.Duration(contract.Limits.BuildSeconds) * time.Second,
+		output:    contract.Limits.CapturedOutputBytes,
+		arguments: []string{
+			"buildx", "build",
+			"--builder", builderName,
+			"--output", "type=oci,dest=" + archivePath + ",rewrite-timestamp=true",
+			"--platform", contract.Platform,
+			"--network", "none",
+			"--resource", "memory=" + decimalInt64(contract.Limits.BuildKitMemoryBytes),
+			"--resource", "memory-swap=" + decimalInt64(contract.Limits.BuildKitMemoryBytes),
+			"--resource", "cpu-period=" + decimalInt64(contract.Limits.BuildKitCPUPeriod),
+			"--resource", "cpu-quota=" + decimalInt64(contract.Limits.BuildKitCPUQuota),
+			"--no-cache",
+			"--provenance=false",
+			"--sbom=false",
+			"--metadata-file", metadataPath,
+			"--progress", "plain",
+			"--build-arg", "SOURCE_DATE_EPOCH=" + decimalInt64(contract.SourceDateEpoch),
+			"--build-context", "pdf_tools_base=oci-layout://" + base.Layout + "@" + base.Image.ManifestDigest,
+			"--file", filepath.Join(contextRoot, "Dockerfile"),
+			contextRoot,
+		},
+		files: []boundedDockerFile{{
+			path: archivePath, maximum: contract.Limits.FinalArchiveBytes, label: "final OCI archive",
+		}},
+		directories: []boundedDockerDirectory{{
+			path: filepath.Dir(archivePath), maximum: contract.Limits.FinalArchiveBytes + contract.Limits.CapturedOutputBytes,
+			maximumEntries: 4, maximumDepth: 1, label: "Buildx final-image output inventory",
+		}},
+	}
+}
+
+func expectedBuildKitDaemonFlags(contract Contract) []string {
+	keepStorageMegabytes := 4 * contract.Limits.FinalArchiveBytes / (1024 * 1024)
+	return []string{
+		// Pinned Buildx stops its entitlement scan at the first unrelated
+		// buildkitd flag. Keep the sole admitted entitlement first so Buildx
+		// does not append a duplicate default permission.
+		"--allow-insecure-entitlement=network.host",
+		"--cdi-disabled",
+		"--containerd-worker=false",
+		"--oci-max-parallelism=1",
+		"--oci-worker-gc=true",
+		"--oci-worker-gc-keepstorage=" + decimalInt64(keepStorageMegabytes),
+		"--proxy-network",
+	}
+}
+
+func validateReproductionBuilder(
+	ctx context.Context,
+	executor dockerExecutor,
+	authority checkedAuthority,
+	builder reproductionBuilder,
+) error {
+	result, err := executor.run(ctx, dockerRequest{
+		operation: "inspect bounded PDF-tools BuildKit daemon",
+		directory: authority.root,
+		timeout:   30 * time.Second,
+		output:    authority.contract.Limits.CapturedOutputBytes,
+		arguments: []string{"container", "inspect", "--format", "{{json .}}", builder.Container},
+	})
+	if err != nil {
+		return err
+	}
+	inspection, err := decodeDockerJSON[buildKitContainerInspection](result.stdout, "PDF-tools BuildKit daemon")
+	if err != nil {
+		return err
+	}
+	limits := authority.contract.Limits
+	mismatches := make([]string, 0, 20)
+	require := func(condition bool, field string) {
+		if !condition {
+			mismatches = append(mismatches, field)
+		}
+	}
+	require(inspection.Name == "/"+builder.Container, "name")
+	require(inspection.State.Running, "running state")
+	require(inspection.Config.Image == authority.renderer.Lock.Builder.BuildKitImage, "image")
+	require(slices.Equal(inspection.Config.Entrypoint, []string{"/usr/bin/buildkitd-entrypoint"}), "entrypoint")
+	require(slices.Equal(inspection.Config.Command, expectedBuildKitDaemonFlags(authority.contract)), "daemon flags")
+	require(inspection.Host.NetworkMode == "none", "daemon network")
+	require(inspection.Host.Privileged, "privileged mode")
+	require(inspection.Host.Restart.Name == "no", "restart policy")
+	require(!inspection.Host.PublishAllPorts && len(inspection.Host.PortBindings) == 0, "published ports")
+	require(inspection.Host.Memory == limits.BuildKitMemoryBytes, "memory")
+	require(inspection.Host.MemorySwap == limits.BuildKitMemoryBytes, "memory swap")
+	require(inspection.Host.PIDsLimit != nil && *inspection.Host.PIDsLimit == int64(limits.BuildKitPIDs), "PID limit")
+	require(inspection.Host.CPUPeriod == limits.BuildKitCPUPeriod, "CPU period")
+	require(inspection.Host.CPUQuota == limits.BuildKitCPUQuota, "CPU quota")
+	require(len(inspection.NetworkSettings.Networks) == 1, "network attachment count")
+	_, disabledNetwork := inspection.NetworkSettings.Networks["none"]
+	require(disabledNetwork, "disabled network attachment")
+	require(len(inspection.Mounts) == 1, "mount count")
+	if len(inspection.Mounts) == 1 {
+		require(inspection.Mounts[0].Type == "volume", "state mount type")
+		require(inspection.Mounts[0].Name == builder.Volume, "state volume")
+		require(inspection.Mounts[0].Destination == "/var/lib/buildkit", "state mount destination")
+		require(inspection.Mounts[0].ReadWrite, "state mount access")
+	}
+	if len(mismatches) != 0 {
+		return fmt.Errorf("Docker did not retain the exact PDF-tools BuildKit daemon boundary: %s", strings.Join(mismatches, ", "))
+	}
+	version, err := executor.run(ctx, dockerRequest{
+		operation: "verify pinned PDF-tools BuildKit daemon version",
+		directory: authority.root,
+		timeout:   30 * time.Second,
+		output:    authority.contract.Limits.CapturedOutputBytes,
+		arguments: []string{"container", "exec", builder.Container, "/usr/bin/buildkitd", "--version"},
+	})
+	if err != nil {
+		return err
+	}
+	fields := strings.Fields(string(version.stdout))
+	if len(version.stderr) != 0 || len(fields) != 4 || fields[0] != "buildkitd" ||
+		fields[1] != "github.com/moby/buildkit" || strings.TrimPrefix(fields[2], "v") != authority.renderer.Lock.Builder.BuildKitVersion ||
+		!revisionPattern.MatchString(fields[3]) {
+		return errors.New("running BuildKit daemon differs from the pinned PDF renderer authority")
+	}
+	return nil
+}
+
+func validateFinalBuildMetadata(path string, identity imageIdentity, maximum int64) error {
+	body, err := readTemporaryFile(path, maximum, "PDF-tools Buildx metadata")
+	if err != nil {
+		return err
+	}
+	var values map[string]json.RawMessage
+	if _, err := decodeArtifactJSON[map[string]json.RawMessage](body, 32, "PDF-tools Buildx metadata"); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(body, &values); err != nil {
+		return fmt.Errorf("decode PDF-tools Buildx metadata: %w", err)
+	}
+	for name, wanted := range map[string]string{
+		"containerimage.digest":        identity.ManifestDigest,
+		"containerimage.config.digest": identity.ConfigDigest,
+	} {
+		var value string
+		if body, exists := values[name]; !exists || json.Unmarshal(body, &value) != nil || value != wanted {
+			return fmt.Errorf("PDF-tools Buildx metadata %s does not match the inspected archive", name)
+		}
+	}
+	return nil
+}
+
+func verifyBuildxIdentity(ctx context.Context, executor dockerExecutor, authority checkedAuthority) error {
+	result, err := executor.run(ctx, dockerRequest{
+		operation: "verify locked Docker Buildx client",
+		directory: authority.root,
+		timeout:   30 * time.Second,
+		output:    authority.contract.Limits.CapturedOutputBytes,
+		arguments: []string{"buildx", "version"},
+	})
+	if err != nil {
+		return err
+	}
+	fields := strings.Fields(string(result.stdout))
+	builder := authority.renderer.Lock.Builder
+	if len(fields) != 3 || fields[0] != "github.com/docker/buildx" ||
+		strings.TrimPrefix(fields[1], "v") != builder.BuildxVersion || fields[2] != builder.BuildxRevision {
+		return errors.New("Docker Buildx client differs from the PDF renderer authority")
+	}
+	return nil
+}
+
+func ensureAuthorityUnchanged(authority checkedAuthority) error {
+	current, err := checkAuthority(authority.root)
+	if err != nil || current.contractSHA256 != authority.contractSHA256 ||
+		current.renderer.LockSHA256 != authority.renderer.LockSHA256 {
+		return errors.New("PDF-tools or BuildKit authority changed during local reproduction")
+	}
+	return nil
+}
+
+func rejectBuildKitTimestampWarnings(result dockerResult) error {
+	output := string(append(bytes.Clone(result.stdout), result.stderr...))
+	if strings.Contains(output, "rewrite-timestamp is specified, but no source-date-epoch was found") ||
+		(strings.Contains(output, "failed to rewrite layer ") && strings.Contains(output, " to match source-date-epoch ")) {
+		return errors.New("BuildKit did not apply the required PDF-tools timestamp rewrite")
+	}
+	return nil
+}
+
+func removeReproductionBuilder(
+	executor dockerExecutor,
+	authority checkedAuthority,
+	builder reproductionBuilder,
+) error {
+	output := authority.contract.Limits.CapturedOutputBytes
+	present, inventoryError := reproductionBuilderPresent(executor, builder.Name, output)
+	var removeError error
+	if inventoryError == nil && present {
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		_, removeError = executor.run(ctx, dockerRequest{
+			operation: "remove pinned PDF-tools BuildKit builder",
+			directory: authority.root,
+			timeout:   60 * time.Second,
+			output:    output,
+			arguments: []string{"buildx", "rm", "--force", builder.Name},
+		})
+		cancel()
+	}
+	containerError := removeRuntimeContainer(executor, authority, builder.Container)
+	volumeError := removeReproductionVolume(executor, authority, builder.Volume)
+	present, finalBuilderError := reproductionBuilderPresent(executor, builder.Name, output)
+	containerPresent, finalContainerError := runtimeContainerPresent(executor, authority, builder.Container)
+	volumePresent, finalVolumeError := reproductionVolumePresent(executor, authority, builder.Volume)
+	if present || containerPresent || volumePresent {
+		return errors.Join(
+			inventoryError, removeError, containerError, volumeError,
+			finalBuilderError, finalContainerError, finalVolumeError,
+			errors.New("owned PDF-tools BuildKit builder resources remain after cleanup"),
+		)
+	}
+	return errors.Join(inventoryError, finalBuilderError, finalContainerError, finalVolumeError)
+}
+
+func reproductionBuilderPresent(executor dockerExecutor, name string, output int64) (bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	result, err := executor.run(ctx, dockerRequest{
+		operation: "inventory local Docker Buildx builders",
+		timeout:   30 * time.Second,
+		output:    output,
+		arguments: []string{"buildx", "ls", "--format", "{{.Name}}"},
+	})
+	if err != nil {
+		return false, err
+	}
+	if len(result.stderr) != 0 {
+		return false, errors.New("Docker Buildx builder inventory wrote unexpected stderr")
+	}
+	lines := strings.Split(strings.TrimSpace(string(result.stdout)), "\n")
+	if len(lines) > 4096 {
+		return false, errors.New("Docker Buildx builder inventory exceeds its count boundary")
+	}
+	for _, line := range lines {
+		if line == name {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func reproductionVolumePresent(
+	executor dockerExecutor,
+	authority checkedAuthority,
+	name string,
+) (bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	result, err := executor.run(ctx, dockerRequest{
+		operation: "inventory local Docker volumes",
+		directory: authority.root,
+		timeout:   30 * time.Second,
+		output:    authority.contract.Limits.CapturedOutputBytes,
+		arguments: []string{"volume", "ls", "--format", "{{.Name}}"},
+	})
+	if err != nil {
+		return false, err
+	}
+	if len(result.stderr) != 0 {
+		return false, errors.New("local Docker volume inventory wrote unexpected stderr")
+	}
+	lines := strings.Split(strings.TrimSpace(string(result.stdout)), "\n")
+	if len(lines) > 4096 {
+		return false, errors.New("local Docker volume inventory exceeds its count boundary")
+	}
+	for _, line := range lines {
+		if line == name {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func removeReproductionVolume(executor dockerExecutor, authority checkedAuthority, name string) error {
+	present, err := reproductionVolumePresent(executor, authority, name)
+	if err != nil || !present {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	_, removeError := executor.run(ctx, dockerRequest{
+		operation: "remove owned PDF-tools BuildKit state volume",
+		directory: authority.root,
+		timeout:   30 * time.Second,
+		output:    authority.contract.Limits.CapturedOutputBytes,
+		arguments: []string{"volume", "rm", name},
+	})
+	cancel()
+	present, inspectionError := reproductionVolumePresent(executor, authority, name)
+	if inspectionError != nil {
+		return errors.Join(removeError, inspectionError)
+	}
+	if present {
+		return errors.Join(removeError, errors.New("owned PDF-tools BuildKit state volume remains after cleanup"))
+	}
+	return nil
+}
+
+func reproductionName(role string) (string, error) {
+	random := make([]byte, 8)
+	if _, err := rand.Read(random); err != nil {
+		return "", fmt.Errorf("create PDF-tools local reproduction identity: %w", err)
+	}
+	return fmt.Sprintf("pdf20w-%s-%d-%s", role, os.Getpid(), hex.EncodeToString(random)), nil
+}
+
+func validDockerMountSources(values ...string) error {
+	for _, value := range values {
+		if value == "" || strings.ContainsAny(value, ",\r\n\x00") {
+			return errors.New("PDF-tools Docker mount source contains an unsupported character")
+		}
+	}
+	return nil
+}
+
+func dockerBindValue(source, destination string, readOnly bool) string {
+	value := "type=bind,src=" + source + ",dst=" + destination
+	if readOnly {
+		value += ",readonly"
+	}
+	return value
+}
+
+func dockerTmpfsValue(destination string, size int64) string {
+	return destination + ":rw,noexec,nosuid,nodev,size=" + decimalInt64(size) + ",mode=1777"
+}
+
+func decimalInt64(value int64) string { return strconv.FormatInt(value, 10) }

--- a/tooling/internal/pdftools/reproduction_context.go
+++ b/tooling/internal/pdftools/reproduction_context.go
@@ -1,0 +1,174 @@
+package pdftools
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"hash"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const finalImageDockerfile = "FROM pdf_tools_base\nCOPY --chown=0:0 notices/ /usr/share/licenses/poppler/\n"
+
+type noticeContextIdentity struct {
+	SHA256     string
+	Entries    int
+	FileBytes  int64
+	Dockerfile string
+}
+
+func prepareNoticeContext(ctx context.Context, root string, authority checkedAuthority) (noticeContextIdentity, error) {
+	if err := os.MkdirAll(filepath.Join(root, "notices"), 0o755); err != nil {
+		return noticeContextIdentity{}, fmt.Errorf("create PDF-tools notice context: %w", err)
+	}
+	epoch := time.Unix(authority.contract.SourceDateEpoch, 0)
+	if err := writeNormalizedContextFile(filepath.Join(root, "Dockerfile"), []byte(finalImageDockerfile), epoch); err != nil {
+		return noticeContextIdentity{}, err
+	}
+	for _, entry := range authority.contract.NoticeLayer.Entries {
+		if err := ctx.Err(); err != nil {
+			return noticeContextIdentity{}, err
+		}
+		body, err := readRelative(
+			authority.root,
+			"tooling/pdf-tools/"+entry.Source,
+			"Poppler notice context source "+entry.Source,
+			authority.contract.Limits.NoticeBytes,
+		)
+		if err != nil {
+			return noticeContextIdentity{}, err
+		}
+		if int64(len(body)) != entry.Size || digestRaw(body) != entry.SHA256 {
+			return noticeContextIdentity{}, fmt.Errorf("Poppler notice context source %s changed", entry.Source)
+		}
+		destination := filepath.Join(root, "notices", filepath.Base(entry.Source))
+		if err := writeNormalizedContextFile(destination, body, epoch); err != nil {
+			return noticeContextIdentity{}, err
+		}
+	}
+	for _, directory := range []string{filepath.Join(root, "notices"), root} {
+		if err := os.Chmod(directory, 0o755); err != nil {
+			return noticeContextIdentity{}, fmt.Errorf("normalize notice context directory mode: %w", err)
+		}
+		if err := os.Chtimes(directory, epoch, epoch); err != nil {
+			return noticeContextIdentity{}, fmt.Errorf("normalize notice context directory timestamp: %w", err)
+		}
+	}
+	return inspectNoticeContext(ctx, root, authority.contract)
+}
+
+func writeNormalizedContextFile(path string, body []byte, epoch time.Time) (returnError error) {
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	if err != nil {
+		return fmt.Errorf("create normalized notice context file: %w", err)
+	}
+	complete := false
+	defer func() {
+		_ = file.Close()
+		if !complete {
+			_ = os.Remove(path)
+		}
+	}()
+	if _, err := file.Write(body); err != nil {
+		return fmt.Errorf("write normalized notice context file: %w", err)
+	}
+	if err := file.Sync(); err != nil {
+		return fmt.Errorf("sync normalized notice context file: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close normalized notice context file: %w", err)
+	}
+	if err := os.Chmod(path, 0o644); err != nil {
+		return fmt.Errorf("normalize notice context file mode: %w", err)
+	}
+	if err := os.Chtimes(path, epoch, epoch); err != nil {
+		return fmt.Errorf("normalize notice context file timestamp: %w", err)
+	}
+	complete = true
+	return nil
+}
+
+func inspectNoticeContext(ctx context.Context, root string, contract Contract) (noticeContextIdentity, error) {
+	epoch := time.Unix(contract.SourceDateEpoch, 0)
+	for _, directory := range []string{root, filepath.Join(root, "notices")} {
+		information, err := os.Lstat(directory)
+		if err != nil || !information.IsDir() || information.Mode()&os.ModeSymlink != 0 ||
+			information.Mode().Perm() != 0o755 || !information.ModTime().Equal(epoch) {
+			return noticeContextIdentity{}, errors.New("notice context directory is not normalized")
+		}
+	}
+	rootEntries, err := os.ReadDir(root)
+	if err != nil || len(rootEntries) != 2 || rootEntries[0].Name() != "Dockerfile" ||
+		rootEntries[1].Name() != "notices" || !rootEntries[1].IsDir() {
+		return noticeContextIdentity{}, errors.New("notice context root inventory is not exact")
+	}
+	noticeEntries, err := os.ReadDir(filepath.Join(root, "notices"))
+	if err != nil || len(noticeEntries) != len(contract.NoticeLayer.Entries) {
+		return noticeContextIdentity{}, errors.New("notice context file inventory is not exact")
+	}
+	noticeBodies := make(map[string]NoticeEntry, len(contract.NoticeLayer.Entries))
+	for index, entry := range contract.NoticeLayer.Entries {
+		if noticeEntries[index].Name() != filepath.Base(entry.Source) || noticeEntries[index].IsDir() ||
+			noticeEntries[index].Type()&os.ModeSymlink != 0 {
+			return noticeContextIdentity{}, errors.New("notice context file inventory is not exact")
+		}
+		noticeBodies["notices/"+filepath.Base(entry.Source)] = entry
+	}
+	wanted := make([]struct {
+		path string
+		body []byte
+	}, 0, len(contract.NoticeLayer.Entries)+1)
+	wanted = append(wanted, struct {
+		path string
+		body []byte
+	}{path: "Dockerfile", body: []byte(finalImageDockerfile)})
+	for _, entry := range contract.NoticeLayer.Entries {
+		wanted = append(wanted, struct {
+			path string
+			body []byte
+		}{path: "notices/" + filepath.Base(entry.Source)})
+	}
+	digest := sha256.New()
+	identity := noticeContextIdentity{Entries: len(wanted) + 2, Dockerfile: digestRaw([]byte(finalImageDockerfile))}
+	for _, expected := range wanted {
+		if err := ctx.Err(); err != nil {
+			return noticeContextIdentity{}, err
+		}
+		path := filepath.Join(root, filepath.FromSlash(expected.path))
+		information, err := os.Lstat(path)
+		if err != nil || !information.Mode().IsRegular() || information.Mode().Perm() != 0o644 ||
+			!information.ModTime().Equal(time.Unix(contract.SourceDateEpoch, 0)) {
+			return noticeContextIdentity{}, fmt.Errorf("notice context file %s is not normalized", expected.path)
+		}
+		body, err := readTemporaryFile(path, contract.Limits.NoticeBytes, "normalized notice context file")
+		if err != nil {
+			return noticeContextIdentity{}, err
+		}
+		if expected.body != nil && string(body) != string(expected.body) {
+			return noticeContextIdentity{}, fmt.Errorf("normalized context file %s changed", expected.path)
+		}
+		if entry, notice := noticeBodies[expected.path]; notice &&
+			(int64(len(body)) != entry.Size || digestRaw(body) != entry.SHA256) {
+			return noticeContextIdentity{}, fmt.Errorf("normalized context notice %s changed", expected.path)
+		}
+		identity.FileBytes += int64(len(body))
+		writeContextDigestField(digest, []byte(expected.path))
+		writeContextDigestField(digest, []byte("-rw-r--r--"))
+		writeContextDigestField(digest, body)
+	}
+	if identity.FileBytes > contract.Limits.NoticeBytes+int64(len(finalImageDockerfile)) {
+		return noticeContextIdentity{}, errors.New("notice context exceeds its byte boundary")
+	}
+	identity.SHA256 = "sha256:" + hex.EncodeToString(digest.Sum(nil))
+	return identity, nil
+}
+
+func writeContextDigestField(digest hash.Hash, body []byte) {
+	_ = binary.Write(digest, binary.BigEndian, uint64(len(body)))
+	_, _ = digest.Write(body)
+}

--- a/tooling/internal/pdftools/reproduction_unit_test.go
+++ b/tooling/internal/pdftools/reproduction_unit_test.go
@@ -1,0 +1,295 @@
+package pdftools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+type recordingDockerExecutor struct {
+	requests []dockerRequest
+	result   dockerResult
+	err      error
+}
+
+func (executor *recordingDockerExecutor) run(_ context.Context, request dockerRequest) (dockerResult, error) {
+	executor.requests = append(executor.requests, request)
+	return executor.result, executor.err
+}
+
+func TestReproductionRequestsStayPinnedBoundedAndNonPublishing(t *testing.T) {
+	t.Parallel()
+	root := filepath.Clean(filepath.Join("..", "..", ".."))
+	authority, err := checkAuthority(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	outputRoot := t.TempDir()
+	apko, err := apkoBuildRequest(authority, outputRoot, "20w-test-apko")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertArgumentsContain(t, apko.arguments,
+		authority.contract.Builder.Image,
+		"--memory-swap", decimalInt64(authority.contract.Limits.ApkoMemoryBytes),
+		"--pids-limit", "512",
+		"--lockfile", authority.contract.Apko.Lock,
+	)
+	if len(apko.files) != 1 || len(apko.directories) != 1 || apko.timeout <= 0 {
+		t.Fatalf("apko boundaries = %#v / %#v / %s", apko.files, apko.directories, apko.timeout)
+	}
+	version := apkoVersionRequest(authority, "20w-test-apko-version")
+	assertArgumentsContain(t, version.arguments,
+		"--pull", "missing",
+		"--network", "none",
+		"--read-only",
+		"--memory", decimalInt64(authority.contract.Limits.RuntimeMemoryBytes),
+		"--pids-limit", "64",
+		authority.contract.Builder.Image,
+		"version", "--json",
+	)
+	if version.timeout <= 0 || version.output != authority.contract.Limits.CapturedOutputBytes {
+		t.Fatalf("apko version boundaries = %s / %d", version.timeout, version.output)
+	}
+	final := finalBuildRequest(
+		authority,
+		baseBuild{Layout: filepath.Join(outputRoot, "base"), Image: imageIdentity{ManifestDigest: authority.contract.BaseImage.ManifestDigest}},
+		filepath.Join(outputRoot, "context"), "20w-test-builder",
+		filepath.Join(outputRoot, "final.tar"), filepath.Join(outputRoot, "metadata.json"), 1,
+	)
+	assertArgumentsContain(t, final.arguments,
+		"--builder", "20w-test-builder",
+		"--network", "none",
+		"--no-cache",
+		"--provenance=false",
+		"--sbom=false",
+		"--build-context", "pdf_tools_base=oci-layout://"+filepath.Join(outputRoot, "base")+"@"+authority.contract.BaseImage.ManifestDigest,
+	)
+	joined := strings.Join(append(slices.Clone(apko.arguments), final.arguments...), " ")
+	for _, forbidden := range []string{"skopeo", "--push", "type=registry", "--tag"} {
+		if strings.Contains(joined, forbidden) {
+			t.Fatalf("reproduction request contains forbidden %q: %s", forbidden, joined)
+		}
+	}
+	if len(final.files) != 1 || len(final.directories) != 1 || final.timeout <= 0 {
+		t.Fatalf("final boundaries = %#v / %#v / %s", final.files, final.directories, final.timeout)
+	}
+	for _, argument := range final.arguments {
+		if argument == "--allow" || strings.HasPrefix(argument, "--allow=") {
+			t.Fatalf("final build requested an entitlement: %q", argument)
+		}
+	}
+	builder := reproductionBuilder{
+		Name: "pdf20w-test-builder", Node: "pdf20w-test-builder-node",
+		Container: "buildx_buildkit_pdf20w-test-builder-node",
+		Volume:    "buildx_buildkit_pdf20w-test-builder-node_state",
+	}
+	builderRequest := reproductionBuilderCreateRequest(authority, builder)
+	assertArgumentsContain(t, builderRequest.arguments,
+		"--driver", "docker-container",
+		"--driver-opt", "image="+authority.renderer.Lock.Builder.BuildKitImage,
+		"--driver-opt", "network=none",
+		"--driver-opt", "memory="+decimalInt64(authority.contract.Limits.BuildKitMemoryBytes),
+		"--driver-opt", "memory-swap="+decimalInt64(authority.contract.Limits.BuildKitMemoryBytes),
+		"--buildkitd-flags", strings.Join(expectedBuildKitDaemonFlags(authority.contract), " "),
+		"--bootstrap",
+	)
+	if !strings.Contains(strings.Join(builderRequest.arguments, " "), "--allow-insecure-entitlement=network.host") {
+		t.Fatal("Buildx's sole daemon-side entitlement was not explicit")
+	}
+	joined += " " + strings.Join(builderRequest.arguments, " ")
+	for _, forbidden := range []string{"security.insecure"} {
+		if strings.Contains(joined, forbidden) {
+			t.Fatalf("reproduction request contains forbidden %q: %s", forbidden, joined)
+		}
+	}
+}
+
+func TestParseApkoBuilderIdentityRequiresObservedContractIdentity(t *testing.T) {
+	t.Parallel()
+	expected := Builder{Version: "1.2.41", Revision: "c89724f244e9d41f5e14cc7a5f3d0bd08a82128e", GoVersion: "1.27.0"}
+	valid := `{
+  "gitVersion": "v1.2.41",
+  "gitCommit": "c89724f244e9d41f5e14cc7a5f3d0bd08a82128e",
+  "gitTreeState": "dirty",
+  "buildDate": "2026-08-28T04:48:59Z",
+  "goVersion": "go1.27.0",
+  "compiler": "gc",
+  "platform": "linux/amd64"
+}`
+	identity, err := parseApkoBuilderIdentity([]byte(valid), expected, "linux/amd64")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if identity.Version != expected.Version || identity.Revision != expected.Revision ||
+		identity.GoVersion != expected.GoVersion || identity.TreeState != "dirty" ||
+		identity.BuildDate != "2026-08-28T04:48:59Z" {
+		t.Fatalf("apko identity = %#v", identity)
+	}
+	mutations := map[string]string{
+		"version":    strings.Replace(valid, "v1.2.41", "v1.2.42", 1),
+		"revision":   strings.Replace(valid, expected.Revision, strings.Repeat("0", 40), 1),
+		"go-version": strings.Replace(valid, "go1.27.0", "go1.28.0", 1),
+		"tree-state": strings.Replace(valid, "dirty", "unknown", 1),
+		"build-date": strings.Replace(valid, "2026-08-28T04:48:59Z", "2026-08-28T06:48:59+02:00", 1),
+		"compiler":   strings.Replace(valid, `"gc"`, `"gccgo"`, 1),
+		"platform":   strings.Replace(valid, "linux/amd64", "linux/arm64", 1),
+		"unknown":    strings.Replace(valid, "\n}", ",\n  \"extra\": true\n}", 1),
+	}
+	for name, body := range mutations {
+		name, body := name, body
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := parseApkoBuilderIdentity([]byte(body), expected, "linux/amd64"); err == nil {
+				t.Fatal("mutated apko identity was accepted")
+			}
+		})
+	}
+}
+
+func TestBoundedDockerEnvironmentDropsAmbientRouting(t *testing.T) {
+	t.Setenv("DOCKER_HOST", "tcp://attacker.invalid:2375")
+	t.Setenv("DOCKER_CONTEXT", "remote")
+	t.Setenv("DOCKER_TLS_VERIFY", "1")
+	for _, entry := range boundedDockerEnvironment() {
+		for _, forbidden := range []string{"DOCKER_HOST=", "DOCKER_CONTEXT=", "DOCKER_TLS_VERIFY="} {
+			if strings.HasPrefix(entry, forbidden) {
+				t.Fatalf("bounded Docker environment retained %q", entry)
+			}
+		}
+	}
+}
+
+func TestVerifyLocalDockerEndpointRejectsRemoteContext(t *testing.T) {
+	t.Parallel()
+	authority := checkedAuthority{root: ".", contract: Contract{Limits: Limits{CapturedOutputBytes: 64 * 1024}}}
+	for name, endpoint := range map[string]string{
+		"unix":   "unix:///var/run/docker.sock",
+		"npipe":  "npipe:////./pipe/docker_engine",
+		"remote": "tcp://remote.invalid:2376",
+	} {
+		name, endpoint := name, endpoint
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			body, _ := json.Marshal(endpoint)
+			executor := &recordingDockerExecutor{result: dockerResult{stdout: append(body, '\n')}}
+			err := verifyLocalDockerEndpoint(context.Background(), executor, authority)
+			if (name == "remote") != (err != nil) {
+				t.Fatalf("verifyLocalDockerEndpoint(%s) error = %v", endpoint, err)
+			}
+		})
+	}
+}
+
+func TestBoundedDockerDirectoryCapsEmptyEntriesAndDepth(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	boundary := boundedDockerDirectory{path: root, maximum: 1024, maximumEntries: 2, maximumDepth: 2, label: "test"}
+	if err := os.Mkdir(filepath.Join(root, "one"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(root, "two"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateBoundedDockerDirectory(boundary); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(root, "three"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateBoundedDockerDirectory(boundary); err == nil {
+		t.Fatal("directory entry overflow was accepted")
+	}
+	deepRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(deepRoot, "one", "two", "three"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	boundary.path = deepRoot
+	boundary.maximumEntries = 8
+	if err := validateBoundedDockerDirectory(boundary); err == nil {
+		t.Fatal("directory depth overflow was accepted")
+	}
+}
+
+func TestReproductionReceiptIsBoundedAtomicAndNoReplace(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	path, err := prepareReproductionReceiptPath(root, "build/evidence/pdf-tools.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt := ReproductionReceipt{
+		Schema: 1, Status: "local-construction-pass", Scope: "local-pdf-tools-final-image-reproduction",
+		Authority: "NO_RESULT", BaseBuilds: []ReproductionBuild{}, FinalBuilds: []ReproductionBuild{},
+		Notices: []NoticeObservation{}, ManPages: []string{},
+	}
+	if err := writeReproductionReceipt(path, receipt, 64*1024); err != nil {
+		t.Fatal(err)
+	}
+	body, err := os.ReadFile(path)
+	if err != nil || !strings.Contains(string(body), `"authority": "NO_RESULT"`) {
+		t.Fatalf("receipt = %q, error = %v", body, err)
+	}
+	if err := writeReproductionReceipt(path, receipt, 64*1024); err == nil {
+		t.Fatal("receipt replacement was accepted")
+	}
+	after, err := os.ReadFile(path)
+	if err != nil || string(after) != string(body) {
+		t.Fatal("existing receipt changed after replacement attempt")
+	}
+	bounded := filepath.Join(filepath.Dir(path), "too-small.json")
+	if err := writeReproductionReceipt(bounded, receipt, 1); err == nil {
+		t.Fatal("oversized receipt was accepted")
+	}
+	if _, err := os.Lstat(bounded); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("oversized receipt left destination: %v", err)
+	}
+	temporary, err := filepath.Glob(filepath.Join(filepath.Dir(path), ".20w-pdf-tools-receipt-*.tmp"))
+	if err != nil || len(temporary) != 0 {
+		t.Fatalf("temporary receipt links = %v, error = %v", temporary, err)
+	}
+}
+
+func TestPrepareReproductionReceiptPathRejectsEscapeAndExisting(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	for _, path := range []string{"../escape.json", "receipt.json", "build/evidence/not-json"} {
+		if _, err := prepareReproductionReceiptPath(root, path); err == nil {
+			t.Fatalf("prepareReproductionReceiptPath() accepted %q", path)
+		}
+	}
+	path, err := prepareReproductionReceiptPath(root, ".workingdir2/evidence/publication/existing.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("existing"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := prepareReproductionReceiptPath(root, ".workingdir2/evidence/publication/existing.json"); err == nil {
+		t.Fatal("prepareReproductionReceiptPath() accepted an existing receipt")
+	}
+}
+
+func TestDockerRequestTimeoutIsPositive(t *testing.T) {
+	t.Parallel()
+	request := dockerRequest{operation: "test", timeout: time.Second, output: 1, arguments: []string{"version"}}
+	if request.timeout <= 0 {
+		t.Fatal("test fixture has no timeout")
+	}
+}
+
+func assertArgumentsContain(t *testing.T, arguments []string, wanted ...string) {
+	t.Helper()
+	joined := "\x00" + strings.Join(arguments, "\x00") + "\x00"
+	for _, value := range wanted {
+		if !strings.Contains(joined, "\x00"+value+"\x00") {
+			t.Fatalf("arguments omit %q: %q", value, arguments)
+		}
+	}
+}

--- a/tooling/internal/pdftools/runtime.go
+++ b/tooling/internal/pdftools/runtime.go
@@ -1,0 +1,507 @@
+package pdftools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// RuntimeObservation is the bounded local execution evidence for the exact
+// final image that was compared.
+type RuntimeObservation struct {
+	ImageManifestDigest string                   `json:"image_manifest_digest"`
+	ConfiguredUID       int                      `json:"configured_uid"`
+	ConfiguredGID       int                      `json:"configured_gid"`
+	IdentityBasis       string                   `json:"identity_basis"`
+	ContentRetention    string                   `json:"content_retention"`
+	Tools               []RuntimeToolObservation `json:"tools"`
+	Containment         RuntimeContainment       `json:"containment"`
+}
+
+// RuntimeToolObservation records one version probe and its required stream.
+type RuntimeToolObservation struct {
+	Name          string `json:"name"`
+	Version       string `json:"version"`
+	VersionStream string `json:"version_stream"`
+}
+
+// RuntimeContainment records the Docker configuration inspected before the
+// same argument set is used for the Poppler probes.
+type RuntimeContainment struct {
+	Network         string `json:"network"`
+	ReadOnlyRoot    bool   `json:"read_only_root"`
+	Capabilities    string `json:"capabilities"`
+	NoNewPrivileges bool   `json:"no_new_privileges"`
+	MemoryBytes     int64  `json:"memory_bytes"`
+	PIDs            int    `json:"pids"`
+	TemporaryBytes  int64  `json:"temporary_bytes"`
+}
+
+type dockerImageInspection struct {
+	ID           string   `json:"Id"`
+	RepoTags     []string `json:"RepoTags"`
+	Architecture string   `json:"Architecture"`
+	OS           string   `json:"Os"`
+	Config       struct {
+		User   string            `json:"User"`
+		Env    []string          `json:"Env"`
+		Labels map[string]string `json:"Labels"`
+	} `json:"Config"`
+	RootFS struct {
+		Type   string   `json:"Type"`
+		Layers []string `json:"Layers"`
+	} `json:"RootFS"`
+	Descriptor struct {
+		Digest string `json:"digest"`
+	} `json:"Descriptor"`
+}
+
+type dockerContainerInspection struct {
+	Image    string `json:"Image"`
+	Platform string `json:"Platform"`
+	Host     struct {
+		NetworkMode  string            `json:"NetworkMode"`
+		CapAdd       []string          `json:"CapAdd"`
+		CapDrop      []string          `json:"CapDrop"`
+		Privileged   bool              `json:"Privileged"`
+		ReadonlyRoot bool              `json:"ReadonlyRootfs"`
+		SecurityOpt  []string          `json:"SecurityOpt"`
+		Memory       int64             `json:"Memory"`
+		MemorySwap   int64             `json:"MemorySwap"`
+		PIDsLimit    int               `json:"PidsLimit"`
+		Tmpfs        map[string]string `json:"Tmpfs"`
+	} `json:"HostConfig"`
+	Config struct {
+		User       string            `json:"User"`
+		Image      string            `json:"Image"`
+		Entrypoint []string          `json:"Entrypoint"`
+		Env        []string          `json:"Env"`
+		Labels     map[string]string `json:"Labels"`
+	} `json:"Config"`
+	NetworkSettings struct {
+		Networks map[string]json.RawMessage `json:"Networks"`
+	} `json:"NetworkSettings"`
+}
+
+func inspectFinalRuntime(
+	ctx context.Context,
+	executor dockerExecutor,
+	authority checkedAuthority,
+	build finalBuild,
+) (_ RuntimeObservation, returnError error) {
+	preexistingReference, preexisting, err := localFinalImageReference(ctx, executor, authority, build.Image.Identity)
+	if err != nil {
+		return RuntimeObservation{}, err
+	}
+	if preexisting {
+		if err := validateLoadedFinalImage(ctx, executor, authority, build.Image, preexistingReference); err != nil {
+			return RuntimeObservation{}, err
+		}
+	}
+	aliasName, err := reproductionName("runtime-image")
+	if err != nil {
+		return RuntimeObservation{}, err
+	}
+	alias := "20w-local/" + aliasName + ":reproduction"
+	if err := requireRuntimeAliasAvailable(executor, authority, alias); err != nil {
+		return RuntimeObservation{}, err
+	}
+	defer func() {
+		returnError = errors.Join(returnError, removeRuntimeAliasIfPresent(executor, authority, alias))
+	}()
+	if _, err := executor.run(ctx, dockerRequest{
+		operation: "load compared untagged PDF-tools final image locally",
+		directory: authority.root,
+		timeout:   2 * time.Minute,
+		output:    authority.contract.Limits.CapturedOutputBytes,
+		arguments: []string{"image", "load", "--input", build.Archive},
+	}); err != nil {
+		return RuntimeObservation{}, err
+	}
+	reference, present, err := localFinalImageReference(ctx, executor, authority, build.Image.Identity)
+	if err != nil || !present {
+		return RuntimeObservation{}, errors.Join(err, errors.New("Docker did not retain the loaded PDF-tools image identity"))
+	}
+	if _, err := executor.run(ctx, dockerRequest{
+		operation: "create owned PDF-tools runtime alias",
+		directory: authority.root,
+		timeout:   30 * time.Second,
+		output:    authority.contract.Limits.CapturedOutputBytes,
+		arguments: []string{"image", "tag", reference, alias},
+	}); err != nil {
+		return RuntimeObservation{}, err
+	}
+	if err := validateLoadedFinalImage(ctx, executor, authority, build.Image, alias); err != nil {
+		return RuntimeObservation{}, err
+	}
+	containment, uid, gid, err := inspectRuntimeContainment(ctx, executor, authority, build.Image, alias)
+	if err != nil {
+		return RuntimeObservation{}, err
+	}
+	tools := make([]RuntimeToolObservation, 0, len(authority.contract.Runtime.RequiredTools))
+	for _, tool := range authority.contract.Runtime.RequiredTools {
+		if err := runVersionProbe(ctx, executor, authority, alias, tool); err != nil {
+			return RuntimeObservation{}, err
+		}
+		tools = append(tools, RuntimeToolObservation{
+			Name: tool.Name, Version: tool.Version, VersionStream: tool.VersionStream,
+		})
+	}
+	return RuntimeObservation{
+		ImageManifestDigest: build.Image.Identity.ManifestDigest,
+		ConfiguredUID:       uid,
+		ConfiguredGID:       gid,
+		IdentityBasis:       "exact-image-and-container-config-user-with-direct-entrypoints",
+		ContentRetention:    "temporary-alias-removed; untagged-content-remains-docker-managed",
+		Tools:               tools,
+		Containment:         containment,
+	}, nil
+}
+
+func localFinalImageReference(
+	ctx context.Context,
+	executor dockerExecutor,
+	authority checkedAuthority,
+	identity imageIdentity,
+) (string, bool, error) {
+	result, err := executor.run(ctx, dockerRequest{
+		operation: "inventory local Docker image identities",
+		directory: authority.root,
+		timeout:   30 * time.Second,
+		output:    authority.contract.Limits.CapturedOutputBytes,
+		arguments: []string{"image", "ls", "--all", "--no-trunc", "--quiet"},
+	})
+	if err != nil {
+		return "", false, err
+	}
+	if len(result.stderr) != 0 {
+		return "", false, errors.New("local Docker image inventory wrote unexpected stderr")
+	}
+	seen := make(map[string]struct{})
+	for _, line := range strings.Split(strings.TrimSpace(string(result.stdout)), "\n") {
+		if line == "" {
+			continue
+		}
+		if !digestPattern.MatchString(line) || len(seen) >= 4096 {
+			return "", false, errors.New("local Docker image inventory is ambiguous or exceeds its count boundary")
+		}
+		seen[line] = struct{}{}
+	}
+	_, manifestPresent := seen[identity.ManifestDigest]
+	_, configPresent := seen[identity.ConfigDigest]
+	if manifestPresent && configPresent && identity.ManifestDigest != identity.ConfigDigest {
+		return "", false, errors.New("local Docker image inventory exposes both manifest and config identities ambiguously")
+	}
+	if manifestPresent {
+		return identity.ManifestDigest, true, nil
+	}
+	if configPresent {
+		return identity.ConfigDigest, true, nil
+	}
+	return "", false, nil
+}
+
+func validateLoadedFinalImage(
+	ctx context.Context,
+	executor dockerExecutor,
+	authority checkedAuthority,
+	image inspectedFinalImage,
+	tag string,
+) error {
+	result, err := executor.run(ctx, dockerRequest{
+		operation: "inspect loaded PDF-tools final image",
+		directory: authority.root,
+		timeout:   30 * time.Second,
+		output:    authority.contract.Limits.CapturedOutputBytes,
+		arguments: []string{"image", "inspect", "--format", "{{json .}}", tag},
+	})
+	if err != nil {
+		return err
+	}
+	body := result.stdout
+	inspection, err := decodeDockerJSON[dockerImageInspection](body, "loaded PDF-tools image")
+	if err != nil {
+		return err
+	}
+	identityMatches := inspection.ID == image.Identity.ManifestDigest || inspection.ID == image.Identity.ConfigDigest
+	if inspection.Descriptor.Digest != "" {
+		identityMatches = identityMatches && inspection.Descriptor.Digest == image.Identity.ManifestDigest
+	}
+	if !identityMatches || strings.HasPrefix(tag, "20w-local/") && !slices.Contains(inspection.RepoTags, tag) ||
+		inspection.Architecture != "amd64" ||
+		inspection.OS != "linux" || inspection.Config.User != "65532" || inspection.RootFS.Type != "layers" ||
+		!slices.Equal(inspection.RootFS.Layers, image.Identity.LayerDiffIDs) ||
+		!slices.Equal(inspection.Config.Env, image.Config.Config.Env) ||
+		!equalStringMap(inspection.Config.Labels, image.Config.Config.Labels) {
+		return errors.New("loaded PDF-tools image differs from the inspected final archive")
+	}
+	return nil
+}
+
+func inspectRuntimeContainment(
+	ctx context.Context,
+	executor dockerExecutor,
+	authority checkedAuthority,
+	image inspectedFinalImage,
+	reference string,
+) (_ RuntimeContainment, uid, gid int, returnError error) {
+	name, err := reproductionName("runtime-inspect")
+	if err != nil {
+		return RuntimeContainment{}, 0, 0, err
+	}
+	if err := requireOwnedContainerNameAvailable(executor, authority, name); err != nil {
+		return RuntimeContainment{}, 0, 0, err
+	}
+	defer func() {
+		returnError = errors.Join(returnError, removeRuntimeContainer(executor, authority, name))
+	}()
+	arguments := append([]string{"container", "create", "--pull", "never", "--name", name}, runtimeContainmentArguments(authority.contract)...)
+	arguments = append(arguments, "--entrypoint", "/usr/bin/pdfinfo", reference, "-v")
+	if _, err := executor.run(ctx, dockerRequest{
+		operation: "create contained PDF-tools inspection container",
+		directory: authority.root,
+		timeout:   time.Duration(authority.contract.Limits.RuntimeSeconds) * time.Second,
+		output:    authority.contract.Limits.CapturedOutputBytes,
+		arguments: arguments,
+	}); err != nil {
+		return RuntimeContainment{}, 0, 0, err
+	}
+	result, err := executor.run(ctx, dockerRequest{
+		operation: "inspect contained PDF-tools runtime",
+		directory: authority.root,
+		timeout:   time.Duration(authority.contract.Limits.RuntimeSeconds) * time.Second,
+		output:    authority.contract.Limits.CapturedOutputBytes,
+		arguments: []string{"container", "inspect", "--format", "{{json .}}", name},
+	})
+	if err != nil {
+		return RuntimeContainment{}, 0, 0, err
+	}
+	inspection, err := decodeDockerJSON[dockerContainerInspection](result.stdout, "PDF-tools containment")
+	if err != nil {
+		return RuntimeContainment{}, 0, 0, err
+	}
+	contract := authority.contract
+	expectedUser := strconv.Itoa(contract.Runtime.UID) + ":" + strconv.Itoa(contract.Runtime.GID)
+	if inspection.Platform != "linux" ||
+		(inspection.Image != image.Identity.ManifestDigest && inspection.Image != image.Identity.ConfigDigest) ||
+		inspection.Host.NetworkMode != contract.Runtime.Network || inspection.Host.Privileged ||
+		!inspection.Host.ReadonlyRoot || len(inspection.Host.CapAdd) != 0 ||
+		!slices.Equal(inspection.Host.CapDrop, []string{"ALL"}) ||
+		!slices.Equal(inspection.Host.SecurityOpt, []string{"no-new-privileges"}) ||
+		inspection.Host.Memory != contract.Limits.RuntimeMemoryBytes ||
+		inspection.Host.MemorySwap != contract.Limits.RuntimeMemoryBytes ||
+		inspection.Host.PIDsLimit != contract.Limits.RuntimePIDs || inspection.Config.User != expectedUser ||
+		inspection.Config.Image != reference || !slices.Equal(inspection.Config.Entrypoint, []string{"/usr/bin/pdfinfo"}) ||
+		!slices.Equal(inspection.Config.Env, image.Config.Config.Env) ||
+		!equalStringMap(inspection.Config.Labels, image.Config.Config.Labels) ||
+		!equalStringMap(inspection.Host.Tmpfs, map[string]string{
+			"/tmp": strings.TrimPrefix(dockerTmpfsValue("/tmp", contract.Limits.RuntimeTemporaryBytes), "/tmp:"),
+		}) || len(inspection.NetworkSettings.Networks) != 1 {
+		return RuntimeContainment{}, 0, 0, errors.New("Docker did not retain the exact PDF-tools runtime containment")
+	}
+	if _, exists := inspection.NetworkSettings.Networks[contract.Runtime.Network]; !exists {
+		return RuntimeContainment{}, 0, 0, errors.New("Docker did not attach only the disabled PDF-tools network")
+	}
+	return RuntimeContainment{
+		Network: contract.Runtime.Network, ReadOnlyRoot: true, Capabilities: contract.Runtime.Capabilities,
+		NoNewPrivileges: true, MemoryBytes: contract.Limits.RuntimeMemoryBytes,
+		PIDs: contract.Limits.RuntimePIDs, TemporaryBytes: contract.Limits.RuntimeTemporaryBytes,
+	}, contract.Runtime.UID, contract.Runtime.GID, nil
+}
+
+func runVersionProbe(
+	ctx context.Context,
+	executor dockerExecutor,
+	authority checkedAuthority,
+	tag string,
+	tool Tool,
+) (returnError error) {
+	name, err := reproductionName("runtime-" + tool.Name)
+	if err != nil {
+		return err
+	}
+	if err := requireOwnedContainerNameAvailable(executor, authority, name); err != nil {
+		return err
+	}
+	arguments := append([]string{"run", "--rm", "--pull", "never", "--name", name}, runtimeContainmentArguments(authority.contract)...)
+	arguments = append(arguments, "--entrypoint", "/usr/bin/"+tool.Name, tag, "-v")
+	defer func() {
+		returnError = errors.Join(returnError, removeRuntimeContainer(executor, authority, name))
+	}()
+	result, err := executor.run(ctx, dockerRequest{
+		operation: "run contained " + tool.Name + " version probe",
+		directory: authority.root,
+		timeout:   time.Duration(authority.contract.Limits.RuntimeSeconds) * time.Second,
+		output:    authority.contract.Limits.CapturedOutputBytes,
+		arguments: arguments,
+	})
+	if err != nil {
+		return err
+	}
+	if tool.VersionStream != "stderr" || len(result.stdout) != 0 {
+		return fmt.Errorf("%s wrote its version to an unexpected stream", tool.Name)
+	}
+	lines := strings.Split(strings.TrimSuffix(string(result.stderr), "\n"), "\n")
+	if len(lines) < 1 || lines[0] != tool.Name+" version "+tool.Version {
+		return fmt.Errorf("%s did not report exact version %s", tool.Name, tool.Version)
+	}
+	return nil
+}
+
+func runtimeContainmentArguments(contract Contract) []string {
+	return []string{
+		"--platform", contract.Platform,
+		"--network", contract.Runtime.Network,
+		"--read-only",
+		"--cap-drop", "ALL",
+		"--security-opt", "no-new-privileges",
+		"--memory", decimalInt64(contract.Limits.RuntimeMemoryBytes),
+		"--memory-swap", decimalInt64(contract.Limits.RuntimeMemoryBytes),
+		"--pids-limit", strconv.Itoa(contract.Limits.RuntimePIDs),
+		"--tmpfs", dockerTmpfsValue("/tmp", contract.Limits.RuntimeTemporaryBytes),
+		"--user", strconv.Itoa(contract.Runtime.UID) + ":" + strconv.Itoa(contract.Runtime.GID),
+	}
+}
+
+func decodeDockerJSON[T any](body []byte, label string) (T, error) {
+	var value T
+	if _, err := decodeArtifactJSON[map[string]json.RawMessage](body, 32, label); err != nil {
+		return value, err
+	}
+	if err := json.Unmarshal(body, &value); err != nil {
+		return value, fmt.Errorf("decode %s: %w", label, err)
+	}
+	return value, nil
+}
+
+func removeRuntimeContainer(executor dockerExecutor, authority checkedAuthority, name string) error {
+	present, err := runtimeContainerPresent(executor, authority, name)
+	if err != nil || !present {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	_, removeError := executor.run(ctx, dockerRequest{
+		operation: "remove PDF-tools runtime inspection container",
+		timeout:   30 * time.Second,
+		output:    authority.contract.Limits.CapturedOutputBytes,
+		arguments: []string{"container", "rm", "--force", name},
+	})
+	present, inspectionError := runtimeContainerPresent(executor, authority, name)
+	if inspectionError != nil {
+		return errors.Join(removeError, inspectionError)
+	}
+	if present {
+		return errors.Join(removeError, errors.New("owned PDF-tools container remains after cleanup"))
+	}
+	return nil
+}
+
+func requireOwnedContainerNameAvailable(executor dockerExecutor, authority checkedAuthority, name string) error {
+	present, err := runtimeContainerPresent(executor, authority, name)
+	if err != nil {
+		return err
+	}
+	if present {
+		return errors.New("generated PDF-tools container name is already in use")
+	}
+	return nil
+}
+
+func runtimeContainerPresent(executor dockerExecutor, authority checkedAuthority, name string) (bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	result, err := executor.run(ctx, dockerRequest{
+		operation: "inventory local Docker containers",
+		directory: authority.root,
+		timeout:   30 * time.Second,
+		output:    authority.contract.Limits.CapturedOutputBytes,
+		arguments: []string{"container", "ls", "--all", "--format", "{{.Names}}"},
+	})
+	if err != nil {
+		return false, err
+	}
+	if len(result.stderr) != 0 {
+		return false, errors.New("local Docker container inventory wrote unexpected stderr")
+	}
+	lines := strings.Split(strings.TrimSpace(string(result.stdout)), "\n")
+	if len(lines) > 4096 {
+		return false, errors.New("local Docker container inventory exceeds its count boundary")
+	}
+	for _, line := range lines {
+		if line == name {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func removeRuntimeImage(executor dockerExecutor, authority checkedAuthority, reference, operation string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	_, err := executor.run(ctx, dockerRequest{
+		operation: operation,
+		timeout:   30 * time.Second,
+		output:    authority.contract.Limits.CapturedOutputBytes,
+		arguments: []string{"image", "rm", reference},
+	})
+	return err
+}
+
+func removeRuntimeAliasIfPresent(executor dockerExecutor, authority checkedAuthority, alias string) error {
+	_, present, err := runtimeAliasIdentity(executor, authority, alias)
+	if err != nil || !present {
+		return err
+	}
+	removeError := removeRuntimeImage(executor, authority, alias, "remove owned PDF-tools runtime alias")
+	_, present, inspectionError := runtimeAliasIdentity(executor, authority, alias)
+	if removeError != nil || inspectionError != nil {
+		return errors.Join(removeError, inspectionError)
+	}
+	if present {
+		return errors.New("owned PDF-tools runtime alias remains after cleanup")
+	}
+	return nil
+}
+
+func requireRuntimeAliasAvailable(executor dockerExecutor, authority checkedAuthority, alias string) error {
+	_, present, err := runtimeAliasIdentity(executor, authority, alias)
+	if err != nil {
+		return err
+	}
+	if present {
+		return errors.New("generated PDF-tools runtime alias is already in use")
+	}
+	return nil
+}
+
+func runtimeAliasIdentity(
+	executor dockerExecutor,
+	authority checkedAuthority,
+	alias string,
+) (string, bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	result, err := executor.run(ctx, dockerRequest{
+		operation: "inspect owned PDF-tools runtime alias",
+		timeout:   30 * time.Second,
+		output:    authority.contract.Limits.CapturedOutputBytes,
+		arguments: []string{"image", "ls", "--all", "--no-trunc", "--quiet", "--filter", "reference=" + alias},
+	})
+	if err != nil {
+		return "", false, err
+	}
+	identity := strings.TrimSpace(string(result.stdout))
+	if identity == "" {
+		return "", false, nil
+	}
+	if strings.Contains(identity, "\n") || !digestPattern.MatchString(identity) {
+		return "", false, errors.New("owned PDF-tools runtime alias resolves ambiguously")
+	}
+	return identity, true, nil
+}

--- a/tooling/internal/pdftools/spdx.go
+++ b/tooling/internal/pdftools/spdx.go
@@ -1,0 +1,228 @@
+package pdftools
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/lusoris/20-watts-was-enough/tooling/internal/strictjson"
+)
+
+var spdxTopLevelKeys = []string{
+	"SPDXID",
+	"creationInfo",
+	"dataLicense",
+	"documentDescribes",
+	"documentNamespace",
+	"name",
+	"packages",
+	"relationships",
+	"spdxVersion",
+}
+
+var admittedSPDXRelationshipTypes = map[string]struct{}{
+	"CONTAINS":       {},
+	"DESCRIBED_BY":   {},
+	"GENERATED_FROM": {},
+	"VARIANT_OF":     {},
+}
+
+type spdxIdentity struct {
+	RawSHA256       string
+	RawSize         int64
+	CanonicalSHA256 string
+	CanonicalSize   int64
+	Packages        int
+	Relationships   int
+	canonical       []byte
+}
+
+func canonicalizeSPDX(body []byte, maximumBytes int64, maximumPackages, maximumRelationships int) (spdxIdentity, error) {
+	if len(body) == 0 || int64(len(body)) > maximumBytes || maximumPackages <= 0 || maximumRelationships <= 0 {
+		return spdxIdentity{}, errors.New("SPDX document exceeds its input boundary")
+	}
+	if err := strictjson.Validate(body, 32); err != nil {
+		return spdxIdentity{}, fmt.Errorf("validate unambiguous SPDX JSON: %w", err)
+	}
+	document, err := decodeSPDXDocument(body)
+	if err != nil {
+		return spdxIdentity{}, err
+	}
+	packages, relationships, err := validateSPDXGraph(document, maximumPackages, maximumRelationships)
+	if err != nil {
+		return spdxIdentity{}, err
+	}
+	sort.Slice(relationships, func(left, right int) bool {
+		return bytes.Compare(relationships[left].canonical, relationships[right].canonical) < 0
+	})
+	ordered := make([]any, len(relationships))
+	for index, relationship := range relationships {
+		ordered[index] = relationship.value
+	}
+	document["relationships"] = ordered
+	canonical, err := json.MarshalIndent(document, "", "  ")
+	if err != nil {
+		return spdxIdentity{}, fmt.Errorf("encode canonical SPDX graph: %w", err)
+	}
+	canonical = append(canonical, '\n')
+	if int64(len(canonical)) > maximumBytes {
+		return spdxIdentity{}, errors.New("canonical SPDX document exceeds its byte boundary")
+	}
+	return spdxIdentity{
+		RawSHA256:       digestRaw(body),
+		RawSize:         int64(len(body)),
+		CanonicalSHA256: digestRaw(canonical),
+		CanonicalSize:   int64(len(canonical)),
+		Packages:        packages,
+		Relationships:   len(relationships),
+		canonical:       canonical,
+	}, nil
+}
+
+func decodeSPDXDocument(body []byte) (map[string]any, error) {
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.UseNumber()
+	var document map[string]any
+	if err := decoder.Decode(&document); err != nil {
+		return nil, fmt.Errorf("decode SPDX document: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return nil, errors.New("SPDX document contains trailing data")
+	}
+	keys := make([]string, 0, len(document))
+	for key := range document {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	if !slices.Equal(keys, spdxTopLevelKeys) {
+		return nil, errors.New("SPDX document top-level fields differ from the admitted apko profile")
+	}
+	if document["spdxVersion"] != "SPDX-2.3" || document["dataLicense"] != "CC0-1.0" ||
+		document["SPDXID"] != "SPDXRef-DOCUMENT" {
+		return nil, errors.New("SPDX version, data licence, or document identity is invalid")
+	}
+	for _, key := range []string{"name", "documentNamespace"} {
+		value, ok := document[key].(string)
+		if !ok || value == "" || len(value) > 2_048 || strings.ContainsAny(value, "\r\n\x00") {
+			return nil, fmt.Errorf("SPDX %s is invalid", key)
+		}
+	}
+	return document, nil
+}
+
+type canonicalRelationship struct {
+	value     map[string]any
+	canonical []byte
+}
+
+func validateSPDXGraph(document map[string]any, maximumPackages, maximumRelationships int) (int, []canonicalRelationship, error) {
+	packages, ok := document["packages"].([]any)
+	if !ok || len(packages) == 0 || len(packages) > maximumPackages {
+		return 0, nil, errors.New("SPDX package inventory is outside its count boundary")
+	}
+	identities, err := spdxPackageIdentities(packages)
+	if err != nil {
+		return 0, nil, err
+	}
+	if err := validateDocumentDescribes(document["documentDescribes"], identities); err != nil {
+		return 0, nil, err
+	}
+	values, ok := document["relationships"].([]any)
+	if !ok || len(values) == 0 || len(values) > maximumRelationships {
+		return 0, nil, errors.New("SPDX relationship graph is outside its count boundary")
+	}
+	relationships := make([]canonicalRelationship, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		relationship, err := validateSPDXRelationship(value, identities)
+		if err != nil {
+			return 0, nil, err
+		}
+		key := string(relationship.canonical)
+		if _, duplicate := seen[key]; duplicate {
+			return 0, nil, errors.New("SPDX relationship graph repeats an edge")
+		}
+		seen[key] = struct{}{}
+		relationships = append(relationships, relationship)
+	}
+	return len(packages), relationships, nil
+}
+
+func spdxPackageIdentities(packages []any) (map[string]struct{}, error) {
+	identities := make(map[string]struct{}, len(packages))
+	for _, value := range packages {
+		pkg, ok := value.(map[string]any)
+		if !ok {
+			return nil, errors.New("SPDX package entry is not an object")
+		}
+		identity, ok := pkg["SPDXID"].(string)
+		if !ok || !validSPDXElementID(identity) {
+			return nil, errors.New("SPDX package identity is invalid")
+		}
+		if _, duplicate := identities[identity]; duplicate {
+			return nil, fmt.Errorf("SPDX package identity %q is repeated", identity)
+		}
+		identities[identity] = struct{}{}
+	}
+	return identities, nil
+}
+
+func validateDocumentDescribes(value any, identities map[string]struct{}) error {
+	described, ok := value.([]any)
+	if !ok || len(described) != 1 {
+		return errors.New("SPDX document must describe exactly one package identity")
+	}
+	identity, ok := described[0].(string)
+	if !ok {
+		return errors.New("SPDX described package identity is invalid")
+	}
+	if _, exists := identities[identity]; !exists {
+		return errors.New("SPDX document describes an absent package identity")
+	}
+	return nil
+}
+
+func validateSPDXRelationship(value any, identities map[string]struct{}) (canonicalRelationship, error) {
+	relationship, ok := value.(map[string]any)
+	if !ok || len(relationship) != 3 {
+		return canonicalRelationship{}, errors.New("SPDX relationship must contain exactly three fields")
+	}
+	for _, key := range []string{"spdxElementId", "relationshipType", "relatedSpdxElement"} {
+		field, ok := relationship[key].(string)
+		if !ok || field == "" || len(field) > 2_048 {
+			return canonicalRelationship{}, fmt.Errorf("SPDX relationship field %s is invalid", key)
+		}
+	}
+	typeName := relationship["relationshipType"].(string)
+	if _, admitted := admittedSPDXRelationshipTypes[typeName]; !admitted {
+		return canonicalRelationship{}, fmt.Errorf("SPDX relationship type %q is outside the admitted graph", typeName)
+	}
+	for _, key := range []string{"spdxElementId", "relatedSpdxElement"} {
+		identity := relationship[key].(string)
+		if _, exists := identities[identity]; !exists {
+			return canonicalRelationship{}, fmt.Errorf("SPDX relationship references absent package %q", identity)
+		}
+	}
+	canonical, err := json.Marshal(relationship)
+	if err != nil {
+		return canonicalRelationship{}, fmt.Errorf("encode canonical SPDX relationship: %w", err)
+	}
+	return canonicalRelationship{value: relationship, canonical: canonical}, nil
+}
+
+func validSPDXElementID(value string) bool {
+	return strings.HasPrefix(value, "SPDXRef-") && len(value) <= 2_048 &&
+		!strings.ContainsAny(value, " \t\r\n\x00")
+}
+
+func digestRaw(body []byte) string {
+	digest := sha256.Sum256(body)
+	return hex.EncodeToString(digest[:])
+}

--- a/tooling/internal/pdftools/spdx_test.go
+++ b/tooling/internal/pdftools/spdx_test.go
@@ -1,0 +1,100 @@
+package pdftools
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestCanonicalizeSPDXAdmitsOnlyRelationshipOrdering(t *testing.T) {
+	t.Parallel()
+	first := testSPDXDocument(t, false)
+	second := testSPDXDocument(t, true)
+	left, err := canonicalizeSPDX(first, 64*1024, 8, 8)
+	if err != nil {
+		t.Fatal(err)
+	}
+	right, err := canonicalizeSPDX(second, 64*1024, 8, 8)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if left.RawSHA256 == right.RawSHA256 || left.CanonicalSHA256 != right.CanonicalSHA256 ||
+		string(left.canonical) != string(right.canonical) || left.Packages != 3 || left.Relationships != 2 {
+		t.Fatalf("canonical identities = %#v / %#v", left, right)
+	}
+	base := BaseImage{
+		SPDXSize: len64(first), SPDXCanonicalSHA256: left.CanonicalSHA256,
+		SPDXCanonicalSize: left.CanonicalSize, SPDXPackages: left.Packages, SPDXRelationships: left.Relationships,
+	}
+	if err := validatePlatformSPDXIdentity(right, base); err != nil {
+		t.Fatalf("relationship permutation rejected: %v", err)
+	}
+	mutated := strings.Replace(string(first), `"relationshipType":"CONTAINS"`, `"relationshipType":"VARIANT_OF"`, 1)
+	changed, err := canonicalizeSPDX([]byte(mutated), 64*1024, 8, 8)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := validatePlatformSPDXIdentity(changed, base); err == nil {
+		t.Fatal("semantic relationship mutation retained the committed graph identity")
+	}
+}
+
+func TestCanonicalizeSPDXRejectsGraphAndJSONMutations(t *testing.T) {
+	t.Parallel()
+	valid := string(testSPDXDocument(t, false))
+	tests := map[string]string{
+		"duplicate edge":       strings.Replace(valid, `"relationships":[`, `"relationships":[{"relatedSpdxElement":"SPDXRef-A","relationshipType":"CONTAINS","spdxElementId":"SPDXRef-Root"},`, 1),
+		"dangling endpoint":    strings.Replace(valid, `"SPDXRef-A"`, `"SPDXRef-Missing"`, 1),
+		"unknown relationship": strings.Replace(valid, `"CONTAINS"`, `"COPY_OF"`, 1),
+		"unknown top level":    strings.Replace(valid, `{"SPDXID"`, `{"extra":true,"SPDXID"`, 1),
+		"duplicate JSON key":   strings.Replace(valid, `"spdxVersion":"SPDX-2.3"`, `"spdxVersion":"SPDX-2.3","spdxVersion":"SPDX-2.3"`, 1),
+	}
+	for name, body := range tests {
+		name, body := name, body
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := canonicalizeSPDX([]byte(body), 64*1024, 8, 8); err == nil {
+				t.Fatalf("canonicalizeSPDX() accepted %s", name)
+			}
+		})
+	}
+	if _, err := canonicalizeSPDX(testSPDXDocument(t, false), 32, 8, 8); err == nil {
+		t.Fatal("canonicalizeSPDX() accepted an oversized document")
+	}
+	if _, err := canonicalizeSPDX(testSPDXDocument(t, false), 64*1024, 2, 8); err == nil {
+		t.Fatal("canonicalizeSPDX() accepted too many packages")
+	}
+}
+
+func testSPDXDocument(t *testing.T, reverse bool) []byte {
+	t.Helper()
+	relationships := []map[string]any{
+		{"spdxElementId": "SPDXRef-Root", "relationshipType": "CONTAINS", "relatedSpdxElement": "SPDXRef-A"},
+		{"spdxElementId": "SPDXRef-Root", "relationshipType": "CONTAINS", "relatedSpdxElement": "SPDXRef-B"},
+	}
+	if reverse {
+		relationships[0], relationships[1] = relationships[1], relationships[0]
+	}
+	document := map[string]any{
+		"SPDXID":            "SPDXRef-DOCUMENT",
+		"creationInfo":      map[string]any{"created": "2026-08-03T11:48:16Z", "creators": []string{"Tool: test"}},
+		"dataLicense":       "CC0-1.0",
+		"documentDescribes": []string{"SPDXRef-Root"},
+		"documentNamespace": "https://example.invalid/spdx/test",
+		"name":              "test",
+		"packages": []map[string]any{
+			{"SPDXID": "SPDXRef-Root", "name": "root"},
+			{"SPDXID": "SPDXRef-A", "name": "a"},
+			{"SPDXID": "SPDXRef-B", "name": "b"},
+		},
+		"relationships": relationships,
+		"spdxVersion":   "SPDX-2.3",
+	}
+	body, err := json.Marshal(document)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return body
+}
+
+func len64(body []byte) int64 { return int64(len(body)) }

--- a/tooling/pdf-tools/README.md
+++ b/tooling/pdf-tools/README.md
@@ -1,21 +1,21 @@
 # Locked PDF-tools image authority
 
-This directory fixes the inputs for the planned Linux `amd64` PDF-tools
-image. It does not publish an image and it does not make a scientific,
-PDF/UA, WCAG, or legal-compliance claim.
+This directory fixes the inputs for the Linux `amd64` PDF-tools image and its
+local construction check. It does not publish an image and it does not make a
+scientific, PDF/UA, WCAG, or legal-compliance claim.
 
 ## Maintained inputs
 
 - `apko.yaml` selects Wolfi and the exact Poppler `26.08.0-r0` packages.
 - `apko.lock.json` closes the 45-package transitive graph for `x86_64`.
 - `contract.json` binds the apko builder digest, timestamp, base-image
-  observations, runtime checks, source inputs, notice destinations and
-  resource limits.
+  observations, canonical SPDX graph identities, runtime checks, source
+  inputs, notice destinations and resource limits.
 - `apk-retention.json` records the exact URL, size, SHA-256 digest and declared
   licence for every locked APK. Licence declarations are package metadata, not
   a project legal conclusion.
 - `notices/` contains byte-checked files from the official Poppler 26.08.0
-  archive. The planned final image layer places them beneath
+  archive. The final image layer places them beneath
   `/usr/share/licenses/poppler/`.
 - `upstream/wolfi-poppler.yaml` is the byte-checked Wolfi recipe snapshot named
   by the contract.
@@ -41,6 +41,44 @@ records, incomplete APK byte ranges and a missing notice or recipe snapshot.
 It also checks the pinned recipe licence and the existing BuildKit lock selected
 for deterministic final-layer assembly.
 
+## Local final-image reproduction
+
+The Go command can reproduce the complete image twice through the local Docker
+daemon:
+
+```bash
+go -C tooling run ./cmd/20w publication reproduce-pdf-tools-image \
+  --root .. \
+  --receipt .workingdir2/evidence/publication/pdf-tools-local-reproduction.json
+```
+
+The receipt path must be a new repository-relative JSON file in an admitted
+evidence directory. The command runs the exact apko image twice under bounded
+resources after a bounded probe verifies its declared version, revision and Go
+version. The receipt labels the apko network and containment as requested
+settings because the short-lived build containers are not treated as observed
+runtime state. The command admits only the committed base image and canonical SPDX graphs, and
+projects each Docker archive into a private OCI layout without a host image
+converter. It then uses two fresh instances of the locked BuildKit 0.32.2 image
+to build the notice layer. Each local daemon has no Docker network, fixed
+memory, PID and CPU limits, and one worker; each final build also uses no cache,
+no build network and no requested entitlement. The pinned Buildx
+Docker-container driver admits `network.host` at the daemon gate, but the
+network-disabled daemon namespace and unentitled build cannot exercise it. The
+driver necessarily runs these temporary BuildKit daemons as privileged
+containers. The check
+compares both complete final OCI archives, manifests, configs, layers and diff
+IDs before it inspects the notices, man pages, forbidden paths, Poppler
+versions, configured UID/GID and runtime containment.
+
+Success writes an atomic bounded receipt with `authority: NO_RESULT`. The
+command creates no source bundle, retained tag, push, release or
+digest-admission record; it removes the builders, containers, state volumes and
+temporary image alias that it owns. Docker may retain the untagged,
+content-addressed image data in its local content store; the command does not
+claim exclusive ownership of shared digest content or delete it underneath a
+concurrent local reproduction.
+
 ## Reproduction boundary
 
 The pinned apko image is the only admitted package assembler. Set
@@ -54,9 +92,10 @@ Runtime probes observed Poppler 26.08.0, UID/GID 65532 and no `/bin/sh` or
 `/sbin/apk` while using no network, a read-only root, dropped capabilities and
 `no-new-privileges`.
 
-Those observations cover the apko base only. The deterministic notice layer,
-two-build final-image comparison, publication, anonymous digest pull and CI
-consumer lock remain required before the image is admitted.
+The local command now checks the deterministic notice layer and two-build final
+image as construction evidence. Publication, the source-delivery bundle,
+anonymous digest pull, release acceptance and exact-digest CI consumer lock
+remain separate admission gates.
 
 ## Notice and source route
 

--- a/tooling/pdf-tools/contract.json
+++ b/tooling/pdf-tools/contract.json
@@ -33,8 +33,13 @@
     "config_digest": "sha256:ec7b184be25657686299b62442b0f62635b776daf903d2e88e87c884b6043d48",
     "layer_digest": "sha256:170d0daae786b83b82baeb6dd8ca39d718ca41cca4053d053dcf7345ed366136",
     "layer_diff_id": "sha256:1f7bcd328d0a22207c3b8d8197860057bc08aa0e6098b9e2c220b500cae9a196",
-    "spdx_sha256": "fe95a42355a16b8424790f3666bf49d500fc30dd4470697b147eabd8ef196ed6",
-    "spdx_size_bytes": 202202
+    "spdx_size_bytes": 202202,
+    "spdx_canonical_sha256": "0f82548428a88719967c426a0afaa9284c3c2b49add3832717c5cd94215887d9",
+    "spdx_canonical_size_bytes": 202202,
+    "spdx_packages": 209,
+    "spdx_relationships": 225,
+    "spdx_index_canonical_sha256": "e13aa9d0a909c7200618d07d890d7ed79ec73ab211f18f971a2dc91f583d7f18",
+    "spdx_index_canonical_size_bytes": 2949
   },
   "runtime": {
     "uid": 65532,
@@ -166,9 +171,29 @@
     "packages": 64,
     "notice_bytes": 131072,
     "base_archive_bytes": 67108864,
+    "final_archive_bytes": 67108864,
     "source_bundle_bytes": 67108864,
+    "spdx_bytes": 4194304,
+    "spdx_packages": 512,
+    "spdx_relationships": 1024,
+    "apk_control_bytes": 16777216,
+    "apk_data_bytes": 67108864,
+    "apk_index_bytes": 67108864,
+    "http_response_bytes": 67108864,
     "lock_seconds": 120,
     "build_seconds": 300,
-    "captured_output_bytes": 1048576
+    "runtime_seconds": 30,
+    "captured_output_bytes": 1048576,
+    "receipt_bytes": 1048576,
+    "apko_memory_bytes": 4294967296,
+    "apko_pids": 512,
+    "apko_temporary_bytes": 1073741824,
+    "buildkit_memory_bytes": 2147483648,
+    "buildkit_pids": 256,
+    "buildkit_cpu_period": 100000,
+    "buildkit_cpu_quota": 200000,
+    "runtime_memory_bytes": 536870912,
+    "runtime_pids": 64,
+    "runtime_temporary_bytes": 16777216
   }
 }


### PR DESCRIPTION
## Summary

- construct the locked PDF-tools final OCI image without relying on ambient package installation
- reproduce the apko and deterministic final layers byte-for-byte across independent BuildKit builds
- verify runtime identity, notices, source delivery, SPDX material, and bounded cleanup

## Verification

- exact apko and two final BuildKit outputs match byte-for-byte
- `npm run test:release`: 35/35
- `npm run validate:book-pdf`: 170 source files
- `go -C tooling test -race -count=1 ./internal/pdftools ./cmd/20w`
- `go -C tooling vet ./internal/pdftools ./cmd/20w`
- the semantic audit remains explicitly `known-debt`; no PDF accessibility pass or scientific result is claimed

Tracks #20.