### PR TITLE
feat(experiment): add segment-intersection specialist vertical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,12 @@ the exact diff; this file records why the project changed.
   A separate naive matcher validates held references without calling the KMP
   solver; source-bound requests retain no answer bytes, and all construction
   output remains `NO_RESULT`.
+- The segment-intersection construction vertical now reproduces the pinned
+  closed-segment operation and exact no-hint scalar-mask grammar in Go. A
+  separately held orientation verifier covers endpoint contact, collinear
+  overlap and degenerate point-segments without calling the specialist solver.
+  The sole task size remains a fixed four-endpoint geometry control, not a
+  length-extrapolation probe, and all construction output remains `NO_RESULT`.
 - A versioned PDF semantic sentinel now binds the current source, book, A4 and
   tag metadata, Poppler tool identity, separate structure and text streams,
   exact diagnostics, and six nonlinear content anchors. Atomic evidence keeps

--- a/tooling/internal/clrssegments/adapter.go
+++ b/tooling/internal/clrssegments/adapter.go
@@ -1,0 +1,339 @@
+package clrssegments
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/lusoris/20-watts-was-enough/tooling/internal/clrsfixture"
+	"github.com/lusoris/20-watts-was-enough/tooling/internal/specialistcontrol"
+)
+
+const (
+	maximumIdentityBytes            = 128
+	maximumReferencesCeiling        = 4_096
+	maximumReferenceSetBytesCeiling = 64 << 20
+	// Four fixture identities, one prompt digest and the effective-size integer.
+	heldIdentityBytes = 5*sha256.Size + 8
+)
+
+var ErrReferenceLimit = errors.New("segment-intersection reference limit exceeded")
+
+// Specialist is the exact pinned CLRS segment-intersection implementation. It
+// owns no reference data and sees only specialistcontrol.Invocation.
+type Specialist struct {
+	id     string
+	limits Limits
+}
+
+// NewSpecialist closes the candidate-visible solver identity and bounds.
+func NewSpecialist(id string, limits Limits) (Specialist, error) {
+	if !validIdentity(id) {
+		return Specialist{}, errors.New("segment-intersection specialist identity is invalid")
+	}
+	if err := limits.Validate(); err != nil {
+		return Specialist{}, err
+	}
+	return Specialist{id: id, limits: limits}, nil
+}
+
+// Invoke implements specialistcontrol.Specialist.
+func (specialist Specialist) Invoke(
+	ctx context.Context,
+	invocation specialistcontrol.Invocation,
+) (specialistcontrol.SpecialistResult, error) {
+	refused := specialistcontrol.SpecialistResult{
+		Binding: invocation.Binding, SpecialistID: specialist.id, State: specialistcontrol.ResultRefused,
+	}
+	if ctx == nil {
+		return refused, errors.New("invoke segment-intersection specialist: nil context")
+	}
+	if err := ctx.Err(); err != nil {
+		return refused, err
+	}
+	if invocation.Task != specialistcontrol.TaskSegmentsIntersect ||
+		invocation.Binding == (specialistcontrol.Binding{}) || invocation.MaxResultBytes <= 0 {
+		return refused, nil
+	}
+	answer, err := Solve(ctx, invocation.Payload, specialist.limits)
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return refused, err
+		}
+		if errors.Is(err, ErrInvalidLimits) || errors.Is(err, ErrMalformedPrompt) ||
+			errors.Is(err, ErrPromptLimit) || errors.Is(err, ErrAnswerLimit) {
+			return refused, nil
+		}
+		return refused, fmt.Errorf("solve segment-intersection invocation: %w", err)
+	}
+	if len(answer) > invocation.MaxResultBytes {
+		return refused, nil
+	}
+	return specialistcontrol.SpecialistResult{
+		Binding:      invocation.Binding,
+		SpecialistID: specialist.id,
+		State:        specialistcontrol.ResultCompleted,
+		Payload:      answer,
+	}, nil
+}
+
+// VerifierLimits bound the separately held reference index. They are safety
+// caps, not fixture counts or an experiment sampling decision.
+type VerifierLimits struct {
+	MaxReferences     int
+	MaxReferenceBytes int64
+}
+
+// Validate rejects an open or impractically large verifier index.
+func (limits VerifierLimits) Validate() error {
+	if limits.MaxReferences <= 0 || limits.MaxReferences > maximumReferencesCeiling ||
+		limits.MaxReferenceBytes <= 0 || limits.MaxReferenceBytes > maximumReferenceSetBytesCeiling {
+		return ErrReferenceLimit
+	}
+	return nil
+}
+
+type referenceKey struct {
+	runID     string
+	requestID string
+}
+
+type heldReference struct {
+	source             clrsfixture.SourceID
+	contract           clrsfixture.ContractID
+	candidateID        clrsfixture.CandidateID
+	verifierID         clrsfixture.VerifierID
+	promptSHA256       [sha256.Size]byte
+	effectiveInputSize int64
+	answer             []byte
+}
+
+type boundCandidate struct {
+	id     clrsfixture.CandidateID
+	prompt []byte
+}
+
+// RequestSet is the candidate-only projection of one validated
+// segment-intersection dataset run. It cannot be constructed from a raw prompt
+// or held answer.
+type RequestSet struct {
+	runID      string
+	candidates []boundCandidate
+}
+
+// Verifier independently exact-scores against separately held references.
+type Verifier struct {
+	specialistID string
+	limits       Limits
+	references   map[referenceKey]heldReference
+}
+
+// BindDataset validates the exact contract-selected segment-intersection
+// candidate and verifier sets, then returns separate candidate-only and held-
+// reference views. Every value remains NO_RESULT.
+func BindDataset(
+	runID string,
+	specialistID string,
+	source clrsfixture.SourceRecord,
+	contract clrsfixture.GenerationContract,
+	candidates clrsfixture.CandidateSet,
+	verifiers clrsfixture.VerifierSet,
+	limits Limits,
+	verifierLimits VerifierLimits,
+) (RequestSet, Verifier, error) {
+	if !validIdentity(runID) || !validIdentity(specialistID) {
+		return RequestSet{}, Verifier{}, errors.New("segment-intersection run or specialist identity is invalid")
+	}
+	if err := limits.Validate(); err != nil {
+		return RequestSet{}, Verifier{}, err
+	}
+	if err := verifierLimits.Validate(); err != nil {
+		return RequestSet{}, Verifier{}, err
+	}
+	if err := PinnedSourceEvidence().ValidateSource(source); err != nil {
+		return RequestSet{}, Verifier{}, err
+	}
+	task, err := segmentsTaskPlan(source, contract)
+	if err != nil {
+		return RequestSet{}, Verifier{}, err
+	}
+	pairs, err := clrsfixture.PairExamples(
+		source,
+		contract,
+		task.OutputRelativePath,
+		candidates,
+		verifiers,
+	)
+	if err != nil {
+		return RequestSet{}, Verifier{}, fmt.Errorf("pair segment-intersection dataset: %w", err)
+	}
+	if len(pairs) == 0 || len(pairs) > verifierLimits.MaxReferences {
+		return RequestSet{}, Verifier{}, fmt.Errorf("%w: reference count is %d", ErrReferenceLimit, len(pairs))
+	}
+
+	requestSet := RequestSet{runID: runID, candidates: make([]boundCandidate, 0, len(pairs))}
+	validated := make(map[referenceKey]heldReference, len(pairs))
+	var retainedBytes int64
+	for index, pair := range pairs {
+		candidate, held, bindErr := bindPair(pair, limits)
+		if bindErr != nil {
+			return RequestSet{}, Verifier{}, fmt.Errorf("bind segment-intersection pair %d: %w", index, bindErr)
+		}
+		requestID := candidate.id.String()
+		retainedBytes += int64(len(runID)+len(requestID)+len(held.answer)) + heldIdentityBytes
+		if retainedBytes > verifierLimits.MaxReferenceBytes {
+			return RequestSet{}, Verifier{}, fmt.Errorf("%w: retained bytes exceed %d", ErrReferenceLimit, verifierLimits.MaxReferenceBytes)
+		}
+		key := referenceKey{runID: runID, requestID: requestID}
+		if _, duplicate := validated[key]; duplicate {
+			return RequestSet{}, Verifier{}, fmt.Errorf("duplicate segment-intersection reference %s/%s", key.runID, key.requestID)
+		}
+		requestSet.candidates = append(requestSet.candidates, candidate)
+		validated[key] = held
+	}
+	return requestSet, Verifier{specialistID: specialistID, limits: limits, references: validated}, nil
+}
+
+// Requests returns fresh candidate-only controller packets for one closed run
+// window. RequestID is the source-and-contract-bound CandidateID.
+func (set RequestSet) Requests(issuedAt, deadline time.Time) ([]specialistcontrol.Request, error) {
+	if !validIdentity(set.runID) || len(set.candidates) == 0 {
+		return nil, errors.New("segment-intersection request set is unbound")
+	}
+	if issuedAt.IsZero() || deadline.IsZero() || !deadline.After(issuedAt) {
+		return nil, errors.New("segment-intersection request window is invalid")
+	}
+	requests := make([]specialistcontrol.Request, 0, len(set.candidates))
+	for _, candidate := range set.candidates {
+		requestID := candidate.id.String()
+		if !validIdentity(requestID) || len(candidate.prompt) == 0 {
+			return nil, errors.New("segment-intersection bound candidate is invalid")
+		}
+		requests = append(requests, specialistcontrol.Request{
+			RunID:     set.runID,
+			RequestID: requestID,
+			Task:      specialistcontrol.TaskSegmentsIntersect,
+			Payload:   append([]byte(nil), candidate.prompt...),
+			IssuedAt:  issuedAt,
+			Deadline:  deadline,
+		})
+	}
+	return requests, nil
+}
+
+// Verify implements specialistcontrol.ExactVerifier.
+func (verifier Verifier) Verify(
+	ctx context.Context,
+	invocation specialistcontrol.Invocation,
+	candidate specialistcontrol.Candidate,
+) (specialistcontrol.Verification, error) {
+	verification := specialistcontrol.Verification{
+		Binding: candidate.Binding, CandidateBinding: candidate.CandidateBinding,
+		Verdict: specialistcontrol.VerificationAbstain,
+	}
+	if ctx == nil {
+		return verification, errors.New("verify segment-intersection candidate: nil context")
+	}
+	if err := ctx.Err(); err != nil {
+		return verification, err
+	}
+	if invocation.Task != specialistcontrol.TaskSegmentsIntersect || invocation.Binding != candidate.Binding ||
+		candidate.Binding == (specialistcontrol.Binding{}) ||
+		candidate.CandidateBinding == (specialistcontrol.CandidateBinding{}) ||
+		candidate.SpecialistID != verifier.specialistID || candidate.State != specialistcontrol.ResultCompleted {
+		return verification, errors.New("verify segment-intersection candidate: invalid invocation binding")
+	}
+	held, present := verifier.references[referenceKey{runID: invocation.RunID, requestID: invocation.RequestID}]
+	if !present || held.candidateID.String() != invocation.RequestID ||
+		held.promptSHA256 != sha256.Sum256(invocation.Payload) {
+		return verification, errors.New("verify segment-intersection candidate: no exact prompt-bound reference")
+	}
+	if held.effectiveInputSize != coordinateCount {
+		return verification, errors.New("verify segment-intersection candidate: held fixed-endpoint size differs from four")
+	}
+	if _, err := parsePrompt(ctx, invocation.Payload, verifier.limits); err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return verification, err
+		}
+		return verification, errors.New("verify segment-intersection candidate: prompt semantics differ from the held candidate")
+	}
+	if len(candidate.Payload) == 0 || len(candidate.Payload) > verifier.limits.MaxAnswerBytes {
+		return verification, errors.New("verify segment-intersection candidate: answer crosses verifier bounds")
+	}
+	if bytes.Equal(candidate.Payload, held.answer) {
+		verification.Verdict = specialistcontrol.VerificationExact
+	} else {
+		verification.Verdict = specialistcontrol.VerificationMismatch
+	}
+	return verification, nil
+}
+
+func segmentsTaskPlan(
+	source clrsfixture.SourceRecord,
+	contract clrsfixture.GenerationContract,
+) (clrsfixture.TaskPlan, error) {
+	plan, err := contract.Plan(source)
+	if err != nil {
+		return clrsfixture.TaskPlan{}, fmt.Errorf("plan segment-intersection dataset: %w", err)
+	}
+	for _, task := range plan.Tasks {
+		if task.Task != clrsfixture.TaskSegmentsIntersect {
+			continue
+		}
+		if task.Family != clrsfixture.FamilyGeometry ||
+			task.LengthSemantics != clrsfixture.LengthFixedFourEndpoints ||
+			len(task.Sizes) != 1 || task.Sizes[0].Role != clrsfixture.SizeFixedGeometryControl ||
+			task.Sizes[0].RequestedLength != coordinateCount || task.ExpectedExamples <= 0 {
+			return clrsfixture.TaskPlan{}, errors.New("generation contract segment-intersection task is not the fixed-four-endpoint control")
+		}
+		return task, nil
+	}
+	return clrsfixture.TaskPlan{}, errors.New("generation contract has no segment-intersection task")
+}
+
+func bindPair(pair clrsfixture.PairedExample, limits Limits) (boundCandidate, heldReference, error) {
+	candidate := pair.Candidate
+	verifier := pair.Verifier
+	if candidate.Task != clrsfixture.TaskSegmentsIntersect ||
+		candidate.LengthSemantics != clrsfixture.LengthFixedFourEndpoints || candidate.UseHints ||
+		candidate.RequestedLength != coordinateCount || candidate.EffectiveInputSize != coordinateCount ||
+		verifier.CandidateID != candidate.ID {
+		return boundCandidate{}, heldReference{}, errors.New("pair differs from segment-intersection fixed-four-endpoint no-hint semantics")
+	}
+	prompt := []byte(candidate.Prompt)
+	input, err := parsePrompt(context.Background(), prompt, limits)
+	if err != nil {
+		return boundCandidate{}, heldReference{}, fmt.Errorf("validate candidate prompt: %w", err)
+	}
+	answer := []byte(verifier.Reference)
+	if err := validateReference(context.Background(), answer, limits, input); err != nil {
+		return boundCandidate{}, heldReference{}, err
+	}
+	return boundCandidate{id: candidate.ID, prompt: append([]byte(nil), prompt...)}, heldReference{
+		source:             candidate.Source,
+		contract:           candidate.Contract,
+		candidateID:        candidate.ID,
+		verifierID:         verifier.ID,
+		promptSHA256:       sha256.Sum256(prompt),
+		effectiveInputSize: candidate.EffectiveInputSize,
+		answer:             append([]byte(nil), answer...),
+	}, nil
+}
+
+func validIdentity(value string) bool {
+	if len(value) == 0 || len(value) > maximumIdentityBytes {
+		return false
+	}
+	for index := range len(value) {
+		character := value[index]
+		if (character < 'a' || character > 'z') && (character < 'A' || character > 'Z') &&
+			(character < '0' || character > '9') && character != '.' && character != '_' &&
+			character != ':' && character != '-' {
+			return false
+		}
+	}
+	return true
+}

--- a/tooling/internal/clrssegments/adapter_test.go
+++ b/tooling/internal/clrssegments/adapter_test.go
@@ -1,0 +1,912 @@
+package clrssegments
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lusoris/20-watts-was-enough/tooling/internal/clrsfixture"
+	"github.com/lusoris/20-watts-was-enough/tooling/internal/specialistcontrol"
+)
+
+const (
+	testRunID        = "run-001"
+	testSpecialistID = "exact-segment-intersection-v1"
+)
+
+var verticalNow = time.Date(2026, time.August, 31, 12, 0, 0, 0, time.UTC)
+
+type recorderFunc func(context.Context, specialistcontrol.Decision) error
+
+func (function recorderFunc) RecordDecision(ctx context.Context, decision specialistcontrol.Decision) error {
+	return function(ctx, decision)
+}
+
+type specialistFunc func(context.Context, specialistcontrol.Invocation) (specialistcontrol.SpecialistResult, error)
+
+func (function specialistFunc) Invoke(
+	ctx context.Context,
+	invocation specialistcontrol.Invocation,
+) (specialistcontrol.SpecialistResult, error) {
+	return function(ctx, invocation)
+}
+
+type verifierFunc func(
+	context.Context,
+	specialistcontrol.Invocation,
+	specialistcontrol.Candidate,
+) (specialistcontrol.Verification, error)
+
+func (function verifierFunc) Verify(
+	ctx context.Context,
+	invocation specialistcontrol.Invocation,
+	candidate specialistcontrol.Candidate,
+) (specialistcontrol.Verification, error) {
+	return function(ctx, invocation, candidate)
+}
+
+func TestBindDatasetBuildsFixedGeometryRequestsAndIsolatesReferences(t *testing.T) {
+	t.Parallel()
+	fixture := newImportFixture(t, clrsfixture.TaskSegmentsIntersect)
+	reorderedVerifiers := cloneVerifierSet(fixture.verifiers)
+	for left, right := 0, len(reorderedVerifiers.Examples)-1; left < right; left, right = left+1, right-1 {
+		reorderedVerifiers.Examples[left], reorderedVerifiers.Examples[right] =
+			reorderedVerifiers.Examples[right], reorderedVerifiers.Examples[left]
+	}
+	requestSet, verifier, err := BindDataset(
+		testRunID,
+		testSpecialistID,
+		fixture.source,
+		fixture.contract,
+		fixture.candidates,
+		reorderedVerifiers,
+		testLimits(),
+		testVerifierLimits(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fixture.task.Family != clrsfixture.FamilyGeometry ||
+		fixture.task.LengthSemantics != clrsfixture.LengthFixedFourEndpoints ||
+		len(fixture.task.Sizes) != 1 ||
+		fixture.task.Sizes[0].Role != clrsfixture.SizeFixedGeometryControl ||
+		fixture.task.Sizes[0].RequestedLength != coordinateCount {
+		t.Fatalf("task plan is not the fixed geometry control: %#v", fixture.task)
+	}
+	requests, err := requestSet.Requests(verticalNow.Add(-time.Second), verticalNow.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(requests) != fixture.task.ExpectedExamples || len(requests) != 3 {
+		t.Fatalf("request count = %d, want three fixed-geometry seed cells", len(requests))
+	}
+	for index, request := range requests {
+		candidate := fixture.candidates.Examples[index]
+		if request.RunID != testRunID || request.RequestID != candidate.ID.String() ||
+			request.Task != specialistcontrol.TaskSegmentsIntersect ||
+			!bytes.Equal(request.Payload, []byte(candidate.Prompt)) ||
+			candidate.RequestedLength != coordinateCount || candidate.EffectiveInputSize != coordinateCount {
+			t.Fatalf("request %d = %#v, candidate %#v", index, request, candidate)
+		}
+		key := referenceKey{runID: testRunID, requestID: request.RequestID}
+		held, present := verifier.references[key]
+		expectedVerifier := fixture.verifiers.Examples[index]
+		if !present || held.source != candidate.Source || held.contract != candidate.Contract ||
+			held.candidateID != candidate.ID || held.verifierID != expectedVerifier.ID ||
+			held.effectiveInputSize != coordinateCount ||
+			!bytes.Equal(held.answer, []byte(expectedVerifier.Reference)) {
+			t.Fatalf("held reference %d = %#v", index, held)
+		}
+	}
+	for _, candidateType := range []reflect.Type{
+		reflect.TypeOf(RequestSet{}),
+		reflect.TypeOf(boundCandidate{}),
+		reflect.TypeOf(specialistcontrol.Invocation{}),
+	} {
+		for index := 0; index < candidateType.NumField(); index++ {
+			name := strings.ToLower(candidateType.Field(index).Name)
+			if strings.Contains(name, "answer") || strings.Contains(name, "reference") {
+				t.Fatalf("candidate-visible type %s exposes verifier field %q", candidateType, name)
+			}
+		}
+	}
+}
+
+func TestSpecialistMatchesEveryContractBoundFixedGeometryCell(t *testing.T) {
+	t.Parallel()
+	fixture := newImportFixture(t, clrsfixture.TaskSegmentsIntersect)
+	requestSet, _ := bindFixture(t, fixture, testLimits(), testVerifierLimits())
+	requests, err := requestSet.Requests(verticalNow.Add(-time.Second), verticalNow.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	specialist, err := NewSpecialist(testSpecialistID, testLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for index, request := range requests {
+		invocation, _ := verificationInputs(request, nil)
+		result, invokeErr := specialist.Invoke(context.Background(), invocation)
+		want := []byte(fixture.verifiers.Examples[index].Reference)
+		if invokeErr != nil || result.State != specialistcontrol.ResultCompleted ||
+			result.SpecialistID != testSpecialistID || result.Binding != invocation.Binding ||
+			!bytes.Equal(result.Payload, want) {
+			t.Fatalf("cell %d result/error = %#v/%v, want %q", index, result, invokeErr, want)
+		}
+	}
+}
+
+func TestBindDatasetRejectsForeignAndTamperedAuthorityRecords(t *testing.T) {
+	t.Parallel()
+	segments := newImportFixture(t, clrsfixture.TaskSegmentsIntersect)
+	insertion := newImportFixture(t, clrsfixture.TaskInsertionSort)
+	if _, _, err := BindDataset(
+		testRunID, testSpecialistID, insertion.source, insertion.contract,
+		insertion.candidates, insertion.verifiers, testLimits(), testVerifierLimits(),
+	); err == nil {
+		t.Fatal("BindDataset accepted a valid foreign task set")
+	}
+
+	recordMutations := []struct {
+		name   string
+		mutate func(*clrsfixture.CandidateSet, *clrsfixture.VerifierSet)
+	}{
+		{"candidate identity", func(c *clrsfixture.CandidateSet, _ *clrsfixture.VerifierSet) { c.Examples[0].ID[0] ^= 1 }},
+		{"candidate prompt", func(c *clrsfixture.CandidateSet, _ *clrsfixture.VerifierSet) { c.Examples[0].Prompt += " mutation" }},
+		{"candidate task", func(c *clrsfixture.CandidateSet, _ *clrsfixture.VerifierSet) {
+			c.Examples[0].Task = clrsfixture.TaskInsertionSort
+		}},
+		{"candidate semantics", func(c *clrsfixture.CandidateSet, _ *clrsfixture.VerifierSet) {
+			c.Examples[0].LengthSemantics = clrsfixture.LengthDeclaredInput
+		}},
+		{"candidate requested length", func(c *clrsfixture.CandidateSet, _ *clrsfixture.VerifierSet) { c.Examples[0].RequestedLength++ }},
+		{"candidate effective size", func(c *clrsfixture.CandidateSet, _ *clrsfixture.VerifierSet) { c.Examples[0].EffectiveInputSize++ }},
+		{"candidate hints", func(c *clrsfixture.CandidateSet, _ *clrsfixture.VerifierSet) { c.Examples[0].UseHints = true }},
+		{"verifier identity", func(_ *clrsfixture.CandidateSet, v *clrsfixture.VerifierSet) { v.Examples[0].ID[0] ^= 1 }},
+		{"verifier answer", func(_ *clrsfixture.CandidateSet, v *clrsfixture.VerifierSet) { v.Examples[0].Reference += " mutation" }},
+		{"missing candidate", func(c *clrsfixture.CandidateSet, _ *clrsfixture.VerifierSet) { c.Examples = c.Examples[1:] }},
+		{"missing verifier", func(_ *clrsfixture.CandidateSet, v *clrsfixture.VerifierSet) { v.Examples = v.Examples[1:] }},
+		{"reordered candidates", func(c *clrsfixture.CandidateSet, _ *clrsfixture.VerifierSet) {
+			c.Examples[0], c.Examples[1] = c.Examples[1], c.Examples[0]
+		}},
+	}
+	for _, test := range recordMutations {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			candidates := cloneCandidateSet(segments.candidates)
+			verifiers := cloneVerifierSet(segments.verifiers)
+			test.mutate(&candidates, &verifiers)
+			if _, _, err := BindDataset(
+				testRunID, testSpecialistID, segments.source, segments.contract,
+				candidates, verifiers, testLimits(), testVerifierLimits(),
+			); err == nil {
+				t.Fatalf("BindDataset accepted %s", test.name)
+			}
+		})
+	}
+
+	foreignSource := segments.source
+	foreignSource.Commit = "a" + foreignSource.Commit[1:]
+	if _, _, err := BindDataset(
+		testRunID, testSpecialistID, foreignSource, segments.contract,
+		segments.candidates, segments.verifiers, testLimits(), testVerifierLimits(),
+	); err == nil {
+		t.Fatal("BindDataset accepted a source outside the pinned geometry evidence")
+	}
+	contractMutations := []struct {
+		name   string
+		mutate func(*clrsfixture.GenerationContract)
+	}{
+		{"seed", func(contract *clrsfixture.GenerationContract) { contract.Seeds[0]++ }},
+		{"length semantics", func(contract *clrsfixture.GenerationContract) {
+			contract.Tasks[5].LengthSemantics = clrsfixture.LengthDeclaredInput
+		}},
+		{"size role", func(contract *clrsfixture.GenerationContract) {
+			contract.Tasks[5].Sizes[0].Role = clrsfixture.SizePublishedTrain
+		}},
+		{"requested length", func(contract *clrsfixture.GenerationContract) { contract.Tasks[5].Sizes[0].RequestedLength = 5 }},
+	}
+	for _, test := range contractMutations {
+		contract := cloneContract(segments.contract)
+		test.mutate(&contract)
+		if _, _, err := BindDataset(
+			testRunID, testSpecialistID, segments.source, contract,
+			segments.candidates, segments.verifiers, testLimits(), testVerifierLimits(),
+		); err == nil {
+			t.Fatalf("BindDataset accepted mutated contract %s", test.name)
+		}
+	}
+}
+
+func TestBindDatasetRejectsPromptSemanticsMissingFromGenericImporter(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		mutate func(*testExample)
+	}{
+		{"three endpoints", func(example *testExample) {
+			example.prompt = strings.Replace(example.prompt, "0.558854 0.259252 0.415101 0.283525", "0.558854 0.259252 0.415101", 1)
+		}},
+		{"hint-bearing prompt", func(example *testExample) { example.prompt += "hint:\n" }},
+		{"out-of-range coordinate", func(example *testExample) { example.prompt = strings.Replace(example.prompt, "0.558854", "1.0", 1) }},
+		{"wrong output marker", func(example *testExample) {
+			example.prompt = strings.Replace(example.prompt, "\nintersect:\n", "\nreturn:\n", 1)
+		}},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			fixture := newImportFixture(t, clrsfixture.TaskSegmentsIntersect)
+			test.mutate(&fixture.dataset.examples[0])
+			fixture.importDataset(t)
+			if _, _, err := BindDataset(
+				testRunID, testSpecialistID, fixture.source, fixture.contract,
+				fixture.candidates, fixture.verifiers, testLimits(), testVerifierLimits(),
+			); err == nil {
+				t.Fatalf("BindDataset accepted %s", test.name)
+			}
+		})
+	}
+}
+
+func TestBindDatasetRejectsSemanticallyWrongHeldAnswers(t *testing.T) {
+	t.Parallel()
+	for name, reference := range map[string]string{
+		"wrong mask":         falseAnswer,
+		"boolean spelling":   "true\n\n",
+		"missing blank line": "1\n",
+		"array spelling":     "[1]\n\n",
+	} {
+		name, reference := name, reference
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			fixture := newImportFixture(t, clrsfixture.TaskSegmentsIntersect)
+			fixture.dataset.examples[0].reference = reference
+			fixture.importDataset(t)
+			if _, _, err := BindDataset(
+				testRunID, testSpecialistID, fixture.source, fixture.contract,
+				fixture.candidates, fixture.verifiers, testLimits(), testVerifierLimits(),
+			); err == nil {
+				t.Fatalf("BindDataset accepted %s held answer", name)
+			}
+		})
+	}
+}
+
+func TestRequestSetAndVerifierSnapshotTheirSeparateInputs(t *testing.T) {
+	t.Parallel()
+	fixture := newImportFixture(t, clrsfixture.TaskSegmentsIntersect)
+	originalPrompt := fixture.candidates.Examples[0].Prompt
+	originalAnswer := fixture.verifiers.Examples[0].Reference
+	requestSet, verifier := bindFixture(t, fixture, testLimits(), testVerifierLimits())
+	fixture.candidates.Examples[0].Prompt = "mutated"
+	fixture.verifiers.Examples[0].Reference = "mutated"
+
+	requests, err := requestSet.Requests(verticalNow.Add(-time.Second), verticalNow.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	requests[0].Payload[0] = 'X'
+	fresh, err := requestSet.Requests(verticalNow.Add(-time.Second), verticalNow.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(fresh[0].Payload) != originalPrompt {
+		t.Fatalf("fresh request payload = %q, want original prompt", fresh[0].Payload)
+	}
+	invocation, candidate := verificationInputs(fresh[0], []byte(originalAnswer))
+	verification, err := verifier.Verify(context.Background(), invocation, candidate)
+	if err != nil || verification.Verdict != specialistcontrol.VerificationExact {
+		t.Fatalf("Verify(snapshot) = %#v, error %v", verification, err)
+	}
+
+	for name, window := range map[string][2]time.Time{
+		"zero issued":   {{}, verticalNow},
+		"zero deadline": {verticalNow, {}},
+		"equal":         {verticalNow, verticalNow},
+		"reverse":       {verticalNow, verticalNow.Add(-time.Second)},
+	} {
+		if _, err := requestSet.Requests(window[0], window[1]); err == nil {
+			t.Fatalf("Requests accepted %s window", name)
+		}
+	}
+	if _, err := (RequestSet{}).Requests(verticalNow, verticalNow.Add(time.Second)); err == nil {
+		t.Fatal("zero RequestSet produced requests")
+	}
+}
+
+func TestVerifierRejectsSubstitutionAndInvalidBindings(t *testing.T) {
+	t.Parallel()
+	fixture := newImportFixture(t, clrsfixture.TaskSegmentsIntersect)
+	requestSet, verifier := bindFixture(t, fixture, testLimits(), testVerifierLimits())
+	requests, err := requestSet.Requests(verticalNow.Add(-time.Second), verticalNow.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	answer := []byte(fixture.verifiers.Examples[0].Reference)
+	invocation, candidate := verificationInputs(requests[0], answer)
+	if verification, err := verifier.Verify(context.Background(), invocation, candidate); err != nil ||
+		verification.Verdict != specialistcontrol.VerificationExact {
+		t.Fatalf("baseline verification = %#v, error %v", verification, err)
+	}
+
+	invocationMutations := []struct {
+		name   string
+		mutate func(*specialistcontrol.Invocation)
+	}{
+		{"run", func(value *specialistcontrol.Invocation) { value.RunID = "run-foreign" }},
+		{"candidate identity", func(value *specialistcontrol.Invocation) { value.RequestID = requests[1].RequestID }},
+		{"prompt", func(value *specialistcontrol.Invocation) { value.Payload[0] = 'X' }},
+		{"task", func(value *specialistcontrol.Invocation) { value.Task = specialistcontrol.TaskInsertionSort }},
+		{"binding", func(value *specialistcontrol.Invocation) { value.Binding[0]++ }},
+	}
+	for _, test := range invocationMutations {
+		changed := invocation
+		changed.Payload = append([]byte(nil), invocation.Payload...)
+		test.mutate(&changed)
+		if _, err := verifier.Verify(context.Background(), changed, candidate); err == nil {
+			t.Fatalf("Verify accepted %s substitution", test.name)
+		}
+	}
+	candidateMutations := []struct {
+		name   string
+		mutate func(*specialistcontrol.Candidate)
+	}{
+		{"zero binding", func(value *specialistcontrol.Candidate) { value.Binding = specialistcontrol.Binding{} }},
+		{"zero candidate binding", func(value *specialistcontrol.Candidate) {
+			value.CandidateBinding = specialistcontrol.CandidateBinding{}
+		}},
+		{"foreign specialist", func(value *specialistcontrol.Candidate) { value.SpecialistID = "foreign" }},
+		{"wrong state", func(value *specialistcontrol.Candidate) { value.State = specialistcontrol.ResultAbstained }},
+		{"empty answer", func(value *specialistcontrol.Candidate) { value.Payload = nil }},
+	}
+	for _, test := range candidateMutations {
+		changed := candidate
+		test.mutate(&changed)
+		if _, err := verifier.Verify(context.Background(), invocation, changed); err == nil {
+			t.Fatalf("Verify accepted %s", test.name)
+		}
+	}
+	cancelled := &cancelAfterChecksContext{Context: context.Background(), cancelAt: 3}
+	if _, err := verifier.Verify(cancelled, invocation, candidate); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Verify(mid-parse cancellation) error = %v, want context.Canceled", err)
+	}
+	if _, err := verifier.Verify(nil, invocation, candidate); err == nil {
+		t.Fatal("Verify accepted nil context")
+	}
+}
+
+func TestBindDatasetClosesIdentityParserAndReferenceBounds(t *testing.T) {
+	t.Parallel()
+	fixture := newImportFixture(t, clrsfixture.TaskSegmentsIntersect)
+	tests := []struct {
+		name             string
+		runID            string
+		specialistID     string
+		limits           Limits
+		verifierLimits   VerifierLimits
+		wantReferenceErr bool
+	}{
+		{"empty run", "", testSpecialistID, testLimits(), testVerifierLimits(), false},
+		{"bad specialist", testRunID, "bad specialist", testLimits(), testVerifierLimits(), false},
+		{"open reference count", testRunID, testSpecialistID, testLimits(), VerifierLimits{MaxReferenceBytes: 1024}, true},
+		{"small reference count", testRunID, testSpecialistID, testLimits(), VerifierLimits{MaxReferences: 2, MaxReferenceBytes: 16 << 10}, true},
+		{"small reference bytes", testRunID, testSpecialistID, testLimits(), VerifierLimits{MaxReferences: 16, MaxReferenceBytes: 1}, true},
+		{"small token bound", testRunID, testSpecialistID, withLimits(func(value *Limits) { value.MaxTokenBytes = 3 }), testVerifierLimits(), false},
+		{"small prompt bound", testRunID, testSpecialistID, withLimits(func(value *Limits) { value.MaxPromptBytes = 16 }), testVerifierLimits(), false},
+		{"small answer bound", testRunID, testSpecialistID, withLimits(func(value *Limits) { value.MaxAnswerBytes = 2 }), testVerifierLimits(), false},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			_, _, err := BindDataset(
+				test.runID, test.specialistID, fixture.source, fixture.contract,
+				fixture.candidates, fixture.verifiers, test.limits, test.verifierLimits,
+			)
+			if err == nil {
+				t.Fatalf("BindDataset accepted %s", test.name)
+			}
+			if test.wantReferenceErr && !errors.Is(err, ErrReferenceLimit) {
+				t.Fatalf("BindDataset(%s) error = %v, want ErrReferenceLimit", test.name, err)
+			}
+		})
+	}
+}
+
+func TestSegmentVerticalRecordsBeforeEffectAndKeepsReferenceOutOfSpecialist(t *testing.T) {
+	t.Parallel()
+	runner, events, request, reference := verticalRunner(t, nil)
+	run, err := runner.Run(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.Decision.State != specialistcontrol.DecisionInvoke ||
+		run.Outcome.State != specialistcontrol.OutcomeVerified ||
+		run.Outcome.Authority != specialistcontrol.ResultAuthority ||
+		!bytes.Equal(run.Outcome.Payload, reference) {
+		t.Fatalf("vertical outcome = %#v", run)
+	}
+	if !reflect.DeepEqual(*events, []string{"record", "invoke", "verify"}) {
+		t.Fatalf("effect order = %v, want record/invoke/verify", *events)
+	}
+}
+
+func TestSegmentVerticalRefusesMalformedAndOversizedInputBeforeVerification(t *testing.T) {
+	t.Parallel()
+	fixture := newImportFixture(t, clrsfixture.TaskSegmentsIntersect)
+	requestSet, verifier := bindFixture(t, fixture, testLimits(), testVerifierLimits())
+	requests, err := requestSet.Requests(verticalNow.Add(-time.Second), verticalNow.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, setup := range map[string]struct {
+		prompt []byte
+		limits Limits
+	}{
+		"malformed": {[]byte("segments_intersect:\nx: [0.1 0.2], y: [0.1 0.2]\nintersect:\n"), testLimits()},
+		"oversized": {[]byte(pinnedSeed3Prompt), withLimits(func(value *Limits) { value.MaxPromptBytes = 16 })},
+	} {
+		name, setup := name, setup
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			specialist, err := NewSpecialist(testSpecialistID, setup.limits)
+			if err != nil {
+				t.Fatal(err)
+			}
+			verifierCalled := false
+			observedVerifier := verifierFunc(func(
+				ctx context.Context,
+				invocation specialistcontrol.Invocation,
+				candidate specialistcontrol.Candidate,
+			) (specialistcontrol.Verification, error) {
+				verifierCalled = true
+				return verifier.Verify(ctx, invocation, candidate)
+			})
+			runner := newVerticalRunner(
+				t, specialist,
+				recorderFunc(func(context.Context, specialistcontrol.Decision) error { return nil }),
+				observedVerifier, func() time.Time { return verticalNow },
+			)
+			request := requests[0]
+			request.Payload = setup.prompt
+			run, runErr := runner.Run(context.Background(), request)
+			if runErr != nil || verifierCalled || run.Outcome.State != specialistcontrol.OutcomeRefused ||
+				run.Outcome.Reason != specialistcontrol.ReasonSpecialistRefused ||
+				run.Outcome.Authority != specialistcontrol.ResultAuthority {
+				t.Fatalf("Run(%s) error/verifier/outcome = %v/%t/%#v", name, runErr, verifierCalled, run.Outcome)
+			}
+		})
+	}
+}
+
+func TestSegmentVerticalTypesCancellationAndDeadlineAsNoResult(t *testing.T) {
+	t.Parallel()
+	t.Run("cancelled", func(t *testing.T) {
+		t.Parallel()
+		runner, _, request, _ := verticalRunner(t, nil)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		run, err := runner.Run(ctx, request)
+		if !errors.Is(err, context.Canceled) || run.Outcome.State != specialistcontrol.OutcomeAbstained ||
+			run.Outcome.Reason != specialistcontrol.ReasonCancelled ||
+			run.Outcome.Authority != specialistcontrol.ResultAuthority {
+			t.Fatalf("cancelled outcome/error = %#v/%v", run.Outcome, err)
+		}
+	})
+
+	t.Run("deadline", func(t *testing.T) {
+		t.Parallel()
+		fixture := newImportFixture(t, clrsfixture.TaskSegmentsIntersect)
+		requestSet, verifier := bindFixture(t, fixture, testLimits(), testVerifierLimits())
+		requests, err := requestSet.Requests(verticalNow.Add(-time.Second), verticalNow.Add(time.Second))
+		if err != nil {
+			t.Fatal(err)
+		}
+		specialist, err := NewSpecialist(testSpecialistID, testLimits())
+		if err != nil {
+			t.Fatal(err)
+		}
+		calls := 0
+		clock := func() time.Time {
+			calls++
+			if calls == 2 {
+				return requests[0].Deadline
+			}
+			return verticalNow
+		}
+		invoked := false
+		runner := newVerticalRunner(
+			t,
+			specialistFunc(func(ctx context.Context, invocation specialistcontrol.Invocation) (specialistcontrol.SpecialistResult, error) {
+				invoked = true
+				return specialist.Invoke(ctx, invocation)
+			}),
+			recorderFunc(func(context.Context, specialistcontrol.Decision) error { return nil }),
+			verifier, clock,
+		)
+		run, runErr := runner.Run(context.Background(), requests[0])
+		if runErr != nil || invoked || run.Outcome.State != specialistcontrol.OutcomeAbstained ||
+			run.Outcome.Reason != specialistcontrol.ReasonDeadlineElapsed ||
+			run.Outcome.Authority != specialistcontrol.ResultAuthority {
+			t.Fatalf("deadline outcome/error/invoked = %#v/%v/%t", run.Outcome, runErr, invoked)
+		}
+	})
+}
+
+func TestSegmentVerticalAbstainsOnWrongAnswer(t *testing.T) {
+	t.Parallel()
+	fixture := newImportFixture(t, clrsfixture.TaskSegmentsIntersect)
+	requestSet, verifier := bindFixture(t, fixture, testLimits(), testVerifierLimits())
+	requests, err := requestSet.Requests(verticalNow.Add(-time.Second), verticalNow.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrong := specialistFunc(func(_ context.Context, invocation specialistcontrol.Invocation) (specialistcontrol.SpecialistResult, error) {
+		return specialistcontrol.SpecialistResult{
+			Binding: invocation.Binding, SpecialistID: testSpecialistID,
+			State: specialistcontrol.ResultCompleted, Payload: []byte(falseAnswer),
+		}, nil
+	})
+	runner := newVerticalRunner(
+		t, wrong,
+		recorderFunc(func(context.Context, specialistcontrol.Decision) error { return nil }),
+		verifier, func() time.Time { return verticalNow },
+	)
+	run, runErr := runner.Run(context.Background(), requests[0])
+	if runErr != nil || run.Outcome.State != specialistcontrol.OutcomeAbstained ||
+		run.Outcome.Reason != specialistcontrol.ReasonVerificationMismatch ||
+		run.Outcome.Authority != specialistcontrol.ResultAuthority || len(run.Outcome.Payload) != 0 {
+		t.Fatalf("wrong-answer outcome/error = %#v/%v", run.Outcome, runErr)
+	}
+}
+
+func TestSpecialistRefusesWrongTaskBindingAndResultCap(t *testing.T) {
+	t.Parallel()
+	specialist, err := NewSpecialist(testSpecialistID, testLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := specialistcontrol.Invocation{
+		Task: specialistcontrol.TaskSegmentsIntersect, Binding: specialistcontrol.Binding{1},
+		Payload: []byte(pinnedSeed3Prompt), MaxResultBytes: len(trueAnswer),
+	}
+	for name, mutate := range map[string]func(*specialistcontrol.Invocation){
+		"wrong task":       func(value *specialistcontrol.Invocation) { value.Task = specialistcontrol.TaskInsertionSort },
+		"zero binding":     func(value *specialistcontrol.Invocation) { value.Binding = specialistcontrol.Binding{} },
+		"zero result cap":  func(value *specialistcontrol.Invocation) { value.MaxResultBytes = 0 },
+		"small result cap": func(value *specialistcontrol.Invocation) { value.MaxResultBytes = len(trueAnswer) - 1 },
+	} {
+		invocation := base
+		mutate(&invocation)
+		result, err := specialist.Invoke(context.Background(), invocation)
+		if err != nil || result.State != specialistcontrol.ResultRefused || len(result.Payload) != 0 {
+			t.Fatalf("Invoke(%s) = %#v, error %v", name, result, err)
+		}
+	}
+	if _, err := NewSpecialist("bad specialist", testLimits()); err == nil {
+		t.Fatal("NewSpecialist accepted invalid identity")
+	}
+	if _, err := specialist.Invoke(nil, base); err == nil {
+		t.Fatal("Invoke accepted nil context")
+	}
+}
+
+func verticalRunner(
+	t *testing.T,
+	clock func() time.Time,
+) (specialistcontrol.Runner, *[]string, specialistcontrol.Request, []byte) {
+	t.Helper()
+	if clock == nil {
+		clock = func() time.Time { return verticalNow }
+	}
+	fixture := newImportFixture(t, clrsfixture.TaskSegmentsIntersect)
+	requestSet, verifier := bindFixture(t, fixture, testLimits(), testVerifierLimits())
+	requests, err := requestSet.Requests(verticalNow.Add(-time.Second), verticalNow.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	reference := []byte(fixture.verifiers.Examples[0].Reference)
+	specialist, err := NewSpecialist(testSpecialistID, testLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	events := make([]string, 0, 3)
+	observedSpecialist := specialistFunc(func(
+		ctx context.Context,
+		invocation specialistcontrol.Invocation,
+	) (specialistcontrol.SpecialistResult, error) {
+		events = append(events, "invoke")
+		if bytes.Contains(invocation.Payload, reference) {
+			t.Fatal("verifier-only reference bytes leaked into the specialist request")
+		}
+		return specialist.Invoke(ctx, invocation)
+	})
+	observedVerifier := verifierFunc(func(
+		ctx context.Context,
+		invocation specialistcontrol.Invocation,
+		candidate specialistcontrol.Candidate,
+	) (specialistcontrol.Verification, error) {
+		events = append(events, "verify")
+		return verifier.Verify(ctx, invocation, candidate)
+	})
+	runner := newVerticalRunner(
+		t, observedSpecialist,
+		recorderFunc(func(context.Context, specialistcontrol.Decision) error {
+			events = append(events, "record")
+			return nil
+		}),
+		observedVerifier, clock,
+	)
+	return runner, &events, requests[0], reference
+}
+
+func newVerticalRunner(
+	t *testing.T,
+	target specialistcontrol.Specialist,
+	recorder specialistcontrol.DecisionRecorder,
+	verifier specialistcontrol.ExactVerifier,
+	clock func() time.Time,
+) specialistcontrol.Runner {
+	t.Helper()
+	routes := make([]specialistcontrol.Route, 0, len(specialistcontrol.Tasks()))
+	specialists := make(map[string]specialistcontrol.Specialist, len(specialistcontrol.Tasks()))
+	for _, task := range specialistcontrol.Tasks() {
+		id := "unavailable-" + string(task)
+		if task == specialistcontrol.TaskSegmentsIntersect {
+			id = testSpecialistID
+			specialists[id] = target
+		} else {
+			specialists[id] = specialistFunc(func(
+				_ context.Context,
+				invocation specialistcontrol.Invocation,
+			) (specialistcontrol.SpecialistResult, error) {
+				return specialistcontrol.SpecialistResult{
+					Binding: invocation.Binding, SpecialistID: "unavailable-" + string(invocation.Task),
+					State: specialistcontrol.ResultAbstained,
+				}, nil
+			})
+		}
+		routes = append(routes, specialistcontrol.Route{Task: task, SpecialistID: id})
+	}
+	policy, err := specialistcontrol.NewPolicy(specialistcontrol.Limits{
+		MaxRequestBytes: 64 << 10,
+		MaxResultBytes:  8 << 10,
+		MaxRequestAge:   2 * time.Second,
+		MaxExecution:    2 * time.Second,
+	}, routes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner, err := specialistcontrol.NewRunner(policy, recorder, specialists, verifier, clock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return runner
+}
+
+type testExample struct {
+	prompt    string
+	reference string
+	length    int64
+	seed      int64
+	useHints  bool
+}
+
+type testDataset struct {
+	name     string
+	examples []testExample
+}
+
+type importFixture struct {
+	source     clrsfixture.SourceRecord
+	contract   clrsfixture.GenerationContract
+	task       clrsfixture.TaskPlan
+	dataset    testDataset
+	candidates clrsfixture.CandidateSet
+	verifiers  clrsfixture.VerifierSet
+}
+
+func newImportFixture(t *testing.T, task clrsfixture.TaskKind) importFixture {
+	t.Helper()
+	sourceBody := readGeneratorFile(t, "upstream.json")
+	source, err := clrsfixture.ParseSourceRecord(sourceBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	contractBody := readGeneratorFile(t, "contract.json")
+	contract, err := clrsfixture.ParseGenerationContract(contractBody, source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := contract.Plan(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var selected clrsfixture.TaskPlan
+	for _, candidate := range plan.Tasks {
+		if candidate.Task == task {
+			selected = candidate
+			break
+		}
+	}
+	if selected.Task == "" {
+		t.Fatalf("task %s is absent from tracked contract", task)
+	}
+	fixture := importFixture{
+		source: source, contract: contract, task: selected,
+		dataset: makeTestDataset(plan, selected),
+	}
+	fixture.importDataset(t)
+	return fixture
+}
+
+func (fixture *importFixture) importDataset(t *testing.T) {
+	t.Helper()
+	body, err := json.Marshal(fixture.dataset.jsonValue())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixture.candidates, fixture.verifiers, err = clrsfixture.ImportDataset(
+		bytes.NewReader(body),
+		fixture.source,
+		fixture.contract,
+		fixture.task.OutputRelativePath,
+		testImportLimits(),
+	)
+	if err != nil {
+		t.Fatalf("import synthetic contract-bound %s dataset: %v", fixture.task.Task, err)
+	}
+}
+
+func makeTestDataset(plan clrsfixture.GenerationPlan, task clrsfixture.TaskPlan) testDataset {
+	dataset := testDataset{name: "clrs_text_" + string(task.Task)}
+	for _, size := range task.Sizes {
+		for _, seed := range plan.Seeds {
+			for sample := 0; sample < plan.SamplesPerCell; sample++ {
+				prompt := fmt.Sprintf("%s:\ninput: %d/%d/%d", task.Task, size.RequestedLength, seed, sample)
+				reference := fmt.Sprintf("reference-%d-%d-%d", size.RequestedLength, seed, sample)
+				if task.Task == clrsfixture.TaskSegmentsIntersect {
+					prompt, reference = segmentExample(seed)
+				}
+				dataset.examples = append(dataset.examples, testExample{
+					prompt: prompt, reference: reference,
+					length: size.RequestedLength, seed: seed, useHints: plan.UseHints,
+				})
+			}
+		}
+	}
+	return dataset
+}
+
+func (dataset testDataset) jsonValue() map[string]any {
+	examples := make([]any, 0, len(dataset.examples))
+	for _, example := range dataset.examples {
+		examples = append(examples, map[string]any{
+			"prompt":     example.prompt,
+			"references": []string{example.reference},
+			"auxiliary": map[string]any{
+				"length": example.length, "seed": example.seed, "use_hints": example.useHints,
+			},
+		})
+	}
+	return map[string]any{"name": dataset.name, "examples": examples}
+}
+
+func segmentExample(seed int64) (string, string) {
+	switch seed {
+	case 3:
+		return pinnedSeed3Prompt, trueAnswer
+	case 14:
+		return geometryPrompt(
+			"0.257592 0.701151 0.657 0.182007",
+			"0.322062 0.887537 0.083349 0.746564",
+		), trueAnswer
+	case 35:
+		return geometryPrompt(
+			"0.988724 0.750084 0.222386 0.147903",
+			"0.51579 0.394258 0.06988 0.338225",
+		), falseAnswer
+	default:
+		panic(fmt.Sprintf("unrecognised fixed segment seed %d", seed))
+	}
+}
+
+func readGeneratorFile(t *testing.T, name string) []byte {
+	t.Helper()
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("locate segment-intersection adapter test")
+	}
+	body, err := os.ReadFile(filepath.Join(filepath.Dir(filename), "..", "..", "clrs-generator", name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return body
+}
+
+func bindFixture(
+	t *testing.T,
+	fixture importFixture,
+	limits Limits,
+	verifierLimits VerifierLimits,
+) (RequestSet, Verifier) {
+	t.Helper()
+	requestSet, verifier, err := BindDataset(
+		testRunID,
+		testSpecialistID,
+		fixture.source,
+		fixture.contract,
+		fixture.candidates,
+		fixture.verifiers,
+		limits,
+		verifierLimits,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return requestSet, verifier
+}
+
+func verificationInputs(
+	request specialistcontrol.Request,
+	answer []byte,
+) (specialistcontrol.Invocation, specialistcontrol.Candidate) {
+	invocation := specialistcontrol.Invocation{
+		RunID: request.RunID, RequestID: request.RequestID, Task: request.Task,
+		Payload: append([]byte(nil), request.Payload...), Binding: specialistcontrol.Binding{1},
+		Deadline: request.Deadline, MaxResultBytes: 8 << 10,
+	}
+	candidate := specialistcontrol.Candidate{
+		Binding: invocation.Binding, CandidateBinding: specialistcontrol.CandidateBinding{1},
+		SpecialistID: testSpecialistID, State: specialistcontrol.ResultCompleted,
+		Payload: append([]byte(nil), answer...),
+	}
+	return invocation, candidate
+}
+
+func cloneCandidateSet(set clrsfixture.CandidateSet) clrsfixture.CandidateSet {
+	set.Examples = append([]clrsfixture.CandidateExample(nil), set.Examples...)
+	return set
+}
+
+func cloneVerifierSet(set clrsfixture.VerifierSet) clrsfixture.VerifierSet {
+	set.Examples = append([]clrsfixture.VerifierExample(nil), set.Examples...)
+	return set
+}
+
+func cloneContract(contract clrsfixture.GenerationContract) clrsfixture.GenerationContract {
+	contract.Seeds = append([]int64(nil), contract.Seeds...)
+	contract.Tasks = append([]clrsfixture.GenerationTask(nil), contract.Tasks...)
+	for index := range contract.Tasks {
+		contract.Tasks[index].Sizes = append([]clrsfixture.SizeSelection(nil), contract.Tasks[index].Sizes...)
+	}
+	return contract
+}
+
+func testImportLimits() clrsfixture.ImportLimits {
+	return clrsfixture.ImportLimits{
+		MaxDatasetBytes: 1 << 20, MaxExamples: 16,
+		MaxPromptBytes: 64 << 10, MaxReferenceBytes: 8 << 10, MaxDeclaredLength: 64,
+	}
+}
+
+func testVerifierLimits() VerifierLimits {
+	return VerifierLimits{MaxReferences: 16, MaxReferenceBytes: 16 << 10}
+}
+
+func withLimits(change func(*Limits)) Limits {
+	limits := testLimits()
+	change(&limits)
+	return limits
+}

--- a/tooling/internal/clrssegments/prompt.go
+++ b/tooling/internal/clrssegments/prompt.go
@@ -1,0 +1,362 @@
+package clrssegments
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+)
+
+const (
+	promptPrefix    = "segments_intersect:\nx: ["
+	vectorMarker    = "], y: ["
+	promptSuffix    = "]\nintersect:\n"
+	falseAnswer     = "0\n\n"
+	trueAnswer      = "1\n\n"
+	coordinateCount = 4
+
+	maximumPromptBytesCeiling = 1 << 20
+	maximumTokenBytesCeiling  = 128
+	maximumAnswerBytesCeiling = 1 << 20
+	coordinateGridScale       = 1_000_000.0
+	coordinateGridTolerance   = 1e-7
+)
+
+var (
+	// ErrInvalidLimits means a caller did not close every parser/output bound.
+	ErrInvalidLimits = errors.New("invalid segment-intersection limits")
+	// ErrMalformedPrompt means bytes do not match the bounded no-hint grammar.
+	ErrMalformedPrompt = errors.New("malformed segment-intersection prompt")
+	// ErrPromptLimit means candidate-visible input crossed a configured bound.
+	ErrPromptLimit = errors.New("segment-intersection prompt limit exceeded")
+	// ErrAnswerLimit means the exact answer crossed a configured output bound.
+	ErrAnswerLimit = errors.New("segment-intersection answer limit exceeded")
+)
+
+// Limits are parser and bounded-output safety caps. The endpoint count remains
+// fixed by the generation contract rather than caller configuration.
+type Limits struct {
+	MaxPromptBytes int
+	MaxTokenBytes  int
+	MaxAnswerBytes int
+}
+
+// Validate rejects open or impractically large bounds.
+func (limits Limits) Validate() error {
+	if limits.MaxPromptBytes <= 0 || limits.MaxPromptBytes > maximumPromptBytesCeiling ||
+		limits.MaxTokenBytes <= 0 || limits.MaxTokenBytes > maximumTokenBytesCeiling ||
+		limits.MaxAnswerBytes <= 0 || limits.MaxAnswerBytes > maximumAnswerBytesCeiling {
+		return ErrInvalidLimits
+	}
+	return nil
+}
+
+type point struct {
+	x float64
+	y float64
+}
+
+type geometryInput struct {
+	endpoints [coordinateCount]point
+}
+
+// Solve returns the pinned closed-segment intersection mask for the bounded
+// no-hint CLRS-Text grammar. A successful answer remains NO_RESULT.
+func Solve(ctx context.Context, prompt []byte, limits Limits) ([]byte, error) {
+	if ctx == nil {
+		return nil, errors.New("solve segment intersection: nil context")
+	}
+	if err := limits.Validate(); err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	input, err := parsePrompt(ctx, prompt, limits)
+	if err != nil {
+		return nil, err
+	}
+	intersects, err := segmentsIntersect(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+	return formatAnswer(intersects, limits.MaxAnswerBytes)
+}
+
+func parsePrompt(ctx context.Context, prompt []byte, limits Limits) (geometryInput, error) {
+	if len(prompt) > limits.MaxPromptBytes {
+		return geometryInput{}, fmt.Errorf("%w: %d bytes exceeds %d", ErrPromptLimit, len(prompt), limits.MaxPromptBytes)
+	}
+	if len(prompt) == 0 || !utf8.Valid(prompt) {
+		return geometryInput{}, ErrMalformedPrompt
+	}
+	body, found := strings.CutPrefix(string(prompt), promptPrefix)
+	if !found {
+		return geometryInput{}, fmt.Errorf("%w: wrong task or x marker", ErrMalformedPrompt)
+	}
+	body, found = strings.CutSuffix(body, promptSuffix)
+	if !found {
+		return geometryInput{}, fmt.Errorf("%w: wrong intersection marker", ErrMalformedPrompt)
+	}
+	xBody, yBody, found := strings.Cut(body, vectorMarker)
+	if !found || strings.Contains(yBody, vectorMarker) {
+		return geometryInput{}, fmt.Errorf("%w: missing or repeated coordinate-vector marker", ErrMalformedPrompt)
+	}
+	xs, err := parseCoordinateVector(ctx, xBody, limits, "x")
+	if err != nil {
+		return geometryInput{}, err
+	}
+	ys, err := parseCoordinateVector(ctx, yBody, limits, "y")
+	if err != nil {
+		return geometryInput{}, err
+	}
+	var input geometryInput
+	for index := range coordinateCount {
+		input.endpoints[index] = point{x: xs[index], y: ys[index]}
+	}
+	return input, nil
+}
+
+func parseCoordinateVector(
+	ctx context.Context,
+	body string,
+	limits Limits,
+	axis string,
+) ([coordinateCount]float64, error) {
+	var coordinates [coordinateCount]float64
+	tokens := strings.Split(body, " ")
+	if len(tokens) != coordinateCount {
+		return coordinates, fmt.Errorf("%w: %s coordinate count = %d, want %d", ErrMalformedPrompt, axis, len(tokens), coordinateCount)
+	}
+	for index, token := range tokens {
+		if err := ctx.Err(); err != nil {
+			return coordinates, err
+		}
+		value, err := parseCoordinate(token, limits.MaxTokenBytes)
+		if err != nil {
+			if errors.Is(err, ErrPromptLimit) {
+				return coordinates, fmt.Errorf("%w at %s[%d]: %v", ErrPromptLimit, axis, index, err)
+			}
+			return coordinates, fmt.Errorf("%w at %s[%d]: %v", ErrMalformedPrompt, axis, index, err)
+		}
+		coordinates[index] = value
+	}
+	return coordinates, nil
+}
+
+func parseCoordinate(token string, maximumBytes int) (float64, error) {
+	if token == "" {
+		return 0, errors.New("empty coordinate")
+	}
+	if len(token) > maximumBytes {
+		return 0, fmt.Errorf("%w: coordinate exceeds %d bytes", ErrPromptLimit, maximumBytes)
+	}
+	if !coordinateGrammar(token) {
+		return 0, errors.New("coordinate is outside the truncated decimal grammar")
+	}
+	value, err := strconv.ParseFloat(token, 64)
+	if err != nil || math.IsInf(value, 0) || math.IsNaN(value) {
+		return 0, errors.New("coordinate is not finite float64")
+	}
+	if value < 0 || value >= 1 {
+		return 0, errors.New("coordinate is outside the pinned sampler range [0,1)")
+	}
+	scaled := value * coordinateGridScale
+	if math.Abs(scaled-math.Round(scaled)) > coordinateGridTolerance {
+		return 0, errors.New("coordinate is outside the pinned six-decimal grid")
+	}
+	if token != canonicalCoordinate(value) {
+		return 0, errors.New("coordinate is not the pinned NumPy scalar spelling")
+	}
+	return value, nil
+}
+
+func canonicalCoordinate(value float64) string {
+	if value == 0 {
+		return "0.0"
+	}
+	return strconv.FormatFloat(value, 'g', -1, 64)
+}
+
+func coordinateGrammar(token string) bool {
+	mantissa, exponent, scientific := strings.Cut(token, "e")
+	if strings.Contains(exponent, "e") || !coordinateMantissa(mantissa, scientific) {
+		return false
+	}
+	if !scientific {
+		return len(mantissa) >= 3 && mantissa[0] == '0' && mantissa[1] == '.'
+	}
+	if len(exponent) != 3 || exponent[0] != '-' || exponent[1] < '0' || exponent[1] > '9' ||
+		exponent[2] < '0' || exponent[2] > '9' || mantissa[0] == '0' {
+		return false
+	}
+	power := int(exponent[1]-'0')*10 + int(exponent[2]-'0')
+	return power >= 1 && power <= 6
+}
+
+func coordinateMantissa(mantissa string, scientific bool) bool {
+	if mantissa == "" || mantissa[0] < '0' || mantissa[0] > '9' {
+		return false
+	}
+	dot := strings.IndexByte(mantissa, '.')
+	if dot < 0 {
+		return scientific && len(mantissa) == 1
+	}
+	if dot != 1 || dot == len(mantissa)-1 || strings.Contains(mantissa[dot+1:], ".") {
+		return false
+	}
+	fraction := mantissa[dot+1:]
+	if len(fraction) > 6 || (len(fraction) > 1 && fraction[len(fraction)-1] == '0') {
+		return false
+	}
+	for index := range len(fraction) {
+		if fraction[index] < '0' || fraction[index] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// segmentsIntersect mirrors the pinned direction order and inclusive
+// collinear checks over endpoints 0--1 and 2--3.
+func segmentsIntersect(ctx context.Context, input geometryInput) (bool, error) {
+	triples := [coordinateCount][3]int{{2, 3, 0}, {2, 3, 1}, {0, 1, 2}, {0, 1, 3}}
+	var directions [coordinateCount]float64
+	var onSegment [coordinateCount]bool
+	for index, triple := range triples {
+		if err := ctx.Err(); err != nil {
+			return false, err
+		}
+		first := input.endpoints[triple[0]]
+		second := input.endpoints[triple[1]]
+		probe := input.endpoints[triple[2]]
+		directions[index] = pinnedDirection(first, second, probe)
+		onSegment[index] = insideClosedBox(first, second, probe)
+	}
+	proper := oppositeSigns(directions[0], directions[1]) && oppositeSigns(directions[2], directions[3])
+	if proper {
+		return true, nil
+	}
+	for index := range coordinateCount {
+		if directions[index] == 0 && onSegment[index] {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func pinnedDirection(first, second, probe point) float64 {
+	probeX := probe.x - first.x
+	probeY := probe.y - first.y
+	segmentX := second.x - first.x
+	segmentY := second.y - first.y
+	return probeX*segmentY - segmentX*probeY
+}
+
+func oppositeSigns(left, right float64) bool {
+	return (left > 0 && right < 0) || (left < 0 && right > 0)
+}
+
+func insideClosedBox(first, second, probe point) bool {
+	return math.Min(first.x, second.x) <= probe.x && probe.x <= math.Max(first.x, second.x) &&
+		math.Min(first.y, second.y) <= probe.y && probe.y <= math.Max(first.y, second.y)
+}
+
+func formatAnswer(intersects bool, maximumBytes int) ([]byte, error) {
+	answer := falseAnswer
+	if intersects {
+		answer = trueAnswer
+	}
+	if len(answer) > maximumBytes {
+		return nil, fmt.Errorf("%w: %d bytes exceeds %d", ErrAnswerLimit, len(answer), maximumBytes)
+	}
+	return []byte(answer), nil
+}
+
+func parseAnswer(reference []byte, limits Limits) (bool, error) {
+	if len(reference) == 0 || len(reference) > limits.MaxAnswerBytes || !utf8.Valid(reference) {
+		return false, fmt.Errorf("%w: reference must contain 1..%d UTF-8 bytes", ErrAnswerLimit, limits.MaxAnswerBytes)
+	}
+	switch string(reference) {
+	case falseAnswer:
+		return false, nil
+	case trueAnswer:
+		return true, nil
+	default:
+		return false, errors.New("reference is not the exact graph-mask grammar")
+	}
+}
+
+// validateReference checks the held mask through an independently arranged
+// conventional orientation test. It never calls Solve or segmentsIntersect.
+func validateReference(ctx context.Context, reference []byte, limits Limits, input geometryInput) error {
+	if ctx == nil {
+		return errors.New("validate segment-intersection reference: nil context")
+	}
+	want, err := parseAnswer(reference, limits)
+	if err != nil {
+		return err
+	}
+	got, err := referenceIntersects(ctx, input)
+	if err != nil {
+		return err
+	}
+	if got != want {
+		return fmt.Errorf("reference intersection mask = %t, want %t from the closed-segment verifier", want, got)
+	}
+	return nil
+}
+
+func referenceIntersects(ctx context.Context, input geometryInput) (bool, error) {
+	first := input.endpoints[0]
+	second := input.endpoints[1]
+	third := input.endpoints[2]
+	fourth := input.endpoints[3]
+	triples := [coordinateCount][3]point{
+		{first, second, third},
+		{first, second, fourth},
+		{third, fourth, first},
+		{third, fourth, second},
+	}
+	var orientations [coordinateCount]float64
+	for index, triple := range triples {
+		if err := ctx.Err(); err != nil {
+			return false, err
+		}
+		orientations[index] = conventionalOrientation(triple[0], triple[1], triple[2])
+	}
+	if referenceOppositeSides(orientations[0], orientations[1]) &&
+		referenceOppositeSides(orientations[2], orientations[3]) {
+		return true, nil
+	}
+	return (orientations[0] == 0 && referenceInsideClosedBox(first, second, third)) ||
+		(orientations[1] == 0 && referenceInsideClosedBox(first, second, fourth)) ||
+		(orientations[2] == 0 && referenceInsideClosedBox(third, fourth, first)) ||
+		(orientations[3] == 0 && referenceInsideClosedBox(third, fourth, second)), nil
+}
+
+func conventionalOrientation(first, second, probe point) float64 {
+	return (second.x-first.x)*(probe.y-first.y) - (second.y-first.y)*(probe.x-first.x)
+}
+
+// These verifier-side predicates deliberately do not reuse the candidate's
+// sign or bounding-box helpers. That keeps the held reference check from
+// reproducing a defect in either candidate predicate.
+func referenceOppositeSides(left, right float64) bool {
+	return left != 0 && right != 0 && math.Signbit(left) != math.Signbit(right)
+}
+
+func referenceInsideClosedBox(first, second, probe point) bool {
+	return referenceBetween(first.x, second.x, probe.x) &&
+		referenceBetween(first.y, second.y, probe.y)
+}
+
+func referenceBetween(first, second, probe float64) bool {
+	if first > second {
+		first, second = second, first
+	}
+	return first <= probe && probe <= second
+}

--- a/tooling/internal/clrssegments/prompt_test.go
+++ b/tooling/internal/clrssegments/prompt_test.go
@@ -1,0 +1,329 @@
+package clrssegments
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/lusoris/20-watts-was-enough/tooling/internal/clrsfixture"
+)
+
+const pinnedSeed3Prompt = `segments_intersect:
+x: [0.558854 0.259252 0.415101 0.283525], y: [0.693137 0.440453 0.156867 0.544649]
+intersect:
+`
+
+type cancelAfterChecksContext struct {
+	context.Context
+	cancelAt int
+	checks   int
+}
+
+func (ctx *cancelAfterChecksContext) Err() error {
+	ctx.checks++
+	if ctx.checks >= ctx.cancelAt {
+		return context.Canceled
+	}
+	return nil
+}
+
+func TestSolveMatchesPinnedSeed3FixedGeometryCell(t *testing.T) {
+	t.Parallel()
+	first, err := Solve(context.Background(), []byte(pinnedSeed3Prompt), testLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := Solve(context.Background(), []byte(pinnedSeed3Prompt), testLimits())
+	if err != nil || string(first) != trueAnswer || string(second) != trueAnswer {
+		t.Fatalf("Solve(seed=3,fixed-four) = %q/%q, error %v, want %q", first, second, err, trueAnswer)
+	}
+	input, err := parsePrompt(context.Background(), []byte(pinnedSeed3Prompt), testLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := validateReference(context.Background(), []byte(trueAnswer), testLimits(), input); err != nil {
+		t.Fatalf("validateReference(seed=3,fixed-four): %v", err)
+	}
+}
+
+func TestSolveMatchesClosedSegmentBoundarySemantics(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		xs   string
+		ys   string
+		want string
+	}{
+		{"proper crossing", "0.1 0.9 0.1 0.9", "0.1 0.9 0.9 0.1", trueAnswer},
+		{"parallel disjoint", "0.1 0.2 0.1 0.2", "0.1 0.1 0.2 0.2", falseAnswer},
+		{"endpoint touch", "0.1 0.5 0.5 0.9", "0.1 0.5 0.5 0.1", trueAnswer},
+		{"collinear overlap", "0.1 0.7 0.3 0.9", "0.1 0.7 0.3 0.9", trueAnswer},
+		{"collinear separated", "0.1 0.2 0.5 0.6", "0.1 0.2 0.5 0.6", falseAnswer},
+		{"point on segment", "0.5 0.5 0.1 0.9", "0.5 0.5 0.1 0.9", trueAnswer},
+		{"point off segment", "0.5 0.5 0.1 0.9", "0.6 0.6 0.1 0.9", falseAnswer},
+		{"identical point segments", "0.5 0.5 0.5 0.5", "0.5 0.5 0.5 0.5", trueAnswer},
+		{"distinct point segments", "0.2 0.2 0.8 0.8", "0.2 0.2 0.8 0.8", falseAnswer},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			prompt := geometryPrompt(test.xs, test.ys)
+			answer, err := Solve(context.Background(), []byte(prompt), testLimits())
+			if err != nil || string(answer) != test.want {
+				t.Fatalf("Solve(%s) = %q, error %v, want %q", test.name, answer, err, test.want)
+			}
+			input, err := parsePrompt(context.Background(), []byte(prompt), testLimits())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := validateReference(context.Background(), []byte(test.want), testLimits(), input); err != nil {
+				t.Fatalf("validateReference(%s): %v", test.name, err)
+			}
+		})
+	}
+}
+
+func TestSolverAndReferenceVerifierAgreeAcrossDeterministicGrid(t *testing.T) {
+	t.Parallel()
+	random := rand.New(rand.NewSource(0x20))
+	for cell := 0; cell < 4_096; cell++ {
+		xs := make([]string, 0, coordinateCount)
+		ys := make([]string, 0, coordinateCount)
+		for range coordinateCount {
+			xs = append(xs, gridCoordinate(random.Intn(1_000_000)))
+			ys = append(ys, gridCoordinate(random.Intn(1_000_000)))
+		}
+		prompt := geometryPrompt(strings.Join(xs, " "), strings.Join(ys, " "))
+		input, err := parsePrompt(context.Background(), []byte(prompt), testLimits())
+		if err != nil {
+			t.Fatalf("parse deterministic cell %d: %v", cell, err)
+		}
+		intersects, err := referenceIntersects(context.Background(), input)
+		if err != nil {
+			t.Fatalf("verify deterministic cell %d: %v", cell, err)
+		}
+		want, err := formatAnswer(intersects, testLimits().MaxAnswerBytes)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got, err := Solve(context.Background(), []byte(prompt), testLimits())
+		if err != nil || !bytes.Equal(got, want) {
+			t.Fatalf("cell %d solver/verifier = %q/%q, error %v", cell, got, want, err)
+		}
+	}
+}
+
+func TestValidateReferenceRejectsWrongMaskAndForeignGrammar(t *testing.T) {
+	t.Parallel()
+	input, err := parsePrompt(context.Background(), []byte(pinnedSeed3Prompt), testLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, reference := range map[string][]byte{
+		"wrong mask":         []byte(falseAnswer),
+		"missing blank line": []byte("1\n"),
+		"boolean":            []byte("true\n\n"),
+		"array":              []byte("[1]\n\n"),
+		"trailing bytes":     []byte("1\n\nextra"),
+	} {
+		name, reference := name, reference
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if err := validateReference(context.Background(), reference, testLimits(), input); err == nil {
+				t.Fatalf("validateReference accepted %s", name)
+			}
+		})
+	}
+	if err := validateReference(nil, []byte(trueAnswer), testLimits(), input); err == nil {
+		t.Fatal("validateReference accepted nil context")
+	}
+}
+
+func TestSolveAcceptsSixDecimalScientificCoordinateGrammar(t *testing.T) {
+	t.Parallel()
+	prompt := geometryPrompt("1e-06 0.2 0.3 0.4", "9.9e-05 0.2 0.4 0.3")
+	answer, err := Solve(context.Background(), []byte(prompt), testLimits())
+	if err != nil || len(answer) != len(falseAnswer) {
+		t.Fatalf("Solve(scientific coordinates) = %q, error %v", answer, err)
+	}
+}
+
+func TestCoordinateGrammarMatchesPinnedNumPyScalarSpellings(t *testing.T) {
+	t.Parallel()
+	for _, token := range []string{
+		"0.0", "1e-06", "9e-06", "1e-05", "1.1e-05", "9.9e-05",
+		"0.0001", "0.001", "0.01", "0.1", "0.999999",
+	} {
+		if _, err := parseCoordinate(token, testLimits().MaxTokenBytes); err != nil {
+			t.Errorf("parseCoordinate(%q): %v", token, err)
+		}
+	}
+	for _, token := range []string{
+		"0", "0.000001", "0.00001", "1e-04", "1e-03", "1e-02", "1e-01", "1.0e-05",
+	} {
+		if _, err := parseCoordinate(token, testLimits().MaxTokenBytes); err == nil {
+			t.Errorf("parseCoordinate accepted noncanonical spelling %q", token)
+		}
+	}
+}
+
+func TestSolveRejectsMalformedAndOversizedPrompts(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		prompt []byte
+		mutate func(*Limits)
+		want   error
+	}{
+		"empty":               {prompt: nil, want: ErrMalformedPrompt},
+		"bad UTF-8":           {prompt: []byte{0xff}, want: ErrMalformedPrompt},
+		"wrong task":          {prompt: []byte(strings.Replace(pinnedSeed3Prompt, "segments_intersect", "jarvis_march", 1)), want: ErrMalformedPrompt},
+		"wrong x marker":      {prompt: []byte(strings.Replace(pinnedSeed3Prompt, "\nx: [", "\nxs: [", 1)), want: ErrMalformedPrompt},
+		"wrong y marker":      {prompt: []byte(strings.Replace(pinnedSeed3Prompt, "], y: [", "]; y: [", 1)), want: ErrMalformedPrompt},
+		"wrong output":        {prompt: []byte(strings.Replace(pinnedSeed3Prompt, "\nintersect:\n", "\nreturn:\n", 1)), want: ErrMalformedPrompt},
+		"hinted trace":        {prompt: []byte(strings.Replace(pinnedSeed3Prompt, "\nintersect:\n", ", initial_trace: 0\ntrace | intersect:\n", 1)), want: ErrMalformedPrompt},
+		"missing newline":     {prompt: []byte(strings.TrimSuffix(pinnedSeed3Prompt, "\n")), want: ErrMalformedPrompt},
+		"three x coordinates": {prompt: []byte(strings.Replace(pinnedSeed3Prompt, "0.558854 0.259252 0.415101 0.283525", "0.558854 0.259252 0.415101", 1)), want: ErrMalformedPrompt},
+		"five y coordinates":  {prompt: []byte(strings.Replace(pinnedSeed3Prompt, "0.693137 0.440453 0.156867 0.544649", "0.693137 0.440453 0.156867 0.544649 0.1", 1)), want: ErrMalformedPrompt},
+		"double space":        {prompt: []byte(strings.Replace(pinnedSeed3Prompt, "0.558854 0.259252", "0.558854  0.259252", 1)), want: ErrMalformedPrompt},
+		"comma separator":     {prompt: []byte(strings.Replace(pinnedSeed3Prompt, "0.558854 0.259252", "0.558854, 0.259252", 1)), want: ErrMalformedPrompt},
+		"non-finite":          {prompt: []byte(strings.Replace(pinnedSeed3Prompt, "0.558854", "NaN", 1)), want: ErrMalformedPrompt},
+		"negative":            {prompt: []byte(strings.Replace(pinnedSeed3Prompt, "0.558854", "-0.1", 1)), want: ErrMalformedPrompt},
+		"upper boundary":      {prompt: []byte(strings.Replace(pinnedSeed3Prompt, "0.558854", "1.0", 1)), want: ErrMalformedPrompt},
+		"integer zero":        {prompt: []byte(strings.Replace(pinnedSeed3Prompt, "0.558854", "0", 1)), want: ErrMalformedPrompt},
+		"leading zero":        {prompt: []byte(strings.Replace(pinnedSeed3Prompt, "0.558854", "00.558854", 1)), want: ErrMalformedPrompt},
+		"trailing zero":       {prompt: []byte(strings.Replace(pinnedSeed3Prompt, "0.558854", "0.5588540", 1)), want: ErrMalformedPrompt},
+		"sub-grid exponent":   {prompt: []byte(strings.Replace(pinnedSeed3Prompt, "0.558854", "1e-07", 1)), want: ErrMalformedPrompt},
+		"positive exponent":   {prompt: []byte(strings.Replace(pinnedSeed3Prompt, "0.558854", "5e+00", 1)), want: ErrMalformedPrompt},
+		"oversized token":     {prompt: []byte(pinnedSeed3Prompt), mutate: func(limits *Limits) { limits.MaxTokenBytes = 3 }, want: ErrPromptLimit},
+		"oversized prompt":    {prompt: []byte(pinnedSeed3Prompt), mutate: func(limits *Limits) { limits.MaxPromptBytes = len(pinnedSeed3Prompt) - 1 }, want: ErrPromptLimit},
+		"oversized answer":    {prompt: []byte(pinnedSeed3Prompt), mutate: func(limits *Limits) { limits.MaxAnswerBytes = 2 }, want: ErrAnswerLimit},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			limits := testLimits()
+			if test.mutate != nil {
+				test.mutate(&limits)
+			}
+			if _, err := Solve(context.Background(), test.prompt, limits); !errors.Is(err, test.want) {
+				t.Fatalf("Solve() error = %v, want %v", err, test.want)
+			}
+		})
+	}
+}
+
+func TestSolveHonoursCancellationAndClosedLimits(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := Solve(ctx, []byte(pinnedSeed3Prompt), testLimits()); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Solve(cancelled) error = %v, want context.Canceled", err)
+	}
+	if _, err := Solve(nil, []byte(pinnedSeed3Prompt), testLimits()); err == nil {
+		t.Fatal("Solve(nil context) succeeded")
+	}
+	for name, mutate := range map[string]func(*Limits){
+		"prompt": func(limits *Limits) { limits.MaxPromptBytes = 0 },
+		"token":  func(limits *Limits) { limits.MaxTokenBytes = 0 },
+		"answer": func(limits *Limits) { limits.MaxAnswerBytes = 0 },
+	} {
+		limits := testLimits()
+		mutate(&limits)
+		if _, err := Solve(context.Background(), []byte(pinnedSeed3Prompt), limits); !errors.Is(err, ErrInvalidLimits) {
+			t.Fatalf("Solve(open %s limit) error = %v, want ErrInvalidLimits", name, err)
+		}
+	}
+}
+
+func TestSolveAndVerifierCheckCancellationInsideFixedWork(t *testing.T) {
+	t.Parallel()
+	solverContext := &cancelAfterChecksContext{Context: context.Background(), cancelAt: 11}
+	if _, err := Solve(solverContext, []byte(pinnedSeed3Prompt), testLimits()); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Solve(mid-work cancellation) error = %v, want context.Canceled", err)
+	}
+	if solverContext.checks != solverContext.cancelAt {
+		t.Fatalf("solver context checks = %d, want %d", solverContext.checks, solverContext.cancelAt)
+	}
+	input, err := parsePrompt(context.Background(), []byte(pinnedSeed3Prompt), testLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	verifierContext := &cancelAfterChecksContext{Context: context.Background(), cancelAt: 2}
+	if err := validateReference(verifierContext, []byte(trueAnswer), testLimits(), input); !errors.Is(err, context.Canceled) {
+		t.Fatalf("validateReference(mid-work cancellation) error = %v, want context.Canceled", err)
+	}
+}
+
+func TestPinnedSourceEvidenceIsExact(t *testing.T) {
+	t.Parallel()
+	evidence := PinnedSourceEvidence()
+	if evidence.SourceRecordPath != "tooling/clrs-generator/upstream.json" ||
+		evidence.SourceID != "sha256:7ec3b6b7528d04f517c4e9b7c3e0cd0f7034a775d225d469d1aca5c00fec10d1" {
+		t.Fatalf("source identity = %#v", evidence)
+	}
+	if evidence.Formatter.GitBlob != "64a2714ca879cd62a4c1d1db0a80e6c23bf61541" ||
+		evidence.Formatter.SHA256 != "d6d320eb1536be8fbdb512315d55eada2db3ff87afd613762f125d38a9e7a53c" ||
+		evidence.Spec.GitBlob != "db3b02e14072152df590a8df518ef058fd167930" ||
+		evidence.Spec.SHA256 != "51f1cc936b28189c7b2e3b2030c30e224fb448f3d2846181983329448f1ed018" ||
+		evidence.Algorithm.Path != "clrs/_src/algorithms/geometry.py" ||
+		evidence.Algorithm.GitBlob != "502823d877fc184b790955c1c0fe9b32e496f823" ||
+		evidence.Algorithm.SHA256 != "d0ad3ee0eacd35ab54a601cd5b37f55bcffe36146455d70e71fb7c1c67aaf776" ||
+		evidence.Sampler.SHA256 != "01921e9ca7fa0cc81a8ce82dd76869820f1e9ad8863d5b76b088b0610a2e0473" ||
+		evidence.Probing.SHA256 != "6ee8bea717c6a820fec0457c8be01a4459d5b2daab9c2c883ab8db333478f064" {
+		t.Fatalf("source file identities = %#v", evidence)
+	}
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("locate segment-intersection source test")
+	}
+	body, err := os.ReadFile(filepath.Join(filepath.Dir(filename), "..", "..", "clrs-generator", "upstream.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	source, err := clrsfixture.ParseSourceRecord(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := evidence.ValidateSource(source); err != nil {
+		t.Fatal(err)
+	}
+	mutations := []func(*SourceEvidence){
+		func(value *SourceEvidence) { value.SourceRecordPath = "other.json" },
+		func(value *SourceEvidence) { value.Formatter.SHA256 = strings.Repeat("0", 64) },
+		func(value *SourceEvidence) { value.Spec.GitBlob = strings.Repeat("0", 40) },
+		func(value *SourceEvidence) { value.Algorithm.Path = "geometry-other.py" },
+		func(value *SourceEvidence) { value.Sampler.SHA256 = strings.Repeat("f", 64) },
+		func(value *SourceEvidence) { value.Probing.GitBlob = strings.Repeat("a", 40) },
+	}
+	for index, mutate := range mutations {
+		changed := evidence
+		mutate(&changed)
+		if err := changed.ValidateSource(source); err == nil {
+			t.Fatalf("ValidateSource accepted supporting-evidence mutation %d", index)
+		}
+	}
+}
+
+func geometryPrompt(xs, ys string) string {
+	return "segments_intersect:\nx: [" + xs + "], y: [" + ys + "]\nintersect:\n"
+}
+
+func gridCoordinate(micro int) string {
+	if micro == 0 {
+		return "0.0"
+	}
+	return strconv.FormatFloat(float64(micro)/coordinateGridScale, 'g', -1, 64)
+}
+
+func testLimits() Limits {
+	return Limits{MaxPromptBytes: 64 << 10, MaxTokenBytes: 32, MaxAnswerBytes: 8 << 10}
+}

--- a/tooling/internal/clrssegments/source.go
+++ b/tooling/internal/clrssegments/source.go
@@ -1,0 +1,81 @@
+// Package clrssegments implements the exact-program segment-intersection
+// vertical for the CLRS-Text development shakedown. Every value remains
+// NO_RESULT.
+package clrssegments
+
+import (
+	"fmt"
+
+	"github.com/lusoris/20-watts-was-enough/tooling/internal/clrsfixture"
+)
+
+// SourceFile binds one upstream file used to derive this vertical's grammar or
+// exact conventional operation. SHA256 is over the file bytes at Commit.
+type SourceFile struct {
+	Path    string
+	GitBlob string
+	SHA256  string
+}
+
+// SourceEvidence extends the canonical source record with the supporting files
+// used to derive this vertical. It references rather than repeats repository,
+// commit, tree, generator, requirements and licence metadata.
+type SourceEvidence struct {
+	SourceRecordPath string
+	SourceID         string
+	Formatter        SourceFile
+	Spec             SourceFile
+	Algorithm        SourceFile
+	Sampler          SourceFile
+	Probing          SourceFile
+}
+
+// PinnedSourceEvidence returns the exact official source inspected for the
+// no-hint prompt/reference grammar and closed-segment intersection operation.
+func PinnedSourceEvidence() SourceEvidence {
+	return SourceEvidence{
+		SourceRecordPath: "tooling/clrs-generator/upstream.json",
+		SourceID:         "sha256:7ec3b6b7528d04f517c4e9b7c3e0cd0f7034a775d225d469d1aca5c00fec10d1",
+		Formatter: SourceFile{
+			Path:    "clrs/_src/clrs_text/clrs_utils.py",
+			GitBlob: "64a2714ca879cd62a4c1d1db0a80e6c23bf61541",
+			SHA256:  "d6d320eb1536be8fbdb512315d55eada2db3ff87afd613762f125d38a9e7a53c",
+		},
+		Spec: SourceFile{
+			Path:    "clrs/_src/specs.py",
+			GitBlob: "db3b02e14072152df590a8df518ef058fd167930",
+			SHA256:  "51f1cc936b28189c7b2e3b2030c30e224fb448f3d2846181983329448f1ed018",
+		},
+		Algorithm: SourceFile{
+			Path:    "clrs/_src/algorithms/geometry.py",
+			GitBlob: "502823d877fc184b790955c1c0fe9b32e496f823",
+			SHA256:  "d0ad3ee0eacd35ab54a601cd5b37f55bcffe36146455d70e71fb7c1c67aaf776",
+		},
+		Sampler: SourceFile{
+			Path:    "clrs/_src/samplers.py",
+			GitBlob: "442a5c6d1da86c2956d8dcc78c9339ded296e1a8",
+			SHA256:  "01921e9ca7fa0cc81a8ce82dd76869820f1e9ad8863d5b76b088b0610a2e0473",
+		},
+		Probing: SourceFile{
+			Path:    "clrs/_src/probing.py",
+			GitBlob: "e4ba102eecdfee2934268a33727da964a2119d37",
+			SHA256:  "6ee8bea717c6a820fec0457c8be01a4459d5b2daab9c2c883ab8db333478f064",
+		},
+	}
+}
+
+// ValidateSource checks that this grammar evidence points to the supplied
+// canonical source record.
+func (evidence SourceEvidence) ValidateSource(source clrsfixture.SourceRecord) error {
+	if evidence != PinnedSourceEvidence() {
+		return fmt.Errorf("segment-intersection supporting source evidence differs from the pinned record")
+	}
+	identity, err := source.Identity()
+	if err != nil {
+		return fmt.Errorf("validate segment-intersection source record: %w", err)
+	}
+	if identity.String() != evidence.SourceID {
+		return fmt.Errorf("segment-intersection source identity = %s, want %s", identity, evidence.SourceID)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

- add the bounded fixed-four-endpoint segment-intersection specialist
- isolate candidate prompts from a separately held orientation verifier
- accept only the canonical NumPy scalar grammar and exact source-bound seed cells

## Verification

- pinned upstream source and all five blob/SHA-256 identities verified
- seeds 3, 14, and 35 reproduced exactly
- 4,096 deterministic solver/verifier cross-checks
- `go -C tooling test -race -count=10 ./internal/clrssegments`
- `go -C tooling vet ./internal/clrssegments`
- Windows/amd64 CGO-disabled compile
- package coverage: 93.4%
- full repository gate: 722 passed, one intentional skip

All output remains `NO_RESULT`. Tracks #12.