### PR TITLE
fix(ci): require complete CodeQL language results

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,73 +17,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  impact-plan:
-    name: CI impact plan
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      contents: read
-    outputs:
-      mode: ${{ steps.plan.outputs.mode }}
-      go: ${{ steps.plan.outputs.go }}
-      site: ${{ steps.plan.outputs.site }}
-      workstation_any: ${{ steps.plan.outputs.workstation_any }}
-    steps:
-      - name: Check out the complete comparison history
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Use Go 1.27
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version-file: tooling/go.mod
-          cache-dependency-path: tooling/go.sum
-      - name: Validate and project the bounded CI plan
-        id: plan
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          BEFORE_SHA: ${{ github.event.before }}
-          CURRENT_SHA: ${{ github.sha }}
-          EVENT_NAME: ${{ github.event_name }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          set -euo pipefail
-          mkdir -p build
-          if [[ "$EVENT_NAME" == "pull_request" ]]; then
-            go -C tooling run ./cmd/20w ci plan --root .. \
-              --base "$BASE_SHA" --head "$HEAD_SHA" --json \
-              > build/ci-impact-plan.json
-          elif [[ "$EVENT_NAME" == "push" ]]; then
-            zero_sha=0000000000000000000000000000000000000000
-            valid_commit() {
-              local sha="$1"
-              [[ "$sha" =~ ^[0-9a-f]{40}$ ]] && git cat-file -e "${sha}^{commit}" 2>/dev/null
-            }
-            if [[ "$BEFORE_SHA" != "$zero_sha" ]] \
-              && valid_commit "$BEFORE_SHA" \
-              && valid_commit "$CURRENT_SHA" \
-              && git merge-base --is-ancestor "$BEFORE_SHA" "$CURRENT_SHA"; then
-              go -C tooling run ./cmd/20w ci plan --root .. \
-                --base "$BEFORE_SHA" --head "$CURRENT_SHA" --json \
-                > build/ci-impact-plan.json
-            else
-              echo "::notice::Main-push comparison is unavailable; running the fail-closed full plan."
-              go -C tooling run ./cmd/20w ci plan --root .. --full --json \
-                > build/ci-impact-plan.json
-            fi
-          else
-            go -C tooling run ./cmd/20w ci plan --root .. --full --json \
-              > build/ci-impact-plan.json
-          fi
-          test -s build/ci-impact-plan.json
-          go -C tooling run ./cmd/20w ci project \
-            < build/ci-impact-plan.json >> "$GITHUB_OUTPUT"
-
   analyze:
     name: JavaScript and TypeScript analysis
-    needs: impact-plan
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.impact-plan.outputs.mode == 'full' || needs.impact-plan.outputs.site == 'true' || needs.impact-plan.outputs.workstation_any == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -107,8 +42,6 @@ jobs:
 
   analyze-go:
     name: Go analysis
-    needs: impact-plan
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.impact-plan.outputs.mode == 'full' || needs.impact-plan.outputs.go == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,10 +211,13 @@ the exact diff; this file records why the project changed.
 - Public-repository workflows remain on ephemeral GitHub-hosted runners rather
   than exposing fork-controlled code to the privileged office ARC boundary.
   External-fork runs now require approval for every outside contributor.
-  Exact-diff CI and CodeQL selection reduce unaffected work; scheduled and
-  manual runs, plus pushes without comparable ancestry, remain full. Decision
-  0062 records that comparable `main` pushes use this same bounded,
-  fail-closed impact plan without becoming aggregate or release evidence.
+  Exact-diff CI selection reduces unaffected test work; scheduled and manual
+  runs, plus pushes without comparable ancestry, remain full. Decision 0062
+  records that comparable `main` pushes use this same bounded, fail-closed
+  impact plan without becoming aggregate or release evidence. Required CodeQL
+  remains outside impact scoping and now emits both configured language results
+  on every protected pull request and `main` commit, so code-scanning merge
+  protection never waits for a skipped language.
 - Documentation validation now treats byte-identical Mermaid bodies as staged
   source-ownership debt. The exact checked baseline may shrink through reviewed
   owner repairs, while unknown, changed, malformed, or stale groups fail closed.

--- a/docs/repository-rule-crosswalk.md
+++ b/docs/repository-rule-crosswalk.md
@@ -103,8 +103,8 @@ Host controls verified through the GitHub API on 2026-08-28 are:
 - active immutable release-tag ruleset `21727474` for `refs/tags/v*`, with tag
   update and deletion blocked and no bypass actor.
 
-The `main` ruleset was strengthened and read back through the API on
-2026-08-30. Active ruleset `21746706` now has no bypass actor, requires a pull
+The `main` ruleset was read back through the API on 2026-09-04. Active ruleset
+`21746706` has no bypass actor, requires a pull
 request, strict `CI success`, resolved review threads, linear history, and
 CodeQL with no high-or-higher security alert or analysis error. Squash and
 rebase are the admitted merge methods. The approval count remains zero because
@@ -112,6 +112,12 @@ the repository has one human maintainer; GitHub's [ruleset
 guidance](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/available-rules-for-rulesets)
 confirms that zero is a supported setting. A second-human approval gate should
 be added only when a second reviewer can actually serve it.
+
+The advanced CodeQL workflow publishes separate JavaScript/TypeScript and Go
+results for every protected pull-request and `main` commit. Test lanes remain
+impact-scoped, but required code-scanning evidence is not skipped by file type;
+otherwise the ruleset correctly treats the missing language result as a merge
+blocker.
 
 The `cordana.dev` Cloudflare zone has **Always Use HTTPS** enabled. A live check
 on 2026-08-30 verified the exact root redirect and successful HTTPS response;

--- a/scripts/engineering-policy.test.mjs
+++ b/scripts/engineering-policy.test.mjs
@@ -742,50 +742,22 @@ test("Go workflows use tooling/go.mod and the Go CodeQL lane", () => {
   ));
 });
 
-test("CodeQL uses the bounded impact projection and exact language selectors", () => {
+test("CodeQL publishes both configured language results for every protected commit", () => {
   const valid = workflow("codeql");
   assert.deepEqual(validateCodeQlImpactWorkflowObject(valid), []);
 
-  const planFinding = ".github/workflows/codeql.yml: CodeQL must use the exact bounded Go impact projection";
-  const shallowHistory = structuredClone(valid);
-  shallowHistory.jobs["impact-plan"].steps[0].with["fetch-depth"] = 1;
-  assert.ok(validateCodeQlImpactWorkflowObject(shallowHistory).includes(planFinding));
-
-  const forcedPullRequestFull = structuredClone(valid);
-  const plan = forcedPullRequestFull.jobs["impact-plan"].steps.find((step) => step.id === "plan");
-  plan.run = plan.run.replace(
-    "go -C tooling run ./cmd/20w ci plan --root .. \\",
-    "go -C tooling run ./cmd/20w ci plan --root .. --full \\",
-  );
-  assert.ok(validateCodeQlImpactWorkflowObject(forcedPullRequestFull).includes(planFinding));
-
+  const requiredResultFinding = ".github/workflows/codeql.yml: both configured CodeQL languages must run on every protected commit";
   for (const mutate of [
-    (subject) => { subject.defaults = { run: { shell: "true {0}" } }; },
-    (subject) => { subject.jobs["impact-plan"].if = "${{ false }}"; },
-    (subject) => { subject.jobs["impact-plan"].defaults = { run: { shell: "true {0}" } }; },
-    (subject) => {
-      subject.jobs["impact-plan"].steps.find((step) => step.id === "plan").shell = "true {0}";
-    },
+    (subject) => { subject.jobs.analyze.if = "${{ false }}"; },
+    (subject) => { subject.jobs["analyze-go"].if = "${{ false }}"; },
+    (subject) => { subject.jobs.analyze.needs = "impact-plan"; },
+    (subject) => { subject.jobs["analyze-go"]["continue-on-error"] = true; },
+    (subject) => { subject.jobs["impact-plan"] = {}; },
   ]) {
-    const bypassedPlan = structuredClone(valid);
-    mutate(bypassedPlan);
-    assert.ok(validateCodeQlImpactWorkflowObject(bypassedPlan).includes(planFinding));
+    const missingResult = structuredClone(valid);
+    mutate(missingResult);
+    assert.ok(validateCodeQlImpactWorkflowObject(missingResult).includes(requiredResultFinding));
   }
-
-  const broadJavaScript = structuredClone(valid);
-  broadJavaScript.jobs.analyze.if = "always()";
-  assert.ok(validateCodeQlImpactWorkflowObject(broadJavaScript).includes(
-    ".github/workflows/codeql.yml: JavaScript and TypeScript analysis must use only the full-plan, site, or workstation selector",
-  ));
-
-  const missingWorkstationJavaScript = structuredClone(valid);
-  missingWorkstationJavaScript.jobs.analyze.if = missingWorkstationJavaScript.jobs.analyze.if.replace(
-    " || needs.impact-plan.outputs.workstation_any == 'true'",
-    "",
-  );
-  assert.ok(validateCodeQlImpactWorkflowObject(missingWorkstationJavaScript).includes(
-    ".github/workflows/codeql.yml: JavaScript and TypeScript analysis must use only the full-plan, site, or workstation selector",
-  ));
 
   const javascriptFinding = ".github/workflows/codeql.yml: JavaScript and TypeScript CodeQL must keep its exact fail-closed initialization and analysis boundary";
   for (const mutate of [
@@ -807,15 +779,6 @@ test("CodeQL uses the bounded impact projection and exact language selectors", (
     mutate(bypassedJavaScript);
     assert.ok(validateCodeQlImpactWorkflowObject(bypassedJavaScript).includes(javascriptFinding));
   }
-
-  const crossedGoSelector = structuredClone(valid);
-  crossedGoSelector.jobs["analyze-go"].if = crossedGoSelector.jobs["analyze-go"].if.replace(
-    "outputs.go",
-    "outputs.site",
-  );
-  assert.ok(validateCodeQlImpactWorkflowObject(crossedGoSelector).includes(
-    ".github/workflows/codeql.yml: Go analysis must use only the full-plan or Go selector",
-  ));
 });
 
 test("Pages verifies the Cloudflare public transport boundary after deployment", () => {

--- a/scripts/validate-engineering-policy.mjs
+++ b/scripts/validate-engineering-policy.mjs
@@ -1471,16 +1471,10 @@ export function validateCiImpactWorkflowObject(
   return findings;
 }
 
-function codeQlImpactLaneIsExact(job, selectors) {
-  const fullOrSelected = [
-    "github.event_name == 'schedule'",
-    "github.event_name == 'workflow_dispatch'",
-    "needs.impact-plan.outputs.mode == 'full'",
-    ...selectors.map((selector) => `needs.impact-plan.outputs.${selector} == 'true'`),
-  ].join(" || ");
+function codeQlRequiredLaneIsExact(job) {
   return (
-    job?.needs === "impact-plan"
-    && job?.if === fullOrSelected
+    job?.needs === undefined
+    && job?.if === undefined
     && continueOnErrorIsDisabled(job)
     && (job?.steps ?? []).every(continueOnErrorIsDisabled)
   );
@@ -1502,7 +1496,8 @@ function codeQlStepIsExact(step, name, action, expectedWith) {
 function codeQlJobBoundaryIsExact(job, name, expectedStepCount) {
   return (
     job?.name === name
-    && job?.needs === "impact-plan"
+    && job?.needs === undefined
+    && job?.if === undefined
     && job?.["runs-on"] === "ubuntu-latest"
     && job?.["timeout-minutes"] === 30
     && Object.keys(job?.permissions ?? {}).length === 3
@@ -1518,7 +1513,7 @@ function codeQlJobBoundaryIsExact(job, name, expectedStepCount) {
     && Array.isArray(job?.steps)
     && job.steps.length === expectedStepCount
     && Object.keys(job ?? {}).every((key) => [
-      "name", "needs", "if", "runs-on", "timeout-minutes", "permissions", "steps",
+      "name", "runs-on", "timeout-minutes", "permissions", "steps",
     ].includes(key))
   );
 }
@@ -1568,34 +1563,17 @@ export function validateCodeQlImpactWorkflowObject(
 ) {
   const findings = [];
   const jobs = workflow?.jobs ?? {};
-  const plan = jobs["impact-plan"];
-  const expectedOutputs = {
-    mode: "${{ steps.plan.outputs.mode }}",
-    go: "${{ steps.plan.outputs.go }}",
-    site: "${{ steps.plan.outputs.site }}",
-    workstation_any: "${{ steps.plan.outputs.workstation_any }}",
-  };
   recordExpectation(
     findings,
-    Object.keys(plan?.outputs ?? {}).length === Object.keys(expectedOutputs).length
-      && propertiesMatch(plan?.outputs, expectedOutputs)
-      && impactPlanJobRunsExactProjection(workflow, plan),
-    `${relativePath}: CodeQL must use the exact bounded Go impact projection`,
-  );
-  recordExpectation(
-    findings,
-    codeQlImpactLaneIsExact(jobs.analyze, ["site", "workstation_any"]),
-    `${relativePath}: JavaScript and TypeScript analysis must use only the full-plan, site, or workstation selector`,
+    jobs["impact-plan"] === undefined
+      && codeQlRequiredLaneIsExact(jobs.analyze)
+      && codeQlRequiredLaneIsExact(jobs["analyze-go"]),
+    `${relativePath}: both configured CodeQL languages must run on every protected commit`,
   );
   recordExpectation(
     findings,
     javaScriptCodeQlJobIsExact(jobs.analyze),
     `${relativePath}: JavaScript and TypeScript CodeQL must keep its exact fail-closed initialization and analysis boundary`,
-  );
-  recordExpectation(
-    findings,
-    codeQlImpactLaneIsExact(jobs["analyze-go"], ["go"]),
-    `${relativePath}: Go analysis must use only the full-plan or Go selector`,
   );
   return findings;
 }


### PR DESCRIPTION
## Root cause

PR #65 exposed a mismatch between impact-scoped CodeQL jobs and the active main ruleset: the JavaScript/TypeScript result completed, the unchanged Go lane was skipped, and code-scanning merge protection continued waiting for one CodeQL result. A manual run of both language analyses on the exact PR head changed the merge state to clean.

## Change

- run the configured JavaScript/TypeScript and Go CodeQL analyses on every pull request and main commit
- remove the redundant impact-plan job from CodeQL while leaving ordinary CI impact-scoped
- fail repository policy when either required language lane is conditional, dependent, missing, or neutralized
- document the live ruleset and workflow relationship

GitHub documents separate language analyses and treats a missing required code-scanning result as a merge blocker:

- https://docs.github.com/en/code-security/reference/code-scanning/workflow-configuration-options
- https://docs.github.com/en/code-security/concepts/code-scanning/merge-protection

## Validation

- full `npm run check` on Node 26.8.1
- 723 workstation tests: 722 passed, one intentional skip
- 68/68 policy tests
- 65/65 site tests after rebase
- Pages production build and validation
- independent local and AGY/Google AI Ultra reviews, followed by direct source verification

This changes CI/security evidence scheduling only. It creates no scientific result.
