### PR TITLE
fix(github): recover metadata synchronization

### DIFF
--- a/.github/issue-milestones.json
+++ b/.github/issue-milestones.json
@@ -22,6 +22,7 @@
     { "issue": 52, "milestone": "M0" },
     { "issue": 53, "milestone": "M0" },
     { "issue": 54, "milestone": "M0" },
-    { "issue": 55, "milestone": "M0" }
+    { "issue": 55, "milestone": "M0" },
+    { "issue": 61, "milestone": "M0" }
   ]
 }

--- a/.github/workflows/sync-repository-metadata.yml
+++ b/.github/workflows/sync-repository-metadata.yml
@@ -15,6 +15,7 @@ on:
       - tooling/cmd/20w/github_pr_metadata.go
       - tooling/cmd/20w/main.go
       - tooling/internal/githublabels/**
+      - tooling/internal/githubapi/**
       - tooling/internal/githubissuemilestones/**
       - tooling/internal/githubissuelifecycle/**
       - tooling/internal/githubmilestones/**
@@ -38,7 +39,7 @@ jobs:
     permissions:
       contents: read
       issues: write
-      pull-requests: read
+      pull-requests: write
     steps:
       - name: Check out canonical main
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -254,6 +254,11 @@ the exact diff; this file records why the project changed.
 
 ### Fixed
 
+- Trusted repository-metadata repair now has the pull-request write permission
+  required to remove stale lifecycle labels from merged pull requests. Shared
+  GitHub API reads retry only bounded transport failures and 500/502/503/504
+  responses; writes remain single-attempt so an uncertain mutation is never
+  replayed blindly.
 - Release PDF rendering now receives the exact commit produced by the tag
   preflight and refuses a checkout at any other revision. Policy validation
   requires the unique reviewed step, its exact tag-and-commit command and only

--- a/public/downloads/book-manifest.json
+++ b/public/downloads/book-manifest.json
@@ -4,7 +4,7 @@
   "version": "0.3.0",
   "source_ref": "main",
   "pdf": "public/downloads/20-watts-was-enough-full-concept-book.pdf",
-  "source_digest": "ccb8b35726be4cdb87cebc88790ea8b65cc1c46f4ee596658d1e2cfef3775460",
+  "source_digest": "9bb9f9b2c478d3254e99fb6c1a8c79b49fea4440ea6fd11553a12277cb6b81a1",
   "source_files": [
     "app/book-content.ts",
     "app/components/book-edition.tsx",
@@ -152,6 +152,7 @@
     "tooling/internal/docscheck/mermaid-duplicate-baseline.json",
     "tooling/internal/docscheck/mermaid.go",
     "tooling/internal/experiment/catalog.go",
+    "tooling/internal/githubapi/client.go",
     "tooling/internal/githublabels/labels.go",
     "tooling/internal/nodeimage/package.go",
     "tooling/internal/ocimanifest/manifest.go",

--- a/scripts/book-pdf-semantic-baseline.json
+++ b/scripts/book-pdf-semantic-baseline.json
@@ -7,7 +7,7 @@
     "pdf": "public/downloads/20-watts-was-enough-full-concept-book.pdf",
     "manifest": "public/downloads/book-manifest.json",
     "pdf_sha256": "c2620fe99c23cea354584d136013c3fbc9d6134404b1cd3109bb1b158ec74218",
-    "manifest_sha256": "79e53a0ef220a49859e45aeae15b0f5f16735cb4874e248497e2040b8c565cd9",
+    "manifest_sha256": "3f9be74186d325b9f2dd76fec64683a8a649445d7482429b33daec3a0fb4510d",
     "size_bytes": 12779448,
     "pages": 412,
     "page_size_name": "A4",
@@ -18,7 +18,7 @@
     "pdf_version": "1.4",
     "tagged": true,
     "source_ref": "main",
-    "source_digest": "ccb8b35726be4cdb87cebc88790ea8b65cc1c46f4ee596658d1e2cfef3775460",
+    "source_digest": "9bb9f9b2c478d3254e99fb6c1a8c79b49fea4440ea6fd11553a12277cb6b81a1",
     "version": "0.3.0"
   },
   "tools": {

--- a/scripts/book-route.test.mjs
+++ b/scripts/book-route.test.mjs
@@ -203,6 +203,7 @@ test("the full-book source identity includes the locked renderer dependency grap
     "tooling/internal/docscheck/mermaid-duplicate-baseline.json",
     "tooling/internal/docscheck/mermaid.go",
     "tooling/internal/experiment/catalog.go",
+    "tooling/internal/githubapi/client.go",
     "tooling/internal/githublabels/labels.go",
     "tooling/internal/nodeimage/package.go",
     "tooling/internal/ocimanifest/manifest.go",

--- a/scripts/book-source.mjs
+++ b/scripts/book-source.mjs
@@ -93,6 +93,7 @@ export async function bookSourceFiles(projectRoot) {
     "tooling/internal/docscheck/mermaid-duplicate-baseline.json",
     "tooling/internal/docscheck/mermaid.go",
     "tooling/internal/experiment/catalog.go",
+    "tooling/internal/githubapi/client.go",
     "tooling/internal/githublabels/labels.go",
     "tooling/internal/nodeimage/package.go",
     "tooling/internal/ocimanifest/manifest.go",

--- a/scripts/engineering-policy.test.mjs
+++ b/scripts/engineering-policy.test.mjs
@@ -1340,13 +1340,13 @@ test("repository metadata synchronization is manifest-triggered and least-privil
   const tampered = structuredClone(valid);
   tampered.jobs.sync.permissions.contents = "write";
   assert.ok(validateRepositoryMetadataSyncWorkflowObject(tampered).includes(
-    ".github/workflows/sync-repository-metadata.yml: repository metadata synchronization needs only contents:read, issues:write, and pull-requests:read",
+    ".github/workflows/sync-repository-metadata.yml: repository metadata synchronization needs only contents:read, issues:write, and pull-requests:write",
   ));
 
-  const unreadablePullRequests = structuredClone(valid);
-  delete unreadablePullRequests.jobs.sync.permissions["pull-requests"];
-  assert.ok(validateRepositoryMetadataSyncWorkflowObject(unreadablePullRequests).includes(
-    ".github/workflows/sync-repository-metadata.yml: repository metadata synchronization needs only contents:read, issues:write, and pull-requests:read",
+  const readOnlyPullRequests = structuredClone(valid);
+  readOnlyPullRequests.jobs.sync.permissions["pull-requests"] = "read";
+  assert.ok(validateRepositoryMetadataSyncWorkflowObject(readOnlyPullRequests).includes(
+    ".github/workflows/sync-repository-metadata.yml: repository metadata synchronization needs only contents:read, issues:write, and pull-requests:write",
   ));
 
   for (const mutate of [
@@ -1382,7 +1382,7 @@ test("repository metadata synchronization is manifest-triggered and least-privil
     (entry) => entry !== ".github/issue-milestones.json",
   );
   assert.ok(validateRepositoryMetadataSyncWorkflowObject(incompleteTrigger).includes(
-    ".github/workflows/sync-repository-metadata.yml: repository metadata synchronization must run for issue close/reopen events, all three canonical manifests and both lifecycle sources on main, and manual repair",
+    ".github/workflows/sync-repository-metadata.yml: repository metadata synchronization must run for issue close/reopen events, all three canonical manifests and every owned metadata source on main, and manual repair",
   ));
 
   const missingLifecycleSource = structuredClone(valid);
@@ -1390,7 +1390,7 @@ test("repository metadata synchronization is manifest-triggered and least-privil
     (entry) => entry !== "tooling/internal/githubissuelifecycle/**",
   );
   assert.ok(validateRepositoryMetadataSyncWorkflowObject(missingLifecycleSource).includes(
-    ".github/workflows/sync-repository-metadata.yml: repository metadata synchronization must run for issue close/reopen events, all three canonical manifests and both lifecycle sources on main, and manual repair",
+    ".github/workflows/sync-repository-metadata.yml: repository metadata synchronization must run for issue close/reopen events, all three canonical manifests and every owned metadata source on main, and manual repair",
   ));
 
   const missingPullRequestLifecycleSource = structuredClone(valid);
@@ -1398,13 +1398,21 @@ test("repository metadata synchronization is manifest-triggered and least-privil
     (entry) => entry !== "tooling/internal/githubprmetadata/**",
   );
   assert.ok(validateRepositoryMetadataSyncWorkflowObject(missingPullRequestLifecycleSource).includes(
-    ".github/workflows/sync-repository-metadata.yml: repository metadata synchronization must run for issue close/reopen events, all three canonical manifests and both lifecycle sources on main, and manual repair",
+    ".github/workflows/sync-repository-metadata.yml: repository metadata synchronization must run for issue close/reopen events, all three canonical manifests and every owned metadata source on main, and manual repair",
+  ));
+
+  const missingRetrySource = structuredClone(valid);
+  missingRetrySource.on.push.paths = missingRetrySource.on.push.paths.filter(
+    (entry) => entry !== "tooling/internal/githubapi/**",
+  );
+  assert.ok(validateRepositoryMetadataSyncWorkflowObject(missingRetrySource).includes(
+    ".github/workflows/sync-repository-metadata.yml: repository metadata synchronization must run for issue close/reopen events, all three canonical manifests and every owned metadata source on main, and manual repair",
   ));
 
   const missingLifecycleTrigger = structuredClone(valid);
   delete missingLifecycleTrigger.on.issues;
   assert.ok(validateRepositoryMetadataSyncWorkflowObject(missingLifecycleTrigger).includes(
-    ".github/workflows/sync-repository-metadata.yml: repository metadata synchronization must run for issue close/reopen events, all three canonical manifests and both lifecycle sources on main, and manual repair",
+    ".github/workflows/sync-repository-metadata.yml: repository metadata synchronization must run for issue close/reopen events, all three canonical manifests and every owned metadata source on main, and manual repair",
   ));
 
   const unboundLifecycle = structuredClone(valid);

--- a/scripts/validate-engineering-policy.mjs
+++ b/scripts/validate-engineering-policy.mjs
@@ -1635,6 +1635,7 @@ function repositoryMetadataTriggerIsExact(trigger) {
     && arrayIncludes(push?.paths, ".github/issue-milestones.json")
     && arrayIncludes(push?.paths, "tooling/cmd/20w/github_issue_lifecycle.go")
     && arrayIncludes(push?.paths, "tooling/cmd/20w/github_pr_metadata.go")
+    && arrayIncludes(push?.paths, "tooling/internal/githubapi/**")
     && arrayIncludes(push?.paths, "tooling/internal/githubissuelifecycle/**")
     && arrayIncludes(push?.paths, "tooling/internal/githubprmetadata/**")
     && Object.prototype.hasOwnProperty.call(trigger ?? {}, "workflow_dispatch")
@@ -1644,7 +1645,7 @@ function repositoryMetadataTriggerIsExact(trigger) {
 function repositoryMetadataPermissionsAreExact(job) {
   return (
     propertiesMatch(job?.permissions, {
-      contents: "read", issues: "write", "pull-requests": "read",
+      contents: "read", issues: "write", "pull-requests": "write",
     })
     && Object.keys(job?.permissions ?? {}).length === 3
   );
@@ -1708,11 +1709,11 @@ export function validateRepositoryMetadataSyncWorkflowObject(
   const findings = validateGoRuntimeWorkflowObject(workflow, "sync", relativePath);
   const trigger = workflow?.on;
   if (!repositoryMetadataTriggerIsExact(trigger)) {
-    findings.push(`${relativePath}: repository metadata synchronization must run for issue close/reopen events, all three canonical manifests and both lifecycle sources on main, and manual repair`);
+    findings.push(`${relativePath}: repository metadata synchronization must run for issue close/reopen events, all three canonical manifests and every owned metadata source on main, and manual repair`);
   }
   const job = workflow?.jobs?.sync;
   if (!repositoryMetadataPermissionsAreExact(job)) {
-    findings.push(`${relativePath}: repository metadata synchronization needs only contents:read, issues:write, and pull-requests:read`);
+    findings.push(`${relativePath}: repository metadata synchronization needs only contents:read, issues:write, and pull-requests:write`);
   }
   if (!repositoryMetadataExecutionIsBounded(workflow, job)) {
     findings.push(`${relativePath}: repository metadata synchronization must use GitHub's maximum pending queue without cancellation or failure bypass`);

--- a/tooling/cmd/20w/main.go
+++ b/tooling/cmd/20w/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/lusoris/20-watts-was-enough/tooling/internal/ciplan"
 	"github.com/lusoris/20-watts-was-enough/tooling/internal/docscheck"
 	"github.com/lusoris/20-watts-was-enough/tooling/internal/experiment"
+	"github.com/lusoris/20-watts-was-enough/tooling/internal/githubapi"
 	"github.com/lusoris/20-watts-was-enough/tooling/internal/githubissuelifecycle"
 	"github.com/lusoris/20-watts-was-enough/tooling/internal/githubissuemilestones"
 	"github.com/lusoris/20-watts-was-enough/tooling/internal/githublabels"
@@ -432,13 +433,13 @@ func runPublicationRenderPDF(arguments []string, stdout, stderr io.Writer) int {
 	return 0
 }
 
-func githubMetadataHTTPClient() *http.Client {
-	return &http.Client{
+func githubMetadataHTTPClient() githubapi.HTTPClient {
+	return githubapi.NewReadRetryClient(&http.Client{
 		Timeout: 20 * time.Second,
 		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
 			return errors.New("GitHub metadata API redirect refused")
 		},
-	}
+	})
 }
 
 func runGitHubSyncMetadata(arguments []string, stdout, stderr io.Writer) int {

--- a/tooling/internal/githubapi/client.go
+++ b/tooling/internal/githubapi/client.go
@@ -1,0 +1,122 @@
+// Package githubapi provides the bounded HTTP behavior shared by GitHub API
+// commands.
+package githubapi
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"time"
+)
+
+const (
+	maximumAttempts       = 3
+	maximumRetryDrainSize = 32 << 10
+	firstRetryDelay       = 100 * time.Millisecond
+	secondRetryDelay      = 300 * time.Millisecond
+)
+
+// HTTPClient is the smallest transport surface required by GitHub API calls.
+type HTTPClient interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+type waitFunc func(context.Context, time.Duration) error
+
+type readRetryClient struct {
+	client HTTPClient
+	wait   waitFunc
+}
+
+// NewReadRetryClient adds bounded transient retries to bodyless GET requests.
+// Requests with a body and mutation methods always pass through exactly once.
+func NewReadRetryClient(client HTTPClient) HTTPClient {
+	return newReadRetryClient(client, waitForRetry)
+}
+
+func newReadRetryClient(client HTTPClient, wait waitFunc) HTTPClient {
+	if client == nil {
+		panic("githubapi: nil HTTP client")
+	}
+	if wait == nil {
+		panic("githubapi: nil retry waiter")
+	}
+	return &readRetryClient{client: client, wait: wait}
+}
+
+func (client *readRetryClient) Do(request *http.Request) (*http.Response, error) {
+	if !isRetryableRead(request) {
+		return client.client.Do(request)
+	}
+
+	for attempt := 0; attempt < maximumAttempts; attempt++ {
+		if err := request.Context().Err(); err != nil {
+			return nil, err
+		}
+
+		response, err := client.client.Do(request)
+		if !isRetryable(response, err) || attempt == maximumAttempts-1 {
+			return response, err
+		}
+
+		discardIntermediateResponse(response)
+		if err := client.wait(request.Context(), retryDelay(attempt)); err != nil {
+			return nil, err
+		}
+	}
+
+	panic("unreachable")
+}
+
+func isRetryableRead(request *http.Request) bool {
+	if request == nil || (request.Method != "" && request.Method != http.MethodGet) {
+		return false
+	}
+	return request.Body == nil || request.Body == http.NoBody
+}
+
+func isRetryable(response *http.Response, err error) bool {
+	if err != nil {
+		// A non-nil response paired with an error is a client-policy failure
+		// (for example, CheckRedirect), not a transient transport failure.
+		return response == nil
+	}
+	if response == nil {
+		return false
+	}
+	switch response.StatusCode {
+	case http.StatusInternalServerError,
+		http.StatusBadGateway,
+		http.StatusServiceUnavailable,
+		http.StatusGatewayTimeout:
+		return true
+	default:
+		return false
+	}
+}
+
+func retryDelay(attempt int) time.Duration {
+	if attempt == 0 {
+		return firstRetryDelay
+	}
+	return secondRetryDelay
+}
+
+func discardIntermediateResponse(response *http.Response) {
+	if response == nil || response.Body == nil {
+		return
+	}
+	_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, maximumRetryDrainSize))
+	_ = response.Body.Close()
+}
+
+func waitForRetry(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/tooling/internal/githubapi/client_test.go
+++ b/tooling/internal/githubapi/client_test.go
@@ -1,0 +1,334 @@
+package githubapi
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+type doFunc func(*http.Request) (*http.Response, error)
+
+func (function doFunc) Do(request *http.Request) (*http.Response, error) {
+	return function(request)
+}
+
+type observedBody struct {
+	reader *bytes.Reader
+	read   int
+	closed bool
+}
+
+func newObservedBody(contents []byte) *observedBody {
+	return &observedBody{reader: bytes.NewReader(contents)}
+}
+
+func (body *observedBody) Read(destination []byte) (int, error) {
+	count, err := body.reader.Read(destination)
+	body.read += count
+	return count, err
+}
+
+func (body *observedBody) Close() error {
+	body.closed = true
+	return nil
+}
+
+func response(status int, body io.ReadCloser) *http.Response {
+	return &http.Response{StatusCode: status, Body: body, Header: make(http.Header)}
+}
+
+func immediateWait(delays *[]time.Duration) waitFunc {
+	return func(_ context.Context, delay time.Duration) error {
+		*delays = append(*delays, delay)
+		return nil
+	}
+}
+
+func TestReadRetryClientRecoversFromTransientStatuses(t *testing.T) {
+	t.Parallel()
+	statuses := []int{
+		http.StatusInternalServerError,
+		http.StatusBadGateway,
+		http.StatusServiceUnavailable,
+		http.StatusGatewayTimeout,
+	}
+	for _, status := range statuses {
+		status := status
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			t.Parallel()
+			attempts := 0
+			transientBody := newObservedBody([]byte("temporary"))
+			underlying := doFunc(func(*http.Request) (*http.Response, error) {
+				attempts++
+				if attempts == 1 {
+					return response(status, transientBody), nil
+				}
+				return response(http.StatusOK, io.NopCloser(strings.NewReader("ready"))), nil
+			})
+			var delays []time.Duration
+			client := newReadRetryClient(underlying, immediateWait(&delays))
+			request, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://api.github.test/resource", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			got, err := client.Do(request)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer got.Body.Close()
+			if attempts != 2 || got.StatusCode != http.StatusOK {
+				t.Fatalf("attempts/status = %d/%d, want 2/200", attempts, got.StatusCode)
+			}
+			if !transientBody.closed || transientBody.read != len("temporary") {
+				t.Fatalf("intermediate body closed/read = %t/%d", transientBody.closed, transientBody.read)
+			}
+			if len(delays) != 1 || delays[0] != firstRetryDelay {
+				t.Fatalf("retry delays = %v, want [%s]", delays, firstRetryDelay)
+			}
+		})
+	}
+}
+
+func TestReadRetryClientLeavesFinalTransientResponseIntact(t *testing.T) {
+	t.Parallel()
+	largeContents := bytes.Repeat([]byte("x"), maximumRetryDrainSize+17)
+	bodies := []*observedBody{
+		newObservedBody(largeContents),
+		newObservedBody([]byte("second temporary response")),
+		newObservedBody([]byte("final response body")),
+	}
+	attempts := 0
+	underlying := doFunc(func(*http.Request) (*http.Response, error) {
+		body := bodies[attempts]
+		attempts++
+		return response(http.StatusServiceUnavailable, body), nil
+	})
+	var delays []time.Duration
+	client := newReadRetryClient(underlying, immediateWait(&delays))
+	request, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://api.github.test/resource", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := client.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer got.Body.Close()
+	if attempts != maximumAttempts || got.Body != bodies[2] {
+		t.Fatalf("attempts/final body = %d/%p, want %d/%p", attempts, got.Body, maximumAttempts, bodies[2])
+	}
+	if !bodies[0].closed || bodies[0].read != maximumRetryDrainSize {
+		t.Fatalf("large intermediate body closed/read = %t/%d", bodies[0].closed, bodies[0].read)
+	}
+	if !bodies[1].closed || bodies[1].read != len("second temporary response") {
+		t.Fatalf("second intermediate body closed/read = %t/%d", bodies[1].closed, bodies[1].read)
+	}
+	if bodies[2].closed || bodies[2].read != 0 {
+		t.Fatalf("final body closed/read before caller = %t/%d", bodies[2].closed, bodies[2].read)
+	}
+	contents, err := io.ReadAll(got.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(contents) != "final response body" {
+		t.Fatalf("final body = %q", contents)
+	}
+	if len(delays) != 2 || delays[0] != firstRetryDelay || delays[1] != secondRetryDelay {
+		t.Fatalf("retry delays = %v, want [%s %s]", delays, firstRetryDelay, secondRetryDelay)
+	}
+}
+
+func TestReadRetryClientReturnsFinalTransportErrorAtAttemptLimit(t *testing.T) {
+	t.Parallel()
+	attempts := 0
+	finalErr := errors.New("final transport failure")
+	underlying := doFunc(func(*http.Request) (*http.Response, error) {
+		attempts++
+		if attempts == maximumAttempts {
+			return nil, finalErr
+		}
+		return nil, errors.New("temporary transport failure")
+	})
+	var delays []time.Duration
+	client := newReadRetryClient(underlying, immediateWait(&delays))
+	request, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://api.github.test/resource", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := client.Do(request)
+	if !errors.Is(err, finalErr) {
+		t.Fatalf("Do() error = %v, want final transport error", err)
+	}
+	if got != nil || attempts != maximumAttempts {
+		t.Fatalf("response/attempts = %v/%d, want nil/%d", got, attempts, maximumAttempts)
+	}
+	if len(delays) != 2 || delays[0] != firstRetryDelay || delays[1] != secondRetryDelay {
+		t.Fatalf("retry delays = %v, want [%s %s]", delays, firstRetryDelay, secondRetryDelay)
+	}
+}
+
+func TestReadRetryClientDoesNotRetryGETWithBody(t *testing.T) {
+	t.Parallel()
+	attempts := 0
+	responseBody := newObservedBody([]byte("do not retry"))
+	underlying := doFunc(func(*http.Request) (*http.Response, error) {
+		attempts++
+		return response(http.StatusServiceUnavailable, responseBody), nil
+	})
+	client := newReadRetryClient(underlying, func(context.Context, time.Duration) error {
+		t.Fatal("GET request with a body invoked retry waiter")
+		return nil
+	})
+	request, err := http.NewRequestWithContext(
+		context.Background(), http.MethodGet, "https://api.github.test/resource", strings.NewReader("query"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := client.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if attempts != 1 || got.Body != responseBody {
+		t.Fatalf("attempts/body = %d/%p, want 1/%p", attempts, got.Body, responseBody)
+	}
+	if responseBody.closed || responseBody.read != 0 {
+		t.Fatalf("response body closed/read = %t/%d", responseBody.closed, responseBody.read)
+	}
+	_ = got.Body.Close()
+}
+
+func TestReadRetryClientRecoversFromTransportError(t *testing.T) {
+	t.Parallel()
+	attempts := 0
+	underlying := doFunc(func(*http.Request) (*http.Response, error) {
+		attempts++
+		if attempts == 1 {
+			return nil, errors.New("temporary transport failure")
+		}
+		return response(http.StatusOK, io.NopCloser(strings.NewReader("ready"))), nil
+	})
+	var delays []time.Duration
+	client := newReadRetryClient(underlying, immediateWait(&delays))
+	request, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://api.github.test/resource", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := client.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer got.Body.Close()
+	if attempts != 2 || got.StatusCode != http.StatusOK {
+		t.Fatalf("attempts/status = %d/%d, want 2/200", attempts, got.StatusCode)
+	}
+	if len(delays) != 1 || delays[0] != firstRetryDelay {
+		t.Fatalf("retry delays = %v, want [%s]", delays, firstRetryDelay)
+	}
+}
+
+func TestReadRetryClientDoesNotRetryClientPolicyError(t *testing.T) {
+	t.Parallel()
+	attempts := 0
+	policyErr := errors.New("redirect rejected by policy")
+	responseBody := newObservedBody([]byte("policy response"))
+	wantResponse := response(http.StatusFound, responseBody)
+	underlying := doFunc(func(*http.Request) (*http.Response, error) {
+		attempts++
+		return wantResponse, policyErr
+	})
+	client := newReadRetryClient(underlying, func(context.Context, time.Duration) error {
+		t.Fatal("client policy error invoked retry waiter")
+		return nil
+	})
+	request, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://api.github.test/resource", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gotResponse, gotErr := client.Do(request)
+	if gotResponse != wantResponse || !errors.Is(gotErr, policyErr) {
+		t.Fatalf("response/error = %p/%v, want %p/%v", gotResponse, gotErr, wantResponse, policyErr)
+	}
+	if attempts != 1 {
+		t.Fatalf("attempts = %d, want 1", attempts)
+	}
+	if responseBody.closed || responseBody.read != 0 {
+		t.Fatalf("policy response body closed/read = %t/%d", responseBody.closed, responseBody.read)
+	}
+}
+
+func TestReadRetryClientDoesNotRetryMutationMethods(t *testing.T) {
+	t.Parallel()
+	methods := []string{http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete}
+	for _, method := range methods {
+		method := method
+		t.Run(method, func(t *testing.T) {
+			t.Parallel()
+			attempts := 0
+			body := newObservedBody([]byte("do not retry"))
+			underlying := doFunc(func(*http.Request) (*http.Response, error) {
+				attempts++
+				return response(http.StatusServiceUnavailable, body), nil
+			})
+			client := newReadRetryClient(underlying, func(context.Context, time.Duration) error {
+				t.Fatal("mutation request invoked retry waiter")
+				return nil
+			})
+			request, err := http.NewRequestWithContext(context.Background(), method, "https://api.github.test/resource", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			got, err := client.Do(request)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if attempts != 1 || got.Body != body {
+				t.Fatalf("attempts/body = %d/%p, want 1/%p", attempts, got.Body, body)
+			}
+			if body.closed || body.read != 0 {
+				t.Fatalf("mutation response body closed/read = %t/%d", body.closed, body.read)
+			}
+			_ = got.Body.Close()
+		})
+	}
+}
+
+func TestReadRetryClientStopsWhenContextIsCancelled(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	attempts := 0
+	body := newObservedBody([]byte("temporary"))
+	underlying := doFunc(func(*http.Request) (*http.Response, error) {
+		attempts++
+		cancel()
+		return response(http.StatusGatewayTimeout, body), nil
+	})
+	client := NewReadRetryClient(underlying)
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.github.test/resource", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := client.Do(request)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Do() error = %v, want context cancellation", err)
+	}
+	if got != nil || attempts != 1 {
+		t.Fatalf("response/attempts = %v/%d, want nil/1", got, attempts)
+	}
+	if !body.closed || body.read != len("temporary") {
+		t.Fatalf("cancelled intermediate body closed/read = %t/%d", body.closed, body.read)
+	}
+}


### PR DESCRIPTION
## Summary

- grant `pull-requests: write` only to the trusted repository-metadata job so it can remove stale lifecycle labels from merged pull requests
- add one shared Go client that retries only bodyless GET transport failures and HTTP 500/502/503/504, with three total attempts and 100/300 ms context-aware delays
- return redirect-policy failures without retrying, keep mutations single-attempt, bound intermediate response draining, and leave the final response or error to the caller
- bind the new implementation path, permission, issue assignment, and generated book provenance into their canonical authorities

## Live failures fixed

- [run 33897337252](https://github.com/lusoris/20-watts-was-enough/actions/runs/33897337252): deterministic 403 removing stale `status:in-progress` from merged PR #34
- [run 33898396338](https://github.com/lusoris/20-watts-was-enough/actions/runs/33898396338): transient 504 while reading issue #20 during lifecycle verification

## Validation

- `go -C tooling test -race ./...`
- `go -C tooling vet ./...`
- `go -C tooling run ./cmd/20w github sync-metadata --root .. --check`
- `npm run validate:policy`
- `npm run test:policy` (68 tests)
- `npm run check:code-shape` and `npm run test:code-shape`
- `npm run check:prose` and `npm run test:prose`
- deterministic two-pass PDF regeneration and `npm run validate:book-pdf` (172 source files)
- focused book/release/semantic suite (36 tests)
- semantic audit retained exactly the five tracked known-debt sentinels
- official pinned Node 26.8.1 container passed the numeric runtime sentinel

The host-wide `npm run check` stops at its pretest because this workstation binary produces the wrong numeric sentinel despite reporting Node 26.8.1. The official pinned Node 26.8.1 container produces the required sentinel; this PR therefore leaves the aggregate result to the mandatory pinned GitHub Actions lane rather than weakening the runtime gate.

## Authority boundary

The retry client is used only by trusted GitHub metadata commands. It does not retry POST, PUT, PATCH, DELETE, or redirect-policy failures, does not broaden workflow-level permissions, and does not turn a failed remote reconciliation into success.

Closes #61
