### PR TITLE
feat(experiment): add BFS catalogue vertical

### DIFF
--- a/.github/ci-impact.json
+++ b/.github/ci-impact.json
@@ -225,6 +225,7 @@
       "paths": [
         "tooling/clrs-generator/**",
         "tooling/internal/clrsbellmanford/**",
+        "tooling/internal/clrsbfs/**",
         "tooling/internal/clrsbinary/**",
         "tooling/internal/clrsfixture/**",
         "tooling/internal/clrsinsertion/**",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,12 @@ the exact diff; this file records why the project changed.
   overlap and degenerate point-segments without calling the specialist solver.
   The sole task size remains a fixed four-endpoint geometry control, not a
   length-extrapolation probe, and all construction output remains `NO_RESULT`.
+- A source-bound breadth-first-search catalogue candidate now reproduces the
+  pinned unweighted-graph grammar, synchronous reachability waves and
+  row-major predecessor tie rule in Go. An independently arranged shortest-hop
+  verifier cross-checks deterministic synthetic graphs. BFS is not admitted to
+  Decision 0055's frozen six-task fixture or controller contract, and every
+  output remains `NO_RESULT`.
 - A versioned PDF semantic sentinel now binds the current source, book, A4 and
   tag metadata, Poppler tool identity, separate structure and text streams,
   exact diagnostics, and six nonlinear content anchors. Atomic evidence keeps

--- a/tooling/internal/ciplan/mapping_test.go
+++ b/tooling/internal/ciplan/mapping_test.go
@@ -47,6 +47,7 @@ func TestRepositoryImpactMappingIsClosedAndRoutesRepresentativeChanges(t *testin
 		{path: "tooling/internal/clrsbinary/adapter.go", mode: "impact", lanes: []string{"go"}},
 		{path: "tooling/internal/clrsmatrixchain/adapter.go", mode: "impact", lanes: []string{"go"}},
 		{path: "tooling/internal/clrsbellmanford/adapter.go", mode: "impact", lanes: []string{"go"}},
+		{path: "tooling/internal/clrsbfs/bfs.go", mode: "impact", lanes: []string{"go"}},
 		{path: "tooling/internal/clrskmp/adapter.go", mode: "impact", lanes: []string{"go"}},
 		{path: "tooling/internal/clrssegments/adapter.go", mode: "impact", lanes: []string{"go"}},
 		{path: "experiments/workstation/lib/execution-receipt.mjs", mode: "full", lanes: []string{"full"}, reason: "full-authority-changed"},

--- a/tooling/internal/clrsbfs/bfs.go
+++ b/tooling/internal/clrsbfs/bfs.go
@@ -1,0 +1,357 @@
+package clrsbfs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+)
+
+const (
+	promptPrefix = "bfs:\ns: "
+	matrixMarker = ", A: [["
+	promptSuffix = "]]\npi:\n"
+	answerPrefix = "["
+	answerSuffix = "]\n\n"
+	rowSeparator = "], ["
+
+	maximumPromptBytesCeiling = 1 << 20
+	maximumNodesCeiling       = 128
+	maximumTokenBytesCeiling  = 128
+	maximumAnswerBytesCeiling = 1 << 20
+)
+
+var (
+	// ErrInvalidLimits means a caller did not close every parser/output bound.
+	ErrInvalidLimits = errors.New("invalid BFS limits")
+	// ErrMalformedPrompt means bytes do not match the bounded no-hint grammar.
+	ErrMalformedPrompt = errors.New("malformed BFS prompt")
+	// ErrPromptLimit means candidate-visible input crossed a configured bound.
+	ErrPromptLimit = errors.New("BFS prompt limit exceeded")
+	// ErrMalformedAnswer means bytes do not match the exact predecessor grammar.
+	ErrMalformedAnswer = errors.New("malformed BFS answer")
+	// ErrAnswerLimit means the exact answer crossed a configured output bound.
+	ErrAnswerLimit = errors.New("BFS answer limit exceeded")
+	// ErrVerificationMismatch means the answer is not the pinned BFS predecessor vector.
+	ErrVerificationMismatch = errors.New("BFS verification mismatch")
+)
+
+// Limits are parser and bounded-work safety caps, not selected experiment sizes.
+type Limits struct {
+	MaxPromptBytes int
+	MaxNodes       int
+	MaxTokenBytes  int
+	MaxAnswerBytes int
+}
+
+// Validate rejects open or impractically large bounds.
+func (limits Limits) Validate() error {
+	if limits.MaxPromptBytes <= 0 || limits.MaxPromptBytes > maximumPromptBytesCeiling ||
+		limits.MaxNodes <= 0 || limits.MaxNodes > maximumNodesCeiling ||
+		limits.MaxTokenBytes <= 0 || limits.MaxTokenBytes > maximumTokenBytesCeiling ||
+		limits.MaxAnswerBytes <= 0 || limits.MaxAnswerBytes > maximumAnswerBytesCeiling {
+		return ErrInvalidLimits
+	}
+	return nil
+}
+
+type graphInput struct {
+	source    int
+	adjacency [][]bool
+}
+
+// Solve returns the pinned synchronous BFS predecessor vector for the bounded
+// no-hint CLRS-Text grammar. A successful answer remains NO_RESULT.
+func Solve(ctx context.Context, prompt []byte, limits Limits) ([]byte, error) {
+	if ctx == nil {
+		return nil, errors.New("solve BFS: nil context")
+	}
+	if err := limits.Validate(); err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	input, err := parsePrompt(ctx, prompt, limits)
+	if err != nil {
+		return nil, err
+	}
+	predecessors, err := synchronousBFS(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+	return formatAnswer(predecessors, limits.MaxAnswerBytes)
+}
+
+// Verify checks an answer through an independently arranged shortest-hop
+// characterization. It does not call Solve or synchronousBFS.
+func Verify(ctx context.Context, prompt, answer []byte, limits Limits) error {
+	if ctx == nil {
+		return errors.New("verify BFS: nil context")
+	}
+	if err := limits.Validate(); err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	input, err := parsePrompt(ctx, prompt, limits)
+	if err != nil {
+		return fmt.Errorf("verify BFS prompt: %w", err)
+	}
+	predecessors, err := parseAnswer(answer, limits, len(input.adjacency))
+	if err != nil {
+		return err
+	}
+	expected, err := referencePredecessors(ctx, input)
+	if err != nil {
+		return err
+	}
+	for node := range expected {
+		if predecessors[node] != expected[node] {
+			return fmt.Errorf("%w: predecessor[%d] = %d, want %d", ErrVerificationMismatch, node, predecessors[node], expected[node])
+		}
+	}
+	return nil
+}
+
+func parsePrompt(ctx context.Context, prompt []byte, limits Limits) (graphInput, error) {
+	if len(prompt) > limits.MaxPromptBytes {
+		return graphInput{}, fmt.Errorf("%w: %d bytes exceeds %d", ErrPromptLimit, len(prompt), limits.MaxPromptBytes)
+	}
+	if len(prompt) == 0 || !utf8.Valid(prompt) {
+		return graphInput{}, ErrMalformedPrompt
+	}
+	body, found := strings.CutPrefix(string(prompt), promptPrefix)
+	if !found {
+		return graphInput{}, fmt.Errorf("%w: wrong task or source marker", ErrMalformedPrompt)
+	}
+	body, found = strings.CutSuffix(body, promptSuffix)
+	if !found {
+		return graphInput{}, fmt.Errorf("%w: wrong predecessor marker", ErrMalformedPrompt)
+	}
+	sourceToken, matrixBody, found := strings.Cut(body, matrixMarker)
+	if !found || sourceToken == "" || matrixBody == "" {
+		return graphInput{}, fmt.Errorf("%w: missing source or adjacency matrix", ErrMalformedPrompt)
+	}
+	adjacency, err := parseMatrix(ctx, matrixBody, limits)
+	if err != nil {
+		return graphInput{}, err
+	}
+	source, err := parseIndex(sourceToken, len(adjacency), limits.MaxTokenBytes)
+	if err != nil {
+		return graphInput{}, fmt.Errorf("%w: source: %v", ErrMalformedPrompt, err)
+	}
+	return graphInput{source: source, adjacency: adjacency}, nil
+}
+
+func parseMatrix(ctx context.Context, body string, limits Limits) ([][]bool, error) {
+	rows := strings.Split(body, rowSeparator)
+	if len(rows) == 0 || len(rows) > limits.MaxNodes {
+		return nil, fmt.Errorf("%w: %d nodes exceeds 1..%d", ErrPromptLimit, len(rows), limits.MaxNodes)
+	}
+	adjacency := make([][]bool, 0, len(rows))
+	for rowIndex, rowBody := range rows {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		row, err := parseRow(rowBody, limits, rowIndex)
+		if err != nil {
+			return nil, err
+		}
+		adjacency = append(adjacency, row)
+	}
+	for row := range adjacency {
+		if len(adjacency[row]) != len(adjacency) {
+			return nil, fmt.Errorf("%w: row %d has %d values, want square size %d", ErrMalformedPrompt, row, len(adjacency[row]), len(adjacency))
+		}
+		for column := 0; column < row; column++ {
+			if adjacency[row][column] != adjacency[column][row] {
+				return nil, fmt.Errorf("%w: matrix differs at symmetric cells %d,%d", ErrMalformedPrompt, row, column)
+			}
+		}
+	}
+	return adjacency, nil
+}
+
+func parseRow(body string, limits Limits, row int) ([]bool, error) {
+	if body == "" {
+		return nil, fmt.Errorf("%w: row %d is empty", ErrMalformedPrompt, row)
+	}
+	tokens := strings.Split(body, " ")
+	if len(tokens) > limits.MaxNodes {
+		return nil, fmt.Errorf("%w: row %d has %d values", ErrPromptLimit, row, len(tokens))
+	}
+	values := make([]bool, 0, len(tokens))
+	for column, token := range tokens {
+		value, err := parseEdge(token, limits.MaxTokenBytes)
+		if err != nil {
+			if errors.Is(err, ErrPromptLimit) {
+				return nil, fmt.Errorf("%w at matrix cell %d,%d: %v", ErrPromptLimit, row, column, err)
+			}
+			return nil, fmt.Errorf("%w at matrix cell %d,%d: %v", ErrMalformedPrompt, row, column, err)
+		}
+		values = append(values, value)
+	}
+	return values, nil
+}
+
+func parseEdge(token string, maximumBytes int) (bool, error) {
+	if len(token) > maximumBytes {
+		return false, fmt.Errorf("%w: edge token exceeds %d bytes", ErrPromptLimit, maximumBytes)
+	}
+	switch token {
+	case "0":
+		return false, nil
+	case "1":
+		return true, nil
+	default:
+		return false, errors.New("edge is not a pinned unweighted sampler value")
+	}
+}
+
+func parseIndex(token string, size, maximumBytes int) (int, error) {
+	if token == "" || len(token) > maximumBytes || (len(token) > 1 && token[0] == '0') {
+		return 0, errors.New("value is not one bounded canonical non-negative index")
+	}
+	for index := range len(token) {
+		if token[index] < '0' || token[index] > '9' {
+			return 0, errors.New("value is not one canonical non-negative index")
+		}
+	}
+	parsed, err := strconv.ParseUint(token, 10, 31)
+	if err != nil || parsed >= uint64(size) {
+		return 0, fmt.Errorf("value is outside 0..%d", size-1)
+	}
+	return int(parsed), nil
+}
+
+// synchronousBFS mirrors the pinned reachability-wave update and its strict
+// row-major first-predecessor rule.
+func synchronousBFS(ctx context.Context, input graphInput) ([]int, error) {
+	size := len(input.adjacency)
+	reached := make([]bool, size)
+	predecessors := make([]int, size)
+	for node := range size {
+		predecessors[node] = node
+	}
+	reached[input.source] = true
+	for wave := 0; wave < size; wave++ {
+		previous := append([]bool(nil), reached...)
+		for from := range size {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+			if !previous[from] {
+				continue
+			}
+			for to, edge := range input.adjacency[from] {
+				if !edge {
+					continue
+				}
+				if predecessors[to] == to && to != input.source {
+					predecessors[to] = from
+				}
+				reached[to] = true
+			}
+		}
+		if equalReachability(previous, reached) {
+			return predecessors, nil
+		}
+	}
+	return nil, errors.New("BFS reachability did not converge within the node bound")
+}
+
+func equalReachability(left, right []bool) bool {
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}
+
+func formatAnswer(predecessors []int, maximumBytes int) ([]byte, error) {
+	var answer strings.Builder
+	answer.Grow(len(answerPrefix) + len(answerSuffix) + len(predecessors)*3)
+	answer.WriteString(answerPrefix)
+	for index, predecessor := range predecessors {
+		if index > 0 {
+			answer.WriteByte(' ')
+		}
+		answer.WriteString(strconv.Itoa(predecessor))
+	}
+	answer.WriteString(answerSuffix)
+	if answer.Len() > maximumBytes {
+		return nil, fmt.Errorf("%w: %d bytes exceeds %d", ErrAnswerLimit, answer.Len(), maximumBytes)
+	}
+	return []byte(answer.String()), nil
+}
+
+func parseAnswer(answer []byte, limits Limits, size int) ([]int, error) {
+	if len(answer) == 0 || len(answer) > limits.MaxAnswerBytes || !utf8.Valid(answer) {
+		return nil, fmt.Errorf("%w: answer must contain 1..%d UTF-8 bytes", ErrAnswerLimit, limits.MaxAnswerBytes)
+	}
+	body, found := strings.CutPrefix(string(answer), answerPrefix)
+	if !found {
+		return nil, fmt.Errorf("%w: missing predecessor-vector prefix", ErrMalformedAnswer)
+	}
+	body, found = strings.CutSuffix(body, answerSuffix)
+	if !found || body == "" {
+		return nil, fmt.Errorf("%w: missing exact predecessor-vector suffix", ErrMalformedAnswer)
+	}
+	tokens := strings.Split(body, " ")
+	if len(tokens) != size {
+		return nil, fmt.Errorf("%w: predecessor count = %d, want %d", ErrMalformedAnswer, len(tokens), size)
+	}
+	predecessors := make([]int, 0, size)
+	for index, token := range tokens {
+		value, err := parseIndex(token, size, limits.MaxTokenBytes)
+		if err != nil {
+			return nil, fmt.Errorf("%w: predecessor %d: %v", ErrMalformedAnswer, index, err)
+		}
+		predecessors = append(predecessors, value)
+	}
+	return predecessors, nil
+}
+
+// referencePredecessors computes shortest-hop distances with a FIFO queue,
+// then derives the pinned row-major tie rule from the previous distance layer.
+func referencePredecessors(ctx context.Context, input graphInput) ([]int, error) {
+	size := len(input.adjacency)
+	distances := make([]int, size)
+	for node := range size {
+		distances[node] = -1
+	}
+	distances[input.source] = 0
+	queue := make([]int, 1, size)
+	queue[0] = input.source
+	for head := 0; head < len(queue); head++ {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		from := queue[head]
+		for to, edge := range input.adjacency[from] {
+			if edge && distances[to] < 0 {
+				distances[to] = distances[from] + 1
+				queue = append(queue, to)
+			}
+		}
+	}
+	predecessors := make([]int, size)
+	for node := range size {
+		predecessors[node] = node
+		if node == input.source || distances[node] < 0 {
+			continue
+		}
+		for from := range size {
+			if input.adjacency[from][node] && distances[from] == distances[node]-1 {
+				predecessors[node] = from
+				break
+			}
+		}
+	}
+	return predecessors, nil
+}

--- a/tooling/internal/clrsbfs/bfs_test.go
+++ b/tooling/internal/clrsbfs/bfs_test.go
@@ -1,0 +1,316 @@
+package clrsbfs
+
+import (
+	"context"
+	"errors"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/lusoris/20-watts-was-enough/tooling/internal/clrsfixture"
+)
+
+const tiePrompt = "bfs:\ns: 5, A: [[0 0 0 1 1 0 0], [0 0 1 0 0 1 0], [0 1 0 1 0 0 1], [1 0 1 0 0 0 0], [1 0 0 0 0 1 1], [0 1 0 0 1 0 0], [0 0 1 0 1 0 0]]\npi:\n"
+
+type cancelAfterChecksContext struct {
+	context.Context
+	cancelAt int
+	checks   int
+}
+
+func (ctx *cancelAfterChecksContext) Err() error {
+	ctx.checks++
+	if ctx.checks >= ctx.cancelAt {
+		return context.Canceled
+	}
+	return nil
+}
+
+func TestSolveMatchesPinnedSynchronousTieRule(t *testing.T) {
+	t.Parallel()
+	want := "[4 5 1 0 5 5 4]\n\n"
+	first, err := Solve(context.Background(), []byte(tiePrompt), testLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := Solve(context.Background(), []byte(tiePrompt), testLimits())
+	if err != nil || string(first) != want || string(second) != want {
+		t.Fatalf("Solve() = %q/%q, error %v, want exact %q", first, second, err, want)
+	}
+	if err := Verify(context.Background(), []byte(tiePrompt), first, testLimits()); err != nil {
+		t.Fatalf("Verify(Solve()) error = %v", err)
+	}
+	if err := Verify(context.Background(), []byte(tiePrompt), []byte("[4 5 1 2 5 5 4]\n\n"), testLimits()); !errors.Is(err, ErrVerificationMismatch) {
+		t.Fatalf("Verify(alternative shortest tree) error = %v, want ErrVerificationMismatch", err)
+	}
+}
+
+func TestSolveAndVerifierCrossCheckDeterministicGraphCatalogue(t *testing.T) {
+	t.Parallel()
+	random := rand.New(rand.NewSource(20260904))
+	const cases = 512
+	for index := range cases {
+		size := 1 + random.Intn(16)
+		adjacency := make([][]bool, size)
+		for row := range size {
+			adjacency[row] = make([]bool, size)
+			adjacency[row][row] = random.Intn(4) == 0
+			for column := 0; column < row; column++ {
+				edge := random.Intn(3) == 0
+				adjacency[row][column] = edge
+				adjacency[column][row] = edge
+			}
+		}
+		source := random.Intn(size)
+		prompt := buildPrompt(source, adjacency)
+		answer, err := Solve(context.Background(), prompt, testLimits())
+		if err != nil {
+			t.Fatalf("case %d Solve() error = %v", index, err)
+		}
+		if err := Verify(context.Background(), prompt, answer, testLimits()); err != nil {
+			t.Fatalf("case %d Verify(Solve()) error = %v; prompt = %q; answer = %q", index, err, prompt, answer)
+		}
+	}
+}
+
+func TestBFSRemainsOutsideFrozenShakedownRegistry(t *testing.T) {
+	t.Parallel()
+	if ResultAuthority != "NO_RESULT" {
+		t.Fatalf("ResultAuthority = %q, want NO_RESULT", ResultAuthority)
+	}
+	for _, task := range clrsfixture.ShakedownTasks() {
+		if task == clrsfixture.TaskKind("bfs") {
+			t.Fatal("BFS was admitted without superseding Decision 0055")
+		}
+	}
+}
+
+func TestSolveCoversSingleNodeDisconnectedAndCompleteGraphs(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		prompt string
+		want   string
+	}{
+		{name: "single self loop", prompt: "bfs:\ns: 0, A: [[1]]\npi:\n", want: "[0]\n\n"},
+		{name: "disconnected", prompt: "bfs:\ns: 2, A: [[0 1 0 0], [1 0 0 0], [0 0 0 0], [0 0 0 1]]\npi:\n", want: "[0 1 2 3]\n\n"},
+		{name: "complete", prompt: "bfs:\ns: 2, A: [[0 1 1 1], [1 0 1 1], [1 1 0 1], [1 1 1 0]]\npi:\n", want: "[2 2 2 2]\n\n"},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			answer, err := Solve(context.Background(), []byte(test.prompt), testLimits())
+			if err != nil || string(answer) != test.want {
+				t.Fatalf("Solve() = %q, error %v, want %q", answer, err, test.want)
+			}
+			if err := Verify(context.Background(), []byte(test.prompt), answer, testLimits()); err != nil {
+				t.Fatalf("Verify(Solve()) error = %v", err)
+			}
+		})
+	}
+}
+
+func TestSolveRejectsMalformedAndOversizedPrompts(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		prompt []byte
+		mutate func(*Limits)
+		want   error
+	}{
+		"empty":                {prompt: nil, want: ErrMalformedPrompt},
+		"invalid UTF-8":        {prompt: []byte{0xff}, want: ErrMalformedPrompt},
+		"wrong task":           {prompt: []byte(strings.Replace(tiePrompt, "bfs:", "dfs:", 1)), want: ErrMalformedPrompt},
+		"hinted trace":         {prompt: []byte(strings.Replace(tiePrompt, "\npi:\n", ", initial_trace: [0]\ntrace | pi:\n", 1)), want: ErrMalformedPrompt},
+		"wrong source marker":  {prompt: []byte(strings.Replace(tiePrompt, "\ns: ", "\nsource: ", 1)), want: ErrMalformedPrompt},
+		"leading-zero source":  {prompt: []byte(strings.Replace(tiePrompt, "\ns: 5", "\ns: 05", 1)), want: ErrMalformedPrompt},
+		"source out of range":  {prompt: []byte(strings.Replace(tiePrompt, "\ns: 5", "\ns: 7", 1)), want: ErrMalformedPrompt},
+		"wrong output":         {prompt: []byte(strings.Replace(tiePrompt, "\npi:\n", "\nreach:\n", 1)), want: ErrMalformedPrompt},
+		"missing newline":      {prompt: []byte(strings.TrimSuffix(tiePrompt, "\n")), want: ErrMalformedPrompt},
+		"bad row separator":    {prompt: []byte(strings.Replace(tiePrompt, "], [", "],[", 1)), want: ErrMalformedPrompt},
+		"double space":         {prompt: []byte(strings.Replace(tiePrompt, "0 0 0", "0  0 0", 1)), want: ErrMalformedPrompt},
+		"non-square":           {prompt: []byte("bfs:\ns: 0, A: [[0 1], [1]]\npi:\n"), want: ErrMalformedPrompt},
+		"asymmetric":           {prompt: []byte(strings.Replace(tiePrompt, "[0 0 1 0 0 1 0]", "[1 0 1 0 0 1 0]", 1)), want: ErrMalformedPrompt},
+		"float edge":           {prompt: []byte(strings.Replace(tiePrompt, "0 0 0", "0.0 0 0", 1)), want: ErrMalformedPrompt},
+		"negative edge":        {prompt: []byte(strings.Replace(tiePrompt, "0 0 0", "-1 0 0", 1)), want: ErrMalformedPrompt},
+		"nonbinary edge":       {prompt: []byte(strings.Replace(tiePrompt, "0 0 0", "2 0 0", 1)), want: ErrMalformedPrompt},
+		"too many nodes":       {prompt: []byte(tiePrompt), mutate: func(limits *Limits) { limits.MaxNodes = 6 }, want: ErrPromptLimit},
+		"oversized edge token": {prompt: []byte(strings.Replace(tiePrompt, "[[0 ", "[["+strings.Repeat("1", 33)+" ", 1)), want: ErrPromptLimit},
+		"oversized prompt":     {prompt: []byte(tiePrompt), mutate: func(limits *Limits) { limits.MaxPromptBytes = len(tiePrompt) - 1 }, want: ErrPromptLimit},
+		"oversized answer":     {prompt: []byte(tiePrompt), mutate: func(limits *Limits) { limits.MaxAnswerBytes = 4 }, want: ErrAnswerLimit},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			limits := testLimits()
+			if test.mutate != nil {
+				test.mutate(&limits)
+			}
+			if _, err := Solve(context.Background(), test.prompt, limits); !errors.Is(err, test.want) {
+				t.Fatalf("Solve() error = %v, want %v", err, test.want)
+			}
+		})
+	}
+}
+
+func TestVerifyRejectsMalformedAndIncorrectAnswers(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		answer []byte
+		mutate func(*Limits)
+		want   error
+	}{
+		"empty":            {answer: nil, want: ErrAnswerLimit},
+		"invalid UTF-8":    {answer: []byte{0xff}, want: ErrAnswerLimit},
+		"missing prefix":   {answer: []byte("4 5 1 0 5 5 4]\n\n"), want: ErrMalformedAnswer},
+		"missing suffix":   {answer: []byte("[4 5 1 0 5 5 4]"), want: ErrMalformedAnswer},
+		"wrong count":      {answer: []byte("[4 5 1]\n\n"), want: ErrMalformedAnswer},
+		"double space":     {answer: []byte("[4 5  1 0 5 5 4]\n\n"), want: ErrMalformedAnswer},
+		"leading zero":     {answer: []byte("[4 05 1 0 5 5 4]\n\n"), want: ErrMalformedAnswer},
+		"out of range":     {answer: []byte("[4 7 1 0 5 5 4]\n\n"), want: ErrMalformedAnswer},
+		"wrong source":     {answer: []byte("[4 5 1 0 5 4 4]\n\n"), want: ErrVerificationMismatch},
+		"wrong tie":        {answer: []byte("[4 5 1 2 5 5 4]\n\n"), want: ErrVerificationMismatch},
+		"oversized answer": {answer: []byte("[4 5 1 0 5 5 4]\n\n"), mutate: func(limits *Limits) { limits.MaxAnswerBytes = 8 }, want: ErrAnswerLimit},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			limits := testLimits()
+			if test.mutate != nil {
+				test.mutate(&limits)
+			}
+			if err := Verify(context.Background(), []byte(tiePrompt), test.answer, limits); !errors.Is(err, test.want) {
+				t.Fatalf("Verify() error = %v, want %v", err, test.want)
+			}
+		})
+	}
+}
+
+func TestSolveAndVerifyHonourCancellationAndClosedLimits(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := Solve(ctx, []byte(tiePrompt), testLimits()); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Solve(cancelled) error = %v, want context.Canceled", err)
+	}
+	if err := Verify(ctx, []byte(tiePrompt), []byte("[4 5 1 0 5 5 4]\n\n"), testLimits()); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Verify(cancelled) error = %v, want context.Canceled", err)
+	}
+	if _, err := Solve(nil, []byte(tiePrompt), testLimits()); err == nil {
+		t.Fatal("Solve(nil context) succeeded")
+	}
+	if err := Verify(nil, []byte(tiePrompt), []byte("[4 5 1 0 5 5 4]\n\n"), testLimits()); err == nil {
+		t.Fatal("Verify(nil context) succeeded")
+	}
+	limits := testLimits()
+	limits.MaxNodes = 0
+	if _, err := Solve(context.Background(), []byte(tiePrompt), limits); !errors.Is(err, ErrInvalidLimits) {
+		t.Fatalf("Solve(open limits) error = %v, want ErrInvalidLimits", err)
+	}
+	if err := Verify(context.Background(), []byte(tiePrompt), nil, limits); !errors.Is(err, ErrInvalidLimits) {
+		t.Fatalf("Verify(open limits) error = %v, want ErrInvalidLimits", err)
+	}
+}
+
+func TestSolveAndVerifyCheckCancellationInsideGraphWork(t *testing.T) {
+	t.Parallel()
+	solveContext := &cancelAfterChecksContext{Context: context.Background(), cancelAt: 12}
+	if _, err := Solve(solveContext, []byte(tiePrompt), testLimits()); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Solve(graph cancellation) error = %v, want context.Canceled", err)
+	}
+	verifyContext := &cancelAfterChecksContext{Context: context.Background(), cancelAt: 12}
+	if err := Verify(verifyContext, []byte(tiePrompt), []byte("[4 5 1 0 5 5 4]\n\n"), testLimits()); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Verify(graph cancellation) error = %v, want context.Canceled", err)
+	}
+}
+
+func TestPinnedSourceEvidenceIsExact(t *testing.T) {
+	t.Parallel()
+	evidence := PinnedSourceEvidence()
+	if evidence.SourceRecordPath != "tooling/clrs-generator/upstream.json" ||
+		evidence.SourceID != "sha256:7ec3b6b7528d04f517c4e9b7c3e0cd0f7034a775d225d469d1aca5c00fec10d1" {
+		t.Fatalf("source identity = %#v", evidence)
+	}
+	if evidence.Formatter.SHA256 != "d6d320eb1536be8fbdb512315d55eada2db3ff87afd613762f125d38a9e7a53c" ||
+		evidence.Spec.SHA256 != "51f1cc936b28189c7b2e3b2030c30e224fb448f3d2846181983329448f1ed018" ||
+		evidence.Algorithm.Path != "clrs/_src/algorithms/graphs.py" ||
+		evidence.Algorithm.GitBlob != "09303e6eab24e4c35dee510589daceb4e3cc5ee7" ||
+		evidence.Algorithm.SHA256 != "75366fdd2bd72e8f84103dbda6417214fa071bd42237130909b0035b3cd34940" ||
+		evidence.Sampler.SHA256 != "01921e9ca7fa0cc81a8ce82dd76869820f1e9ad8863d5b76b088b0610a2e0473" ||
+		evidence.Probing.SHA256 != "6ee8bea717c6a820fec0457c8be01a4459d5b2daab9c2c883ab8db333478f064" {
+		t.Fatalf("source file identities = %#v", evidence)
+	}
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("locate BFS source test")
+	}
+	body, err := os.ReadFile(filepath.Join(filepath.Dir(filename), "..", "..", "clrs-generator", "upstream.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	source, err := clrsfixture.ParseSourceRecord(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := evidence.ValidateSource(source); err != nil {
+		t.Fatal(err)
+	}
+	mutations := []func(*SourceEvidence){
+		func(value *SourceEvidence) { value.SourceRecordPath = "other.json" },
+		func(value *SourceEvidence) { value.Formatter.SHA256 = strings.Repeat("0", 64) },
+		func(value *SourceEvidence) { value.Spec.GitBlob = strings.Repeat("0", 40) },
+		func(value *SourceEvidence) { value.Algorithm.Path = "graphs-other.py" },
+		func(value *SourceEvidence) { value.Sampler.SHA256 = strings.Repeat("f", 64) },
+		func(value *SourceEvidence) { value.Probing.GitBlob = strings.Repeat("a", 40) },
+	}
+	for index, mutate := range mutations {
+		changed := evidence
+		mutate(&changed)
+		if err := changed.ValidateSource(source); err == nil {
+			t.Fatalf("ValidateSource accepted supporting-evidence mutation %d", index)
+		}
+	}
+	source.Commit = strings.Repeat("f", 40)
+	if err := evidence.ValidateSource(source); err == nil {
+		t.Fatal("ValidateSource accepted a different canonical source identity")
+	}
+}
+
+func buildPrompt(source int, adjacency [][]bool) []byte {
+	var prompt strings.Builder
+	prompt.WriteString("bfs:\ns: ")
+	prompt.WriteString(strconv.Itoa(source))
+	prompt.WriteString(", A: [[")
+	for row := range adjacency {
+		if row > 0 {
+			prompt.WriteString("], [")
+		}
+		for column, edge := range adjacency[row] {
+			if column > 0 {
+				prompt.WriteByte(' ')
+			}
+			if edge {
+				prompt.WriteByte('1')
+			} else {
+				prompt.WriteByte('0')
+			}
+		}
+	}
+	prompt.WriteString("]]\npi:\n")
+	return []byte(prompt.String())
+}
+
+func testLimits() Limits {
+	return Limits{
+		MaxPromptBytes: 64 << 10,
+		MaxNodes:       64,
+		MaxTokenBytes:  32,
+		MaxAnswerBytes: 8 << 10,
+	}
+}

--- a/tooling/internal/clrsbfs/source.go
+++ b/tooling/internal/clrsbfs/source.go
@@ -1,0 +1,85 @@
+// Package clrsbfs implements a source-bound exact-program breadth-first-search
+// catalogue candidate. It is not admitted to the frozen six-task CLRS-Text
+// shakedown, and every value remains NO_RESULT.
+package clrsbfs
+
+import (
+	"fmt"
+
+	"github.com/lusoris/20-watts-was-enough/tooling/internal/clrsfixture"
+)
+
+// ResultAuthority labels this unadmitted construction candidate. It cannot be
+// promoted by a successful solve or verifier cross-check.
+const ResultAuthority = clrsfixture.ResultAuthority
+
+// SourceFile binds one upstream file used to derive this vertical's grammar or
+// exact conventional operation. SHA256 is over the file bytes at Commit.
+type SourceFile struct {
+	Path    string
+	GitBlob string
+	SHA256  string
+}
+
+// SourceEvidence extends the canonical source record with the supporting files
+// used to derive this vertical. It references rather than repeats repository,
+// commit, tree, generator, requirements and licence metadata.
+type SourceEvidence struct {
+	SourceRecordPath string
+	SourceID         string
+	Formatter        SourceFile
+	Spec             SourceFile
+	Algorithm        SourceFile
+	Sampler          SourceFile
+	Probing          SourceFile
+}
+
+// PinnedSourceEvidence returns the exact official source inspected for the
+// no-hint prompt/reference grammar, sampler and synchronous BFS operation.
+func PinnedSourceEvidence() SourceEvidence {
+	return SourceEvidence{
+		SourceRecordPath: "tooling/clrs-generator/upstream.json",
+		SourceID:         "sha256:7ec3b6b7528d04f517c4e9b7c3e0cd0f7034a775d225d469d1aca5c00fec10d1",
+		Formatter: SourceFile{
+			Path:    "clrs/_src/clrs_text/clrs_utils.py",
+			GitBlob: "64a2714ca879cd62a4c1d1db0a80e6c23bf61541",
+			SHA256:  "d6d320eb1536be8fbdb512315d55eada2db3ff87afd613762f125d38a9e7a53c",
+		},
+		Spec: SourceFile{
+			Path:    "clrs/_src/specs.py",
+			GitBlob: "db3b02e14072152df590a8df518ef058fd167930",
+			SHA256:  "51f1cc936b28189c7b2e3b2030c30e224fb448f3d2846181983329448f1ed018",
+		},
+		Algorithm: SourceFile{
+			Path:    "clrs/_src/algorithms/graphs.py",
+			GitBlob: "09303e6eab24e4c35dee510589daceb4e3cc5ee7",
+			SHA256:  "75366fdd2bd72e8f84103dbda6417214fa071bd42237130909b0035b3cd34940",
+		},
+		Sampler: SourceFile{
+			Path:    "clrs/_src/samplers.py",
+			GitBlob: "442a5c6d1da86c2956d8dcc78c9339ded296e1a8",
+			SHA256:  "01921e9ca7fa0cc81a8ce82dd76869820f1e9ad8863d5b76b088b0610a2e0473",
+		},
+		Probing: SourceFile{
+			Path:    "clrs/_src/probing.py",
+			GitBlob: "e4ba102eecdfee2934268a33727da964a2119d37",
+			SHA256:  "6ee8bea717c6a820fec0457c8be01a4459d5b2daab9c2c883ab8db333478f064",
+		},
+	}
+}
+
+// ValidateSource checks that this grammar evidence points to the supplied
+// canonical source record.
+func (evidence SourceEvidence) ValidateSource(source clrsfixture.SourceRecord) error {
+	if evidence != PinnedSourceEvidence() {
+		return fmt.Errorf("BFS supporting source evidence differs from the pinned record")
+	}
+	identity, err := source.Identity()
+	if err != nil {
+		return fmt.Errorf("validate BFS source record: %w", err)
+	}
+	if identity.String() != evidence.SourceID {
+		return fmt.Errorf("BFS source identity = %s, want %s", identity, evidence.SourceID)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

- add a bounded Go implementation of the source-pinned CLRS breadth-first-search vertical
- keep candidate solving separate from the independently arranged shortest-hop verifier
- reject malformed, oversized, cancelled, and source-mismatched construction inputs fail-closed
- route the new package through impact-scoped Go CI while preserving `NO_RESULT`

## Validation

- `go -C tooling test -race ./internal/clrsbfs ./internal/ciplan`
- `go -C tooling vet ./internal/clrsbfs ./internal/ciplan`
- `npm run check:prose`
- `npm run validate:policy`
- `npm run check:code-shape`

Refs #12

A passing implementation or verifier test is construction evidence only; this PR generates no dataset and establishes no scientific result.