### PR TITLE
fix(site): restore semantic document navigation

### DIFF
--- a/.github/ci-impact.json
+++ b/.github/ci-impact.json
@@ -292,6 +292,7 @@
     {
       "id": "script-site-tests",
       "paths": [
+        "scripts/github-pages.test.mjs",
         "scripts/mermaid-browser.test.mjs"
       ],
       "lanes": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -230,6 +230,10 @@ the exact diff; this file records why the project changed.
   the two high-severity unbounded-memory advisories reported by Dependabot and
   OpenSSF Scorecard. The regenerated book manifest and semantic sentinel bind
   the dependency change without changing the rendered PDF bytes.
+- Portal document changes now focus the destination heading and keep fragment,
+  back and forward navigation aligned with that focus. The document rail uses
+  native links, so new-tab, modifier-click and copied-route behaviour remain
+  available alongside same-tab client navigation.
 - Continuous-book deep links now restore every chapter and heading below the
   responsive action bar on cold load and later hash navigation. Internal book
   links remain in the namespaced edition while preserving the current Pages

--- a/app/components/public-research-portal.tsx
+++ b/app/components/public-research-portal.tsx
@@ -8,6 +8,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type MouseEvent,
 } from "react";
 import type { ResearchDocument } from "../research-document";
 import { outlineFromMarkdown } from "../lib/heading-outline";
@@ -34,8 +35,14 @@ const defaultDocumentPath = "concept/00-thesis-and-principles.md";
 const libraryGroups = ["All", "Concept", "Mathematics"] as const;
 const catalogPageSize = 8;
 const documentGroups = ["Concept", "Mathematics"] as const;
+const portalDestinationFrameLimit = 180;
 
 type LibraryGroup = (typeof libraryGroups)[number];
+type PortalNavigationRequest = {
+  focusDestination: boolean;
+  fragment: string;
+};
+type ElementRef<T extends HTMLElement> = { current: T | null };
 
 function withBase(basePath: string, path = "") {
   const base = basePath.endsWith("/") ? basePath : `${basePath}/`;
@@ -64,6 +71,101 @@ function overviewLocation(basePath: string, hash = "") {
 function initialDocumentPath(basePath: string): string | null {
   if (typeof window === "undefined") return null;
   return portalDocumentPathFromLocation(window.location, basePath);
+}
+
+function initialPortalFragment(): string {
+  if (typeof window === "undefined") return "";
+  return window.location.hash.slice(1);
+}
+
+function shouldHandleClientNavigation(event: MouseEvent<HTMLAnchorElement>) {
+  return event.button === 0
+    && !event.altKey
+    && !event.ctrlKey
+    && !event.metaKey
+    && !event.shiftKey
+    && event.currentTarget.target !== "_blank";
+}
+
+function handleClientNavigation(
+  event: MouseEvent<HTMLAnchorElement>,
+  navigate: () => void,
+) {
+  if (!shouldHandleClientNavigation(event)) return;
+  event.preventDefault();
+  navigate();
+}
+
+function makeProgrammaticallyFocusable(target: HTMLElement) {
+  if (!target.matches("a[href], button, input, select, textarea, summary, [tabindex]")) {
+    target.tabIndex = -1;
+  }
+}
+
+function usePortalDestination({
+  navigationRequest,
+  overviewRef,
+  readerPageRef,
+  readerTitleRef,
+  renderedDocumentPath,
+  selectedPath,
+}: {
+  navigationRequest: PortalNavigationRequest;
+  overviewRef: ElementRef<HTMLElement>;
+  readerPageRef: ElementRef<HTMLElement>;
+  readerTitleRef: ElementRef<HTMLHeadingElement>;
+  renderedDocumentPath: string | null | undefined;
+  selectedPath: string | null;
+}) {
+  useEffect(() => {
+    if (!navigationRequest.focusDestination && !navigationRequest.fragment) return;
+
+    let cancelled = false;
+    let frame = 0;
+    let attempts = 0;
+    const reachDestination = () => {
+      if (cancelled) return;
+      const fragmentReady = !selectedPath || renderedDocumentPath === selectedPath;
+      let target: HTMLElement | null = null;
+      if (navigationRequest.fragment && fragmentReady) {
+        target = document.getElementById(
+          decodePortalFragment(navigationRequest.fragment),
+        );
+      } else if (!navigationRequest.fragment) {
+        target = selectedPath ? readerTitleRef.current : overviewRef.current;
+      }
+      if (!target && attempts < portalDestinationFrameLimit) {
+        attempts += 1;
+        frame = window.requestAnimationFrame(reachDestination);
+        return;
+      }
+
+      const resolvedTarget = target
+        ?? (selectedPath ? readerTitleRef.current : overviewRef.current);
+      if (!resolvedTarget) return;
+      if (selectedPath && !navigationRequest.fragment) {
+        readerPageRef.current?.scrollIntoView({ block: "start" });
+      } else {
+        resolvedTarget.scrollIntoView({ block: "start" });
+      }
+      if (navigationRequest.focusDestination) {
+        makeProgrammaticallyFocusable(resolvedTarget);
+        resolvedTarget.focus({ preventScroll: true });
+      }
+    };
+    frame = window.requestAnimationFrame(reachDestination);
+    return () => {
+      cancelled = true;
+      window.cancelAnimationFrame(frame);
+    };
+  }, [
+    navigationRequest,
+    overviewRef,
+    readerPageRef,
+    readerTitleRef,
+    renderedDocumentPath,
+    selectedPath,
+  ]);
 }
 
 function formatNumber(value: number) {
@@ -211,6 +313,10 @@ export function PublicResearchPortal({
   assetBasePath: string;
 }) {
   const [selectedPath, setSelectedPath] = useState<string | null>(() => initialDocumentPath(assetBasePath));
+  const [navigationRequest, setNavigationRequest] = useState(() => ({
+    focusDestination: false,
+    fragment: initialPortalFragment(),
+  }));
   const [documentState, setDocumentState] = useState<{
     path: string;
     document?: ResearchDocument;
@@ -221,7 +327,7 @@ export function PublicResearchPortal({
   const [catalogLimit, setCatalogLimit] = useState(catalogPageSize);
   const deferredQuery = useDeferredValue(query.trim().toLowerCase());
   const overviewRef = useRef<HTMLElement>(null);
-  const readerRef = useRef<HTMLElement>(null);
+  const readerTitleRef = useRef<HTMLHeadingElement>(null);
   const readerPageRef = useRef<HTMLElement>(null);
   const readerLibraryRef = useRef<HTMLElement>(null);
   const mobileMenuRef = useRef<HTMLDetailsElement>(null);
@@ -333,19 +439,23 @@ export function PublicResearchPortal({
   useEffect(() => {
     const handleHistory = () => {
       setSelectedPath(portalDocumentPathFromLocation(window.location, assetBasePath));
+      setNavigationRequest({
+        focusDestination: true,
+        fragment: window.location.hash.slice(1),
+      });
     };
     window.addEventListener("popstate", handleHistory);
     return () => window.removeEventListener("popstate", handleHistory);
   }, [assetBasePath]);
 
-  useEffect(() => {
-    const hash = window.location.hash.slice(1);
-    if (!hash) return;
-    const frame = window.requestAnimationFrame(() => {
-      document.getElementById(decodePortalFragment(hash))?.scrollIntoView();
-    });
-    return () => window.cancelAnimationFrame(frame);
-  }, [selectedDocument, selectedPath]);
+  usePortalDestination({
+    navigationRequest,
+    overviewRef,
+    readerPageRef,
+    readerTitleRef,
+    renderedDocumentPath: selectedDocument?.path,
+    selectedPath,
+  });
 
   useEffect(() => {
     if (!selectedPath) return;
@@ -363,7 +473,7 @@ export function PublicResearchPortal({
     return () => window.cancelAnimationFrame(frame);
   }, [readerLibraryDocuments, selectedPath]);
 
-  const selectDocument = (path: string, hash = "", focusReader = true) => {
+  const selectDocument = (path: string, hash = "") => {
     if (!documentsByPath.has(path)) {
       window.open(
         repositoryDocumentHref(path, hash),
@@ -378,9 +488,9 @@ export function PublicResearchPortal({
       "",
       portalDocumentLocation(path, assetBasePath, hash),
     );
-    window.requestAnimationFrame(() => {
-      if (!hash) readerPageRef.current?.scrollIntoView({ block: "start" });
-      if (focusReader) readerRef.current?.focus({ preventScroll: true });
+    setNavigationRequest({
+      focusDestination: true,
+      fragment: hash,
     });
   };
 
@@ -407,10 +517,9 @@ export function PublicResearchPortal({
       "",
       overviewLocation(assetBasePath, hash),
     );
-    window.requestAnimationFrame(() => {
-      const target = hash ? document.getElementById(hash) : overviewRef.current;
-      target?.scrollIntoView({ block: "start" });
-      target?.focus({ preventScroll: true });
+    setNavigationRequest({
+      focusDestination: true,
+      fragment: hash,
     });
   };
 
@@ -423,10 +532,9 @@ export function PublicResearchPortal({
       "",
       `${targetUrl.pathname}${targetUrl.search}${targetUrl.hash}`,
     );
-    window.requestAnimationFrame(() => {
-      window.requestAnimationFrame(() => {
-        document.getElementById(headingId)?.scrollIntoView({ block: "start" });
-      });
+    setNavigationRequest({
+      focusDestination: true,
+      fragment: headingId,
     });
   };
 
@@ -481,8 +589,7 @@ export function PublicResearchPortal({
         className="portal-wordmark"
         href={overviewLocation(assetBasePath)}
         onClick={(event) => {
-          event.preventDefault();
-          showOverview();
+          handleClientNavigation(event, () => showOverview());
         }}
       >
         <span aria-hidden="true">20W</span>
@@ -492,15 +599,19 @@ export function PublicResearchPortal({
         <a
           href={portalDocumentLocation(defaultDocumentPath, assetBasePath)}
           onClick={(event) => {
-            event.preventDefault();
-            selectDocument(defaultDocumentPath);
+            handleClientNavigation(
+              event,
+              () => selectDocument(defaultDocumentPath),
+            );
           }}
         >Read</a>
         <a
           href={overviewLocation(assetBasePath, "research-system")}
           onClick={(event) => {
-            event.preventDefault();
-            showOverview("research-system");
+            handleClientNavigation(
+              event,
+              () => showOverview("research-system"),
+            );
           }}
         >Evidence</a>
         <a
@@ -520,15 +631,19 @@ export function PublicResearchPortal({
           <a
             href={portalDocumentLocation(defaultDocumentPath, assetBasePath)}
             onClick={(event) => {
-              event.preventDefault();
-              selectDocument(defaultDocumentPath);
+              handleClientNavigation(
+                event,
+                () => selectDocument(defaultDocumentPath),
+              );
             }}
           >Read the thesis</a>
           <a
             href={overviewLocation(assetBasePath, "research-system")}
             onClick={(event) => {
-              event.preventDefault();
-              showOverview("research-system");
+              handleClientNavigation(
+                event,
+                () => showOverview("research-system"),
+              );
             }}
           >Evidence path</a>
           <a
@@ -550,9 +665,9 @@ export function PublicResearchPortal({
     <div className="portal-shell">
       <a
         className="portal-skip-link"
-        href={selectedPath ? "#portal-reader" : "#portal-overview"}
+        href={selectedPath ? "#portal-reader-title" : "#portal-overview"}
         onClick={() => {
-          const targetId = selectedPath ? "portal-reader" : "portal-overview";
+          const targetId = selectedPath ? "portal-reader-title" : "portal-overview";
           window.requestAnimationFrame(() => document.getElementById(targetId)?.focus());
         }}
       >
@@ -571,23 +686,26 @@ export function PublicResearchPortal({
               className="portal-reader-back"
               href={overviewLocation(assetBasePath, "library")}
               onClick={(event) => {
-                event.preventDefault();
-                showOverview("library");
+                handleClientNavigation(event, () => showOverview("library"));
               }}
             >
               <span aria-hidden="true">←</span> Research overview
             </a>
             <div className="portal-reader-toolbar-copy">
               <p>{selectedMetadata.group} · {formatNumber(selectedMetadata.words)} words</p>
-              <h1 id="portal-reader-title">{selectedMetadata.title}</h1>
+              <h1 id="portal-reader-title" ref={readerTitleRef} tabIndex={-1}>
+                {selectedMetadata.title}
+              </h1>
             </div>
             <nav className="portal-reader-sequence" aria-label="Document sequence">
               {previousDocument ? (
                 <a
                   href={portalDocumentLocation(previousDocument.path, assetBasePath)}
                   onClick={(event) => {
-                    event.preventDefault();
-                    selectDocument(previousDocument.path);
+                    handleClientNavigation(
+                      event,
+                      () => selectDocument(previousDocument.path),
+                    );
                   }}
                   rel="prev"
                 >← Previous</a>
@@ -599,8 +717,10 @@ export function PublicResearchPortal({
                 <a
                   href={portalDocumentLocation(nextDocument.path, assetBasePath)}
                   onClick={(event) => {
-                    event.preventDefault();
-                    selectDocument(nextDocument.path);
+                    handleClientNavigation(
+                      event,
+                      () => selectDocument(nextDocument.path),
+                    );
                   }}
                   rel="next"
                 >Next →</a>
@@ -643,8 +763,7 @@ export function PublicResearchPortal({
                       href={`#${heading.id}`}
                       key={heading.id}
                       onClick={(event) => {
-                        event.preventDefault();
-                        selectHeading(heading.id);
+                        handleClientNavigation(event, () => selectHeading(heading.id));
                       }}
                     >{heading.title}</a>
                   ))}
@@ -693,12 +812,16 @@ export function PublicResearchPortal({
                   aria-label="Research documents"
                 >
                   {readerLibraryDocuments.map((document) => (
-                    <button
-                      type="button"
+                    <a
+                      href={portalDocumentLocation(document.path, assetBasePath)}
                       key={document.path}
-                      className={document.path === selectedMetadata.path ? "active" : ""}
                       aria-current={document.path === selectedMetadata.path ? "page" : undefined}
-                      onClick={() => selectDocument(document.path)}
+                      onClick={(event) => {
+                        handleClientNavigation(
+                          event,
+                          () => selectDocument(document.path),
+                        );
+                      }}
                     >
                       <span>{document.title}</span>
                       <small>
@@ -707,7 +830,7 @@ export function PublicResearchPortal({
                           ? " · section heading match"
                           : ""}
                       </small>
-                    </button>
+                    </a>
                   ))}
                   {libraryDocuments.length === 0 ? (
                     <p className="portal-empty-state">
@@ -720,8 +843,6 @@ export function PublicResearchPortal({
               <article
                 className="portal-reader"
                 id="portal-reader"
-                ref={readerRef}
-                tabIndex={-1}
                 aria-labelledby="portal-reader-title"
               >
                 <header className="portal-reader-header">
@@ -782,6 +903,9 @@ export function PublicResearchPortal({
                         className={heading.depth === 3 ? "portal-outline-child" : ""}
                         href={`#${heading.id}`}
                         key={heading.id}
+                        onClick={(event) => {
+                          handleClientNavigation(event, () => selectHeading(heading.id));
+                        }}
                       >{heading.title}</a>
                     ))}
                   </nav>
@@ -820,8 +944,10 @@ export function PublicResearchPortal({
                   className="portal-action portal-action-primary"
                   href={portalDocumentLocation(defaultDocumentPath, assetBasePath)}
                   onClick={(event) => {
-                    event.preventDefault();
-                    selectDocument(defaultDocumentPath);
+                    handleClientNavigation(
+                      event,
+                      () => selectDocument(defaultDocumentPath),
+                    );
                   }}
                 >Read the thesis</a>
                 <a className="portal-action portal-action-secondary" href={withBase(assetBasePath, "book/")}>
@@ -920,8 +1046,10 @@ export function PublicResearchPortal({
                   href={portalDocumentLocation(entry.document.path, assetBasePath)}
                   key={entry.document.path}
                   onClick={(event) => {
-                    event.preventDefault();
-                    selectDocument(entry.document.path);
+                    handleClientNavigation(
+                      event,
+                      () => selectDocument(entry.document.path),
+                    );
                   }}
                 >
                   <span>{entry.label}</span>
@@ -1008,8 +1136,10 @@ export function PublicResearchPortal({
                           <a
                             href={portalDocumentLocation(document.path, assetBasePath)}
                             onClick={(event) => {
-                              event.preventDefault();
-                              selectDocument(document.path);
+                              handleClientNavigation(
+                                event,
+                                () => selectDocument(document.path),
+                              );
                             }}
                           >
                             <span>{documentSequence(document.path, document.group)}</span>

--- a/app/globals.css
+++ b/app/globals.css
@@ -595,7 +595,11 @@ button {
 .portal-shell a:focus-visible,
 .portal-shell button:focus-visible,
 .portal-shell input:focus-visible,
-.portal-reader:focus-visible {
+#portal-reader-title:focus-visible,
+#portal-overview:focus-visible,
+#research-system:focus-visible,
+#library:focus-visible,
+.portal-prose :is(h2, h3, h4, h5, h6):focus-visible {
   outline: 3px solid var(--portal-blue);
   outline-offset: 3px;
 }
@@ -3715,7 +3719,7 @@ button {
     scrollbar-width: thin;
   }
 
-  .portal-library .portal-document-list button {
+  .portal-library .portal-document-list a {
     display: block;
     width: 100%;
     padding: 11px 9px;
@@ -3723,33 +3727,33 @@ button {
     border-left: 2px solid transparent;
     background: transparent;
     color: #344c3e;
-    cursor: pointer;
     text-align: left;
+    text-decoration: none;
   }
 
-  .portal-library .portal-document-list button:hover {
+  .portal-library .portal-document-list a:hover {
     background: #e7ece7;
     color: #183323;
   }
 
-  .portal-library .portal-document-list button.active {
+  .portal-library .portal-document-list a[aria-current="page"] {
     border-color: #276847;
     background: #dfeae2;
     color: #173624;
   }
 
-  .portal-library .portal-document-list button span,
-  .portal-library .portal-document-list button small {
+  .portal-library .portal-document-list a span,
+  .portal-library .portal-document-list a small {
     display: block;
   }
 
-  .portal-library .portal-document-list button span {
+  .portal-library .portal-document-list a span {
     font-size: 13px;
     font-weight: 700;
     line-height: 1.35;
   }
 
-  .portal-library .portal-document-list button small {
+  .portal-library .portal-document-list a small {
     margin-top: 5px;
     color: #6d7c73;
     font-family: var(--font-mono);

--- a/public/downloads/book-manifest.json
+++ b/public/downloads/book-manifest.json
@@ -4,7 +4,7 @@
   "version": "0.3.0",
   "source_ref": "main",
   "pdf": "public/downloads/20-watts-was-enough-full-concept-book.pdf",
-  "source_digest": "915fba06a1251ae0c0397da7964e047b109a40e3d01731e1b71aecda54549322",
+  "source_digest": "2ac5789c477adf2af70394bf5e6e6f43eaf836f58c7fbca3a55b7b9d8f6d8238",
   "source_files": [
     "app/book-content.ts",
     "app/components/book-edition.tsx",

--- a/scripts/book-edition-surface.test.mjs
+++ b/scripts/book-edition-surface.test.mjs
@@ -221,6 +221,10 @@ test("portal utility text and card accents retain readable contrast", async () =
   assert.match(stylesheet, /\.portal-mobile-menu nav a\s*\{[^}]*min-height:\s*44px/s);
   assert.match(stylesheet, /\.prose th\s*\{[^}]*font-size:\s*14px;[^}]*line-height:\s*1\.35/s);
   assert.doesNotMatch(stylesheet, /\.portal-header nav a:(?:first-child|nth-child\()/);
+  assert.match(
+    portal,
+    /#portal-overview:focus-visible,\s*#research-system:focus-visible,\s*#library:focus-visible,\s*\.portal-prose[^{]+\{[^}]*outline:\s*3px solid var\(--portal-blue\)/s,
+  );
 
   const publicationPass = stylesheet.slice(stylesheet.indexOf(
     "/* Research-publication pass: manuscript first, evidence chrome second. */",

--- a/scripts/book-pdf-semantic-baseline.json
+++ b/scripts/book-pdf-semantic-baseline.json
@@ -7,7 +7,7 @@
     "pdf": "public/downloads/20-watts-was-enough-full-concept-book.pdf",
     "manifest": "public/downloads/book-manifest.json",
     "pdf_sha256": "a3bd7e9fb4982e5fd63d07b301a3dfa7152b1d64dd7c744c9fcf4ceebaa422c8",
-    "manifest_sha256": "b3bb33c08c8cb2520f95c95a15f05812f068ee06be01e3252e0883d4d4c493a4",
+    "manifest_sha256": "d1d2fd48d24902c6b2a39cd792573a450e31d6ee3799af960a21e3a42beabbc8",
     "size_bytes": 12780003,
     "pages": 412,
     "page_size_name": "A4",
@@ -18,7 +18,7 @@
     "pdf_version": "1.4",
     "tagged": true,
     "source_ref": "main",
-    "source_digest": "915fba06a1251ae0c0397da7964e047b109a40e3d01731e1b71aecda54549322",
+    "source_digest": "2ac5789c477adf2af70394bf5e6e6f43eaf836f58c7fbca3a55b7b9d8f6d8238",
     "version": "0.3.0"
   },
   "tools": {

--- a/scripts/github-pages.test.mjs
+++ b/scripts/github-pages.test.mjs
@@ -1,5 +1,8 @@
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { createServer as createTcpServer } from "node:net";
+import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
@@ -8,6 +11,13 @@ import {
   encodePortalFragment,
 } from "../app/lib/portal-fragment.mjs";
 import { publication } from "../app/lib/publication.mjs";
+import {
+  connectCdp,
+  devtoolsPage,
+  firstExistingChromium,
+  stopProcess,
+  waitForUrl,
+} from "./lib/chromium-cdp.mjs";
 import {
   decodeBasicHtmlEntitiesOnce,
   stripHtmlTagSyntax,
@@ -22,6 +32,317 @@ const repositoryRoot = path.resolve(
 
 async function source(relative) {
   return readFile(path.join(repositoryRoot, relative), "utf8");
+}
+
+async function reserveLocalPort() {
+  const server = createTcpServer();
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  assert.equal(typeof address, "object");
+  const port = address.port;
+  await new Promise((resolve, reject) => server.close((error) => (
+    error ? reject(error) : resolve()
+  )));
+  return port;
+}
+
+async function evaluateInBrowser(cdp, expression) {
+  const evaluation = await cdp.send("Runtime.evaluate", {
+    expression,
+    returnByValue: true,
+  });
+  if (evaluation.exceptionDetails) {
+    assert.fail(`Browser evaluation failed: ${JSON.stringify(evaluation.exceptionDetails)}`);
+  }
+  return evaluation.result?.value;
+}
+
+async function waitForBrowserState(cdp, expression, accepts, label, timeoutMs = 30_000) {
+  const deadline = Date.now() + timeoutMs;
+  let snapshot;
+  while (Date.now() < deadline) {
+    snapshot = await evaluateInBrowser(cdp, expression);
+    if (accepts(snapshot)) return snapshot;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  assert.fail(`${label}: ${JSON.stringify(snapshot)}`);
+}
+
+const portalStateExpression = `(() => {
+  const title = document.getElementById("portal-reader-title");
+  const hashTarget = location.hash
+    ? document.getElementById(decodeURIComponent(location.hash.slice(1)))
+    : null;
+  const hashBounds = hashTarget?.getBoundingClientRect();
+  const documentLinks = [...document.querySelectorAll(".portal-document-list > a")];
+  return {
+    activeId: document.activeElement?.id ?? "",
+    activeTag: document.activeElement?.tagName ?? "",
+    articleTabIndex: document.getElementById("portal-reader")?.getAttribute("tabindex") ?? null,
+    currentLinks: documentLinks.filter((link) => link.getAttribute("aria-current") === "page").length,
+    documentLinkCount: documentLinks.length,
+    documentLinkTags: [...new Set(documentLinks.map((link) => link.tagName))],
+    hash: location.hash,
+    hashTargetTop: hashBounds?.top ?? null,
+    hashTargetVisible: Boolean(hashBounds && hashBounds.bottom > 0 && hashBounds.top < innerHeight),
+    pathname: location.pathname,
+    readerPresent: Boolean(document.getElementById("portal-reader")),
+    titleTabIndex: title?.getAttribute("tabindex") ?? null,
+    titleText: title?.textContent?.trim() ?? "",
+  };
+})()`;
+
+const portalPagesBasePath = "/20-watts-was-enough/";
+
+async function withPortalBrowser(run) {
+  const browser = await firstExistingChromium();
+  const debugPort = await reserveLocalPort();
+  const serverPort = await reserveLocalPort();
+  const profile = await mkdtemp(path.join(os.tmpdir(), "20w-portal-routing-"));
+  let browserProcess;
+  let cdp;
+  let viteProcess;
+
+  try {
+    const portalUrl = `http://127.0.0.1:${serverPort}${portalPagesBasePath}`;
+    viteProcess = spawn(process.execPath, [
+      path.join(repositoryRoot, "node_modules", "vite", "bin", "vite.js"),
+      "--config",
+      path.join(repositoryRoot, "vite.pages.config.ts"),
+      "--host",
+      "127.0.0.1",
+      "--port",
+      String(serverPort),
+      "--strictPort",
+      "--force",
+      "--logLevel",
+      "silent",
+    ], {
+      cwd: repositoryRoot,
+      env: { ...process.env, PAGES_BASE_PATH: portalPagesBasePath },
+      stdio: "ignore",
+      windowsHide: true,
+    });
+    await waitForUrl(portalUrl, viteProcess);
+    browserProcess = spawn(browser, [
+      "--headless=new",
+      "--disable-gpu",
+      "--disable-extensions",
+      "--disable-background-networking",
+      "--disable-dev-shm-usage",
+      "--disable-features=NetworkServiceSandbox",
+      "--no-sandbox",
+      "--no-proxy-server",
+      "--allow-insecure-localhost",
+      "--no-first-run",
+      "--no-default-browser-check",
+      "--hide-scrollbars",
+      "--window-size=1440,900",
+      `--remote-debugging-port=${debugPort}`,
+      `--user-data-dir=${profile}`,
+      "about:blank",
+    ], { stdio: "ignore", windowsHide: true });
+
+    cdp = await connectCdp(await devtoolsPage(browserProcess, debugPort));
+    await cdp.send("Page.enable");
+    await cdp.send("Runtime.enable");
+    await cdp.send("Emulation.setDeviceMetricsOverride", {
+      width: 1440,
+      height: 900,
+      deviceScaleFactor: 1,
+      mobile: false,
+    });
+    await run(cdp, portalUrl);
+  } finally {
+    cdp?.socket.close();
+    await stopProcess(browserProcess);
+    await stopProcess(viteProcess);
+    await rm(profile, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+  }
+}
+
+async function openThesisRoute(cdp, portalUrl) {
+  const navigation = await cdp.send("Page.navigate", { url: portalUrl });
+  assert.equal(navigation.errorText, undefined);
+  await waitForBrowserState(
+    cdp,
+    `document.readyState === "complete" && Boolean(document.querySelector(".portal-action-primary"))`,
+    Boolean,
+    "portal overview did not render",
+  );
+  await cdp.send("Input.dispatchKeyEvent", {
+    type: "keyDown", key: "Tab", code: "Tab", windowsVirtualKeyCode: 9,
+  });
+  await cdp.send("Input.dispatchKeyEvent", {
+    type: "keyUp", key: "Tab", code: "Tab", windowsVirtualKeyCode: 9,
+  });
+  const focusRings = await evaluateInBrowser(cdp, `(() => (
+    ["portal-overview", "research-system", "library"].map((id) => {
+      const target = document.getElementById(id);
+      target.focus({ preventScroll: true });
+      const style = getComputedStyle(target);
+      return {
+        active: document.activeElement === target,
+        focusVisible: target.matches(":focus-visible"),
+        outlineOffset: style.outlineOffset,
+        outlineStyle: style.outlineStyle,
+        outlineWidth: style.outlineWidth,
+      };
+    })
+  ))()`);
+  assert.deepEqual(focusRings, Array.from({ length: 3 }, () => ({
+    active: true,
+    focusVisible: true,
+    outlineOffset: "3px",
+    outlineStyle: "solid",
+    outlineWidth: "3px",
+  })));
+  const thesis = await evaluateInBrowser(cdp, `(() => {
+    const link = document.querySelector(".portal-action-primary");
+    return { pathname: new URL(link.href).pathname };
+  })()`);
+  await evaluateInBrowser(cdp, `document.querySelector(".portal-action-primary").click()`);
+  const state = await waitForBrowserState(
+    cdp,
+    portalStateExpression,
+    (snapshot) => snapshot.pathname === thesis.pathname
+      && snapshot.activeId === "portal-reader-title"
+      && snapshot.documentLinkCount > 1,
+    "thesis route did not focus its title",
+  );
+  assert.equal(state.activeTag, "H1");
+  assert.equal(state.articleTabIndex, null);
+  assert.equal(state.titleTabIndex, "-1");
+  assert.deepEqual(state.documentLinkTags, ["A"]);
+  assert.equal(state.currentLinks, 1);
+  return { state, thesis };
+}
+
+async function openSidebarRoute(cdp) {
+  const route = await evaluateInBrowser(cdp, `(() => {
+    const link = [...document.querySelectorAll(".portal-document-list > a")]
+      .find((candidate) => candidate.getAttribute("aria-current") !== "page");
+    const probe = (options) => {
+      let preventedBeforeBrowserDefault = null;
+      window.addEventListener("click", (event) => {
+        preventedBeforeBrowserDefault = event.defaultPrevented;
+        event.preventDefault();
+      }, { once: true });
+      const event = new MouseEvent("click", {
+        bubbles: true, cancelable: true, ...options,
+      });
+      link.dispatchEvent(event);
+      return preventedBeforeBrowserDefault;
+    };
+    const modifierPrevented = ["altKey", "ctrlKey", "metaKey", "shiftKey"]
+      .map((modifier) => probe({ button: 0, [modifier]: true }));
+    return {
+      href: link.getAttribute("href"),
+      middlePrevented: probe({ button: 1 }),
+      modifierPrevented,
+      pathname: new URL(link.href).pathname,
+      title: link.querySelector("span").textContent.trim(),
+    };
+  })()`);
+  assert.equal(route.middlePrevented, false);
+  assert.deepEqual(route.modifierPrevented, [false, false, false, false]);
+  assert.ok(route.href);
+  const navigation = await evaluateInBrowser(cdp, `(() => {
+    const link = [...document.querySelectorAll(".portal-document-list > a")]
+      .find((candidate) => new URL(candidate.href).pathname === ${JSON.stringify(route.pathname)});
+    const event = new MouseEvent("click", { bubbles: true, button: 0, cancelable: true });
+    link.dispatchEvent(event);
+    return { prevented: event.defaultPrevented };
+  })()`);
+  assert.equal(navigation.prevented, true);
+  const state = await waitForBrowserState(
+    cdp,
+    portalStateExpression,
+    (snapshot) => snapshot.pathname === route.pathname
+      && snapshot.titleText === route.title
+      && snapshot.activeId === "portal-reader-title",
+    "sidebar route did not focus its title",
+  );
+  assert.equal(state.activeTag, "H1");
+  assert.equal(state.currentLinks, 1);
+  return route;
+}
+
+async function traverseDocumentHistory(cdp, thesis, thesisState, route) {
+  await evaluateInBrowser(cdp, "history.back()");
+  await waitForBrowserState(
+    cdp,
+    portalStateExpression,
+    (snapshot) => snapshot.pathname === thesis.pathname
+      && snapshot.titleText === thesisState.titleText
+      && snapshot.activeId === "portal-reader-title",
+    "back navigation did not restore and focus the thesis title",
+  );
+  await evaluateInBrowser(cdp, "history.forward()");
+  await waitForBrowserState(
+    cdp,
+    portalStateExpression,
+    (snapshot) => snapshot.pathname === route.pathname
+      && snapshot.titleText === route.title
+      && snapshot.activeId === "portal-reader-title",
+    "forward navigation did not restore and focus the document title",
+  );
+}
+
+async function openOutlineFragment(cdp) {
+  const target = await waitForBrowserState(
+    cdp,
+    `(() => {
+      const link = [...document.querySelectorAll(".portal-outline a")].find((candidate) => {
+        const heading = document.getElementById(candidate.hash.slice(1));
+        return heading && heading.getBoundingClientRect().height > 0;
+      });
+      return link ? { found: true, id: link.hash.slice(1) } : { found: false };
+    })()`,
+    (snapshot) => snapshot.found,
+    "document outline did not expose a visible heading target",
+  );
+  const navigation = await evaluateInBrowser(cdp, `(() => {
+    const link = [...document.querySelectorAll(".portal-outline a")]
+      .find((candidate) => candidate.hash === ${JSON.stringify(`#${target.id}`)});
+    const event = new MouseEvent("click", { bubbles: true, button: 0, cancelable: true });
+    link.dispatchEvent(event);
+    return { prevented: event.defaultPrevented };
+  })()`);
+  assert.equal(navigation.prevented, true);
+  const state = await waitForBrowserState(
+    cdp,
+    portalStateExpression,
+    (snapshot) => snapshot.hash === `#${target.id}`
+      && snapshot.activeId === target.id
+      && snapshot.hashTargetVisible,
+    "outline navigation did not preserve and focus its heading fragment",
+  );
+  assert.match(state.activeTag, /^H[2-6]$/u);
+  return target;
+}
+
+async function traverseFragmentHistory(cdp, thesis, route, target) {
+  for (const step of [
+    { direction: "back", hash: "", pathname: route.pathname, activeId: "portal-reader-title" },
+    { direction: "back", hash: "", pathname: thesis.pathname, activeId: "portal-reader-title" },
+    { direction: "forward", hash: "", pathname: route.pathname, activeId: "portal-reader-title" },
+    { direction: "forward", hash: `#${target.id}`, pathname: route.pathname, activeId: target.id },
+  ]) {
+    await evaluateInBrowser(cdp, `history.${step.direction}()`);
+    await waitForBrowserState(
+      cdp,
+      portalStateExpression,
+      (snapshot) => snapshot.pathname === step.pathname
+        && snapshot.hash === step.hash
+        && snapshot.activeId === step.activeId
+        && (!step.hash || snapshot.hashTargetVisible),
+      `${step.direction} navigation did not restore ${step.activeId}`,
+    );
+  }
 }
 
 function assertNoLegacyDeploymentHost(html, label) {
@@ -205,6 +526,9 @@ test("the portal keeps clean-route history and native Markdown links honest on t
   assert.doesNotMatch(portal, /ResizeObserver/);
   assert.match(portal, /readerLibraryRef/);
   assert.match(portal, /list\.scrollTop \+= activeRect\.top/);
+  assert.match(portal, /className="portal-document-list"[\s\S]*<a[\s\S]*href=\{portalDocumentLocation\(document\.path, assetBasePath\)\}/);
+  assert.match(portal, /aria-current=\{document\.path === selectedMetadata\.path \? "page" : undefined\}/);
+  assert.match(portal, /event\.button === 0[\s\S]*!event\.ctrlKey[\s\S]*!event\.metaKey/);
   assert.match(portal, /section heading match/);
   assert.match(portal, /Open \{step\.label\}/);
   assert.match(portal, /document\.getElementById\(targetId\)\?\.focus\(\)/);
@@ -249,6 +573,18 @@ test("the portal keeps clean-route history and native Markdown links honest on t
   }
 });
 
+test("portal document routes preserve native links and focus their destination headings", {
+  timeout: 120_000,
+}, async () => {
+  await withPortalBrowser(async (cdp, portalUrl) => {
+    const { state: thesisState, thesis } = await openThesisRoute(cdp, portalUrl);
+    const route = await openSidebarRoute(cdp);
+    await traverseDocumentHistory(cdp, thesis, thesisState, route);
+    const fragment = await openOutlineFragment(cdp);
+    await traverseFragmentHistory(cdp, thesis, route, fragment);
+  });
+});
+
 test("only genuinely overflowing Markdown tables become labelled keyboard regions", async () => {
   const markdown = await source("app/components/markdown-document.tsx");
 
@@ -268,7 +604,14 @@ test("focused portal documents have a coherent heading hierarchy", async () => {
     source("app/components/markdown-document.tsx"),
   ]);
 
-  assert.match(portal, /<h1 id="portal-reader-title">/);
+  assert.match(
+    portal,
+    /<h1 id="portal-reader-title" ref=\{readerTitleRef\} tabIndex=\{-1\}>/,
+  );
+  assert.doesNotMatch(
+    portal,
+    /<article[\s\S]{0,200}id="portal-reader"[\s\S]{0,200}tabIndex=\{-1\}/,
+  );
   assert.match(portal, /headingOffset=\{1\}/);
   assert.match(markdown, /headingOffset\?: number/);
   assert.match(markdown, /h1: shiftedHeading\(1, headingOffset\)/);


### PR DESCRIPTION
## Summary

- make portal document entries native links while retaining client-side navigation for ordinary clicks
- focus the destination title or explicit fragment across direct navigation and history traversal
- move the skip target to the current document title and preserve modifier/middle-click browser behavior
- add real-Chromium coverage and classify the test in the site CI lane

## Verification

- `npm run test:github-pages` — 52/52 plus build validator
- `npm run test:site` — 63/63 (implementation proof before base-only rebase)
- focused Chromium navigation test — 16/16
- `npm run test:release` — 35/35
- `npm run typecheck`
- `npm run lint`
- `npm run validate:tooling`
- `go -C tooling test ./internal/ciplan/...`
- source-bound PDF manifest and semantic baseline agree; PDF bytes remain unchanged

This is an accessibility engineering repair, not a WCAG conformance claim.

Closes #46