### PR TITLE
fix(release): bind PDF rendering to verified commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,8 +125,9 @@ jobs:
           driver-opts: image=moby/buildkit:v0.32.2@sha256:28a898719c18a33f4e8000685287fa36fd0dd9560c6440227d3a732d79bb41d8
       - name: Render the immutable tag-bound book
         env:
+          RELEASE_COMMIT: ${{ steps.release-ref.outputs.commit }}
           RELEASE_TAG: ${{ steps.release-ref.outputs.tag }}
-        run: npm run generate:book-pdf -- --ref "$RELEASE_TAG"
+        run: npm run generate:book-pdf -- --ref "$RELEASE_TAG" --revision "$RELEASE_COMMIT"
       - name: Build the native 20w convenience binary
         env:
           RELEASE_COMMIT: ${{ steps.release-ref.outputs.commit }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,6 +214,11 @@ the exact diff; this file records why the project changed.
 
 ### Fixed
 
+- Release PDF rendering now receives the exact commit produced by the tag
+  preflight and refuses a checkout at any other revision. Policy validation
+  requires the unique reviewed step, its exact tag-and-commit command and only
+  the two verified outputs; missing, ambient, reordered, conditional or
+  failure-tolerant variants fail closed.
 - The locked browser-targeting toolchain now uses Browserslist 4.28.8, closing
   the two high-severity unbounded-memory advisories reported by Dependabot and
   OpenSSF Scorecard. The regenerated book manifest and semantic sentinel bind

--- a/public/downloads/book-manifest.json
+++ b/public/downloads/book-manifest.json
@@ -4,7 +4,7 @@
   "version": "0.3.0",
   "source_ref": "main",
   "pdf": "public/downloads/20-watts-was-enough-full-concept-book.pdf",
-  "source_digest": "70569f9b5ca896635cc4ac8b7321324a7882e7bbfe2e1113bef45f60761cf3a0",
+  "source_digest": "8c3e8f1dde14fdeb222d426d781f8778cdafa617f05bbdec1fbc0c32385d8c94",
   "source_files": [
     "app/book-content.ts",
     "app/components/book-edition.tsx",

--- a/scripts/book-pdf-semantic-baseline.json
+++ b/scripts/book-pdf-semantic-baseline.json
@@ -7,7 +7,7 @@
     "pdf": "public/downloads/20-watts-was-enough-full-concept-book.pdf",
     "manifest": "public/downloads/book-manifest.json",
     "pdf_sha256": "a3bd7e9fb4982e5fd63d07b301a3dfa7152b1d64dd7c744c9fcf4ceebaa422c8",
-    "manifest_sha256": "666c06fdd63dbdd5f927f143a39d5dcc2423beea9dd654a5b871c45eac8431c7",
+    "manifest_sha256": "705feb546a431d04bbaeb18586255c8507abf2ca0a223511ccdb5d1d19869993",
     "size_bytes": 12780003,
     "pages": 412,
     "page_size_name": "A4",
@@ -18,7 +18,7 @@
     "pdf_version": "1.4",
     "tagged": true,
     "source_ref": "main",
-    "source_digest": "70569f9b5ca896635cc4ac8b7321324a7882e7bbfe2e1113bef45f60761cf3a0",
+    "source_digest": "8c3e8f1dde14fdeb222d426d781f8778cdafa617f05bbdec1fbc0c32385d8c94",
     "version": "0.3.0"
   },
   "tools": {

--- a/scripts/engineering-policy.test.mjs
+++ b/scripts/engineering-policy.test.mjs
@@ -1626,6 +1626,58 @@ test("release policy binds native binaries and ingests them after the PDF render
   ));
 });
 
+test("release PDF rendering binds only the exact verified tag and commit", async (t) => {
+  const diagnostic = ".github/workflows/release.yml: release PDF render must use its exact reviewed step, verified tag and commit outputs, and bounded command without a failure bypass";
+  const renderStep = (subject) => subject.jobs.verify.steps.find((step) => (
+    step.name === "Render the immutable tag-bound book"
+  ));
+  const cases = {
+    "missing revision": (subject) => {
+      renderStep(subject).run = 'npm run generate:book-pdf -- --ref "$RELEASE_TAG"';
+    },
+    "ambient commit": (subject) => {
+      renderStep(subject).env.RELEASE_COMMIT = "${{ github.sha }}";
+    },
+    "additional ambient input": (subject) => {
+      renderStep(subject).env.GITHUB_SHA = "${{ github.sha }}";
+    },
+    "reordered command": (subject) => {
+      renderStep(subject).run = 'npm run generate:book-pdf -- --revision "$RELEASE_COMMIT" --ref "$RELEASE_TAG"';
+    },
+    "renamed step": (subject) => {
+      renderStep(subject).name = "Render release PDF";
+    },
+    "continue-on-error bypass": (subject) => {
+      renderStep(subject)["continue-on-error"] = true;
+    },
+    "conditional bypass": (subject) => {
+      renderStep(subject).if = "${{ always() }}";
+    },
+    "render before Buildx": (subject) => {
+      const steps = subject.jobs.verify.steps;
+      const renderIndex = steps.findIndex((step) => step.name === "Render the immutable tag-bound book");
+      const [render] = steps.splice(renderIndex, 1);
+      const setupIndex = steps.findIndex((step) => step.name === "Set up the locked PDF Docker Buildx client");
+      steps.splice(setupIndex, 0, render);
+    },
+  };
+
+  for (const [name, mutate] of Object.entries(cases)) {
+    await t.test(name, () => {
+      const subject = structuredClone(workflow("release"));
+      mutate(subject);
+      const findings = validateReleaseWorkflowObject(subject);
+      if (name === "render before Buildx") {
+        assert.ok(findings.includes(
+          ".github/workflows/release.yml: tag-bound PDF rendering must provision the locked Buildx client and BuildKit image after the source gate",
+        ));
+      } else {
+        assert.ok(findings.includes(diagnostic), JSON.stringify(findings));
+      }
+    });
+  }
+});
+
 test("release publication preserves generated notes before appending image identities", () => {
   assertWorkflowTamper(
     "release",

--- a/scripts/validate-engineering-policy.mjs
+++ b/scripts/validate-engineering-policy.mjs
@@ -1814,6 +1814,25 @@ function findRunStepIndex(steps, fragments) {
   ));
 }
 
+const releasePDFRenderStepName = "Render the immutable tag-bound book";
+const releasePDFRenderCommand = 'npm run generate:book-pdf -- --ref "$RELEASE_TAG" --revision "$RELEASE_COMMIT"';
+
+function releasePDFRenderStepIndex(steps) {
+  const named = steps
+    .map((step, index) => ({ index, step }))
+    .filter(({ step }) => step?.name === releasePDFRenderStepName);
+  if (named.length !== 1) return -1;
+  const { index, step } = named[0];
+  return step?.run?.trim() === releasePDFRenderCommand
+    && step?.if === undefined
+    && continueOnErrorIsDisabled(step)
+    && Object.keys(step?.env ?? {}).length === 2
+    && step.env.RELEASE_COMMIT === "${{ steps.release-ref.outputs.commit }}"
+    && step.env.RELEASE_TAG === "${{ steps.release-ref.outputs.tag }}"
+    ? index
+    : -1;
+}
+
 function releaseVerificationStepIndices(steps) {
   return {
     binary: findRunStepIndex(steps, ["go -C tooling run ./cmd/build-release"]),
@@ -1822,7 +1841,7 @@ function releaseVerificationStepIndices(steps) {
       "experiment release-plan --root .. --json",
     ]),
     prepare: findRunStepIndex(steps, ['npm run prepare:release -- --tag "$RELEASE_TAG"']),
-    render: findRunStepIndex(steps, ['npm run generate:book-pdf -- --ref "$RELEASE_TAG"']),
+    render: releasePDFRenderStepIndex(steps),
   };
 }
 
@@ -1831,6 +1850,11 @@ function validateReleasePDFBuilder(steps, indices, relativePath) {
   const setup = findStepByName(steps, "Set up the locked PDF Docker Buildx client");
   const setupPosition = stepPosition(steps, "Set up the locked PDF Docker Buildx client");
   const gatePosition = stepPosition(steps, "Run the full repository gate");
+  recordExpectation(
+    findings,
+    indices.render >= 0,
+    `${relativePath}: release PDF render must use its exact reviewed step, verified tag and commit outputs, and bounded command without a failure bypass`,
+  );
   recordExpectation(
     findings,
     actionUses(setup, "docker/setup-buildx-action")

--- a/tooling/cmd/20w/main.go
+++ b/tooling/cmd/20w/main.go
@@ -49,7 +49,7 @@ func usage(writer io.Writer) {
 	fmt.Fprintln(writer, "  20w experiment validate [--root <repository>]")
 	fmt.Fprintln(writer, "  20w experiment release-plan [--root <repository>] [--json]")
 	fmt.Fprintln(writer, "  20w experiment package-node-image --artifact <id> --output <directory> [--root <repository>]")
-	fmt.Fprintln(writer, "  20w publication render-pdf [--root <repository>] [--ref main|vMAJOR.MINOR.PATCH] [--check]")
+	fmt.Fprintln(writer, "  20w publication render-pdf [--root <repository>] [--ref main|vMAJOR.MINOR.PATCH] [--revision <commit>] [--check]")
 	fmt.Fprintln(writer, "  20w publication verify-pdf-tools [--root <repository>]")
 	fmt.Fprintln(writer, "  20w publication verify-pdf-reproducibility --receipt <new.json> [--root <repository>] [--ref main|vMAJOR.MINOR.PATCH]")
 	fmt.Fprintln(writer, "  20w publication verify-public-transport [--root <repository>] [--check]")
@@ -374,11 +374,16 @@ func runPublicationRenderPDF(arguments []string, stdout, stderr io.Writer) int {
 	flags.SetOutput(stderr)
 	root := flags.String("root", ".", "repository root")
 	sourceRef := flags.String("ref", "main", "book source ref")
+	sourceRevision := flags.String("revision", "", "exact lowercase 40-character source commit")
 	check := flags.Bool("check", false, "validate the renderer lock without Docker or network access")
 	if err := flags.Parse(arguments); err != nil || flags.NArg() != 0 {
 		return 2
 	}
 	if err := pdfrender.ValidateSourceRef(*sourceRef); err != nil {
+		fmt.Fprintf(stderr, "publication render-pdf: %v\n", err)
+		return 2
+	}
+	if err := pdfrender.ValidateSourceRevision(*sourceRef, *sourceRevision); err != nil {
 		fmt.Fprintf(stderr, "publication render-pdf: %v\n", err)
 		return 2
 	}
@@ -402,6 +407,7 @@ func runPublicationRenderPDF(arguments []string, stdout, stderr io.Writer) int {
 	result, err := pdfrender.Render(context.Background(), pdfrender.Options{
 		RepositoryRoot: *root,
 		SourceRef:      *sourceRef,
+		SourceRevision: *sourceRevision,
 	})
 	if err != nil {
 		fmt.Fprintf(stderr, "Render PDF publication: %v\n", err)

--- a/tooling/cmd/20w/main_test.go
+++ b/tooling/cmd/20w/main_test.go
@@ -129,6 +129,25 @@ func TestRunPublicationRenderPDFRejectsAnUnboundedRefAsUsage(t *testing.T) {
 	}
 }
 
+func TestRunPublicationRenderPDFRequiresAnExactRevisionForATag(t *testing.T) {
+	t.Parallel()
+	for name, arguments := range map[string][]string{
+		"missing":   {"publication", "render-pdf", "--ref", "v1.2.3", "--check"},
+		"malformed": {"publication", "render-pdf", "--ref", "v1.2.3", "--revision", "HEAD", "--check"},
+	} {
+		name, arguments := name, arguments
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			exitCode := run(arguments, &stdout, &stderr)
+			if exitCode != 2 || !strings.Contains(stderr.String(), "source revision") {
+				t.Fatalf("run() exit/stderr = %d/%q, want source-revision usage failure", exitCode, stderr.String())
+			}
+		})
+	}
+}
+
 func TestRunPackageNodeImageRejectsUnsupportedArtifact(t *testing.T) {
 	t.Parallel()
 	var stdout bytes.Buffer

--- a/tooling/internal/pdfrender/command.go
+++ b/tooling/internal/pdfrender/command.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 	"sync"
@@ -14,6 +15,7 @@ import (
 const (
 	maximumDiagnosticBytes = 8 * 1024
 	maximumWaitDelay       = 5 * time.Second
+	sourceRevisionTimeout  = 15 * time.Second
 )
 
 type commandRequest struct {
@@ -29,6 +31,71 @@ type commandExecutor interface {
 }
 
 type localCommandExecutor struct{}
+
+// verifySourceRevision rejects a tag-bound render unless the checked-out
+// repository HEAD is the exact commit already verified by release preflight.
+func verifySourceRevision(ctx context.Context, root, sourceRef, expected string) error {
+	if err := ValidateSourceRevision(sourceRef, expected); err != nil {
+		return err
+	}
+	if expected == "" {
+		return nil
+	}
+	gitExecutable, err := exec.LookPath("git")
+	if err != nil {
+		return errors.New("locate Git executable for PDF source revision")
+	}
+	commandContext, cancel := context.WithTimeout(ctx, sourceRevisionTimeout)
+	defer cancel()
+	standardOutput := &boundedOutput{limit: 128}
+	standardError := &boundedOutput{limit: maximumDiagnosticBytes}
+	command := exec.CommandContext(
+		commandContext,
+		gitExecutable,
+		"-C", root,
+		"rev-parse", "--verify", "HEAD^{commit}",
+	)
+	command.Env = boundedGitEnvironment()
+	command.Stdout = standardOutput
+	command.Stderr = standardError
+	command.WaitDelay = maximumWaitDelay
+	runError := command.Run()
+	resolvedBytes, outputExceeded := standardOutput.result()
+	diagnostic, diagnosticExceeded := standardError.result()
+	if commandContext.Err() != nil {
+		return fmt.Errorf("resolve PDF source revision: %w", commandContext.Err())
+	}
+	if outputExceeded || diagnosticExceeded {
+		return errors.New("resolve PDF source revision: subprocess output exceeded its bound")
+	}
+	if runError != nil {
+		return commandFailure("resolve PDF source revision", runError, diagnostic)
+	}
+	resolved := strings.TrimSpace(string(resolvedBytes))
+	if !gitRevisionPattern.MatchString(resolved) {
+		return errors.New("resolved PDF source revision is not a lowercase 40-character Git identity")
+	}
+	if resolved != expected {
+		return fmt.Errorf("PDF source revision is %s, not verified commit %s", resolved, expected)
+	}
+	return nil
+}
+
+func boundedGitEnvironment() []string {
+	environment := []string{
+		"GIT_CONFIG_GLOBAL=" + os.DevNull,
+		"GIT_CONFIG_NOSYSTEM=1",
+		"GIT_OPTIONAL_LOCKS=0",
+		"LANG=C",
+		"LC_ALL=C",
+	}
+	for _, name := range []string{"PATH", "PATHEXT", "SYSTEMROOT", "TEMP", "TMP", "TMPDIR", "WINDIR"} {
+		if value, present := os.LookupEnv(name); present {
+			environment = append(environment, name+"="+value)
+		}
+	}
+	return environment
+}
 
 type boundedOutput struct {
 	mutex    sync.Mutex

--- a/tooling/internal/pdfrender/render.go
+++ b/tooling/internal/pdfrender/render.go
@@ -25,6 +25,7 @@ var (
 type Options struct {
 	RepositoryRoot string
 	SourceRef      string
+	SourceRevision string
 }
 
 // Result records the exact local image and checked-in lock used for rendering.
@@ -40,6 +41,9 @@ func Render(ctx context.Context, options Options) (Result, error) {
 	if err != nil {
 		return Result{}, err
 	}
+	if err := verifySourceRevision(ctx, configuration.RepositoryRoot, options.SourceRef, options.SourceRevision); err != nil {
+		return Result{}, err
+	}
 	return renderWithDependencies(
 		ctx,
 		configuration,
@@ -53,6 +57,21 @@ func Render(ctx context.Context, options Options) (Result, error) {
 func ValidateSourceRef(sourceRef string) error {
 	if !sourceRefPattern.MatchString(sourceRef) {
 		return errors.New("source ref must be main or vMAJOR.MINOR.PATCH")
+	}
+	return nil
+}
+
+// ValidateSourceRevision requires immutable tag renders to name the exact
+// lowercase Git commit already verified by the release preflight.
+func ValidateSourceRevision(sourceRef, sourceRevision string) error {
+	if err := ValidateSourceRef(sourceRef); err != nil {
+		return err
+	}
+	if sourceRef != "main" && sourceRevision == "" {
+		return errors.New("tag-bound rendering requires an exact source revision")
+	}
+	if sourceRevision != "" && !gitRevisionPattern.MatchString(sourceRevision) {
+		return errors.New("source revision must be a lowercase 40-character Git identity")
 	}
 	return nil
 }

--- a/tooling/internal/pdfrender/render_test.go
+++ b/tooling/internal/pdfrender/render_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -82,6 +83,55 @@ func TestRenderPlanUsesTheExactImageAndHardenedContainer(t *testing.T) {
 	if strings.Contains(strings.Join(run, "\n"), "node_modules/.vite") {
 		t.Fatalf("run arguments depend on pre-existing Vite cache mountpoints: %v", run)
 	}
+}
+
+func TestSourceRevisionBindingRejectsMissingMalformedAndWrongCommits(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	runRenderTestGit(t, root, "init", "--quiet")
+	if err := os.WriteFile(filepath.Join(root, "source.txt"), []byte("source\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runRenderTestGit(t, root, "add", "source.txt")
+	runRenderTestGit(
+		t, root,
+		"-c", "user.name=PDF test", "-c", "user.email=pdf-test@example.invalid",
+		"commit", "--quiet", "-m", "source",
+	)
+	head := strings.TrimSpace(runRenderTestGit(t, root, "rev-parse", "HEAD"))
+	if err := verifySourceRevision(context.Background(), root, "v1.2.3", head); err != nil {
+		t.Fatalf("verifySourceRevision() valid error = %v", err)
+	}
+	for name, revision := range map[string]string{
+		"missing":   "",
+		"malformed": "HEAD",
+		"wrong":     strings.Repeat("f", 40),
+	} {
+		name, revision := name, revision
+		t.Run(name, func(t *testing.T) {
+			err := verifySourceRevision(context.Background(), root, "v1.2.3", revision)
+			if err == nil {
+				t.Fatal("verifySourceRevision() unexpectedly accepted an invalid binding")
+			}
+		})
+	}
+}
+
+func runRenderTestGit(t *testing.T, root string, arguments ...string) string {
+	t.Helper()
+	commandContext, cancel := context.WithTimeout(context.Background(), sourceRevisionTimeout)
+	defer cancel()
+	command := exec.CommandContext(commandContext, "git", append([]string{"-C", root}, arguments...)...)
+	command.Env = boundedGitEnvironment()
+	command.WaitDelay = maximumWaitDelay
+	output, err := command.CombinedOutput()
+	if commandContext.Err() != nil {
+		t.Fatalf("git %v timed out: %v", arguments, commandContext.Err())
+	}
+	if err != nil {
+		t.Fatalf("git %v: %v: %s", arguments, err, output)
+	}
+	return string(output)
 }
 
 func TestRenderRejectsTimestampRewriteWarnings(t *testing.T) {


### PR DESCRIPTION
## Summary

- pass the exact commit produced by release tag preflight into the PDF renderer
- reject tag-bound rendering unless the checked-out repository HEAD matches that verified commit
- require one exact, fail-closed release render step with only verified tag and commit inputs
- add hostile policy and Go tests for missing, ambient, malformed, reordered, conditional, and mismatched identities

## Verification

- `npm run test:policy` — 68/68
- `npm run test:release` — 41/41
- `go test ./...`
- `go test -race ./internal/pdfrender ./cmd/20w`
- `npm run check:prose`
- `npm run validate:book-pdf` — 170 source files
- full aggregate and two-render byte reproducibility passed on the identical pre-rebase tree; the parent-only rebase preserved tree `36e5a61e10a10ad705129524fc63b291d37af99b`
- independent AGY-hosted `gpt-oss-120b-medium` hostile review — no blockers

This enforces the existing publication authority boundary. It does not make a release or scientific-result claim.

Closes #55