### PR TITLE
docs(ci): record comparable main impact scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -212,7 +212,9 @@ the exact diff; this file records why the project changed.
   than exposing fork-controlled code to the privileged office ARC boundary.
   External-fork runs now require approval for every outside contributor.
   Exact-diff CI and CodeQL selection reduce unaffected work; scheduled and
-  manual runs, plus pushes without comparable ancestry, remain full.
+  manual runs, plus pushes without comparable ancestry, remain full. Decision
+  0062 records that comparable `main` pushes use this same bounded,
+  fail-closed impact plan without becoming aggregate or release evidence.
 - Documentation validation now treats byte-identical Mermaid bodies as staged
   source-ownership debt. The exact checked baseline may shrink through reviewed
   owner repairs, while unknown, changed, malformed, or stale groups fail closed.

--- a/decisions/0062-impact-scope-comparable-main-pushes.md
+++ b/decisions/0062-impact-scope-comparable-main-pushes.md
@@ -1,0 +1,61 @@
+# 0062 — Impact-scope comparable main pushes
+
+- **Status:** accepted
+- **Date:** 2026-09-04
+- **Partly supersedes:** [0043](0043-impact-scope-pull-request-ci.md),
+  [0048](0048-gate-ready-pull-requests-with-the-full-ci-matrix.md) and
+  [0052](0052-impact-scope-every-pull-request.md), for ordinary `main`-push
+  planning and acceptance of impact mode outside pull requests
+- **Related:** [issue #7](https://github.com/lusoris/20-watts-was-enough/issues/7),
+  [pull request #34](https://github.com/lusoris/20-watts-was-enough/pull/34)
+
+## Context
+
+The first impact-planning decisions kept every push to `main` on the complete
+aggregate gate. That repeated unrelated workstation and publication work after
+a mapped pull request had already passed its selected boundaries. Pull request
+#34 changed the workflow and its policy tests so a push with an exact,
+comparable before-and-after revision can use the same fail-closed plan.
+
+This change does not meet issue #7's remaining wall-time target. The complete
+[pull-request run 33888059128](https://github.com/lusoris/20-watts-was-enough/actions/runs/33888059128)
+took 8 minutes 21 seconds; the PDF renderer and slowest Fixture 026 shard each
+ran for more than 7 minutes. Reclassifying those jobs would hide the cost, not
+reduce it.
+
+## Decision
+
+1. An opened, synchronised or reopened pull request derives its plan from its
+   exact base and head commits. A push to `main` derives its plan from the event
+   `before` and current commits only when both commits exist and `before` is an
+   ancestor of the current commit.
+2. Comparable `main` pushes use the same bounded Go planner, explicit path map
+   and fail-closed expansion as pull requests. Unknown, non-additive, shared or
+   selector-authority changes still select the full plan.
+3. Missing, zero, invalid or non-ancestral push comparisons select the full
+   plan. Manual dispatches remain full, and the separate exact-tag release
+   workflow retains its complete validation and fresh-evidence boundary.
+4. The required `CI success` job may accept impact mode only for pull requests
+   and pushes. It still rejects every skipped selected lane, every executed
+   unselected lane, malformed selectors and dependency review on a `main`
+   push.
+5. `npm run check` remains the local merge floor. A successful impact plan on a
+   pull request or `main` does not claim that the aggregate gate ran and is not
+   release or scientific evidence.
+
+## Consequences
+
+- Mapped changes do not repeat unrelated workstation shards after merge.
+- A `main` push still expands to the complete gate when its comparison or path
+  authority is uncertain; reducing required checks or remapping slow jobs is
+  not an optimisation path.
+- Issue #7's checked ready-pull-request and unconditional-`main` full-gate
+  statements describe superseded scheduling. The genuinely incomplete item is
+  the measured 3–5 minute full-gate target, which requires physical isolation
+  or setup and renderer improvements without removing assertions.
+
+## Supersession
+
+Supersede this record if a merge queue restores a complete pre-merge
+integration stage, ordinary `main` pushes return to the aggregate gate, or a
+different comparison authority replaces the exact before-to-current plan.

--- a/decisions/README.md
+++ b/decisions/README.md
@@ -48,16 +48,16 @@ than silently changing its outcome.
 | [0040](0040-bind-publications-to-reproducible-and-public-artifacts.md) | Bind publications to reproducible and public artifacts | accepted; renderer-image clauses 1 and 4 partly superseded by [0045](0045-rewrite-renderer-layer-timestamps-before-recording-image-identity.md) |
 | [0041](0041-attest-only-current-run-build-outputs.md) | Attest only current-run build outputs | accepted |
 | [0042](0042-retire-the-host-specific-fixture-012-acquisition-lane.md) | Retire the host-specific Fixture 012 acquisition lane | accepted |
-| [0043](0043-impact-scope-pull-request-ci.md) | Impact-scope pull-request CI | accepted; workstation matrix and full-plan execution shape partly superseded by [0044](0044-shard-workstation-ci-without-splitting-test-authority.md), ready-PR and GitHub-path semantics partly superseded by [0048](0048-gate-ready-pull-requests-with-the-full-ci-matrix.md) |
+| [0043](0043-impact-scope-pull-request-ci.md) | Impact-scope pull-request CI | accepted; workstation matrix and full-plan execution shape partly superseded by [0044](0044-shard-workstation-ci-without-splitting-test-authority.md), ready-PR and GitHub-path semantics partly superseded by [0048](0048-gate-ready-pull-requests-with-the-full-ci-matrix.md), `main`-push full-gate rule partly superseded by [0062](0062-impact-scope-comparable-main-pushes.md) |
 | [0044](0044-shard-workstation-ci-without-splitting-test-authority.md) | Shard workstation CI without splitting test authority | accepted; ready-PR gate extended by [0048](0048-gate-ready-pull-requests-with-the-full-ci-matrix.md), six-Fixture-026-shard clauses partly superseded by [0051](0051-add-a-seventh-fixture-026-shard-after-live-timing.md) |
 | [0045](0045-rewrite-renderer-layer-timestamps-before-recording-image-identity.md) | Rewrite renderer layer timestamps before recording image identity | accepted |
 | [0046](0046-project-the-research-roadmap-into-github-milestones.md) | Project the research roadmap into GitHub milestones | accepted; pull-request exclusion clauses 3 and 6 partly superseded by [0057](0057-project-pull-request-metadata-from-managed-issues.md) |
 | [0047](0047-keep-cloudflare-as-the-public-pages-tls-authority.md) | Keep Cloudflare as the public Pages TLS authority | accepted |
-| [0048](0048-gate-ready-pull-requests-with-the-full-ci-matrix.md) | Gate ready pull requests with the full CI matrix | accepted; readiness-based full-matrix rule partly superseded by [0052](0052-impact-scope-every-pull-request.md) |
+| [0048](0048-gate-ready-pull-requests-with-the-full-ci-matrix.md) | Gate ready pull requests with the full CI matrix | accepted; readiness-based full-matrix rule partly superseded by [0052](0052-impact-scope-every-pull-request.md), `main`-push and pull-request-only impact clauses partly superseded by [0062](0062-impact-scope-comparable-main-pushes.md) |
 | [0049](0049-adopt-bounded-maintenance-automation.md) | Adopt bounded maintenance automation | accepted |
 | [0050](0050-review-the-book-and-pdf-as-one-publication.md) | Review the book and PDF as one publication | accepted |
 | [0051](0051-add-a-seventh-fixture-026-shard-after-live-timing.md) | Add a seventh Fixture 026 shard after live timing | accepted |
-| [0052](0052-impact-scope-every-pull-request.md) | Impact-scope every pull request | accepted |
+| [0052](0052-impact-scope-every-pull-request.md) | Impact-scope every pull request | accepted; `main`-push full-gate and pull-request-only impact clauses partly superseded by [0062](0062-impact-scope-comparable-main-pushes.md) |
 | [0053](0053-lock-the-poppler-pdf-tools-image-foundation.md) | Lock the Poppler PDF-tools image foundation | accepted |
 | [0054](0054-classify-script-impact-by-executable-consumer.md) | Classify script impact by executable consumer | accepted |
 | [0055](0055-freeze-clrs-text-as-a-controller-shakedown.md) | Freeze CLRS-Text as a controller shakedown | accepted |
@@ -65,3 +65,4 @@ than silently changing its outcome.
 | [0057](0057-project-pull-request-metadata-from-managed-issues.md) | Project pull-request metadata from managed issues | accepted |
 | [0059](0059-run-one-enforcing-dependency-audit-per-full-gate.md) | Run one enforcing dependency audit per full gate | accepted |
 | [0061](0061-reconcile-managed-status-with-item-lifecycle.md) | Reconcile managed status with item lifecycle | accepted |
+| [0062](0062-impact-scope-comparable-main-pushes.md) | Impact-scope comparable main pushes | accepted |

--- a/docs/publication-workflow.md
+++ b/docs/publication-workflow.md
@@ -127,10 +127,10 @@ retains both exact PDF and manifest pairs beside that receipt; CI uploads the
 bounded mismatch bundle even if owned-image cleanup then fails. Pull requests
 and `main` pushes preserve their exact diff, so this expensive proof does not
 run for a known unrelated change;
-the pull request may remain impact-scoped while the `main` plan stays full.
-Manual, unavailable, invalid, unmapped and selector-authority diffs select it
-fail-closed; non-additive diffs inspect both retained paths. Tagged releases
-always run the proof and add its
+the pull request and a comparable `main` push may remain impact-scoped.
+Manual runs, unavailable, invalid or non-ancestral push comparisons, unmapped
+paths and selector-authority diffs select it fail-closed; non-additive diffs
+inspect both retained paths. Tagged releases always run the proof and add its
 receipt to the checksum-bound release assets. A mismatch blocks the boundary;
 the receipt remains engineering evidence and is not a scientific result.
 


### PR DESCRIPTION
Refs #7

Records the already-implemented fail-closed impact plan for comparable main pushes and supersedes stale publication-workflow wording. Manual, unavailable, invalid, and non-ancestral comparisons remain full; exact-tag releases remain full.

This does not claim the remaining 3–5 minute full-gate target is met: hosted run 33888059128 took 8m21s, with the renderer and slowest Fixture 026 shard still above seven minutes.