### PR TITLE
perf(ci): create longer matrix jobs first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ the exact diff; this file records why the project changed.
 
 ### Added
 
+- The Go CI projection now lists the longer recently measured workstation jobs
+  first inside the unchanged eight-job concurrency bound. The exact
+  nineteen jobs, static commands, tests and fail-closed success authority stay
+  intact. Replaying two completed runs with unchanged durations and ideal slot
+  availability projects 78–87-second shorter matrix spans. Separate renderer
+  and full-quality bottlenecks remain, so issue 7 stays open until a live full
+  run measures the new order and complete workflow.
 - Fixture 026's three ledger-semantic resume hostiles now run in an eighth
   exact workstation shard. Two recent full-plan runs measured those tests at
   162–172 seconds inside a 377–405-second shard-5 payload; the four retained

--- a/decisions/0066-create-longer-workstation-matrix-jobs-first.md
+++ b/decisions/0066-create-longer-workstation-matrix-jobs-first.md
@@ -1,0 +1,95 @@
+# 0066 — Create longer workstation matrix jobs first
+
+- **Status:** accepted
+- **Date:** 2026-09-04
+- **Extends:** [0044](0044-shard-workstation-ci-without-splitting-test-authority.md),
+  [0051](0051-add-a-seventh-fixture-026-shard-after-live-timing.md) and
+  [0065](0065-isolate-fixture-026-ledger-semantics.md)
+- **Related:** [issue #7](https://github.com/lusoris/20-watts-was-enough/issues/7),
+  [full-plan run 33919786157](https://github.com/lusoris/20-watts-was-enough/actions/runs/33919786157),
+  [main full-plan run 33920538142](https://github.com/lusoris/20-watts-was-enough/actions/runs/33920538142),
+  [GitHub matrix strategy](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstrategymatrix)
+
+## Context
+
+The Go CI projection emits nineteen workstation jobs into one GitHub Actions
+matrix with `max-parallel: 8`. It previously sorted the job identities
+alphabetically. That made eight short or medium jobs the first matrix entries
+and delayed most of the longer Fixture 026 and Fixture 029 jobs until a slot
+became available.
+
+In completed full-plan run 33919786157, the first eight alphabetically ordered
+jobs started at 21:10:35–21:10:36 UTC. Fixture 029 shard 2 started 261 seconds
+later and completed last. The subsequent main full-plan run 33920538142
+repeated the pattern: its first eight jobs started at 21:19:43–21:19:45, while
+Fixture 029 shard 2 started 280 seconds after the first one and again completed
+last. The creation ranks use the mean of these complete job wall times,
+including checkout and locked setup:
+
+| Creation rank | Job | PR run (seconds) | Main run (seconds) | Mean (seconds) |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Fixture 026 shard 6 | 313 | 308 | 310.5 |
+| 2 | Fixture 026 shard 2 | 292 | 323 | 307.5 |
+| 3 | Fixture 026 shard 4 | 291 | 313 | 302.0 |
+| 4 | Fixture 026 shard 1 | 251 | 322 | 286.5 |
+| 5 | Fixture 026 shard 3 | 226 | 311 | 268.5 |
+| 6 | Fixture 026 shard 5 | 257 | 242 | 249.5 |
+| 7 | Fixture 029 shard 2 | 235 | 231 | 233.0 |
+| 8 | Fixture 029 shard 1 | 220 | 228 | 224.0 |
+| 9 | Fixture 026 shard 8 | 189 | 205 | 197.0 |
+| 10 | Candidate 010 | 153 | 170 | 161.5 |
+| 11 | Fixture 026 shard 7 | 69 | 60 | 64.5 |
+| 12 | Fixture 019 | 37 | 37 | 37.0 |
+| 13 | Fixture 024 | 31 | 37 | 34.0 |
+| 14 | Fixture 012 | 37 | 30 | 33.5 |
+| 15 | Fixture 022 | 38 | 25 | 31.5 |
+| 16 | Fixture 027 | 32 | 31 | 31.5 |
+| 17 | Fixture 023 | 33 | 29 | 31.0 |
+| 18 | Fixture 007 | 27 | 30 | 28.5 |
+| 19 | Fixture 025 | 27 | 27 | 27.0 |
+
+GitHub documents that matrix variable order determines job creation order, but
+runner availability and execution duration remain external state. Assigning
+the longer observed jobs first is therefore a bounded scheduling hint, not a
+service-level guarantee.
+
+Replaying the two runs' unchanged wall times through an ideal eight-slot
+longest-first projection gives matrix makespans of 409 and 433 seconds. Their
+observed spans from first matrix start to last completion were 496 and 511
+seconds. The corresponding 87- and 78-second differences are projections only;
+runner availability, changed test duration, the PDF renderer and the full-quality
+lane can still determine the complete workflow time.
+
+## Decision
+
+1. Store one unique creation rank beside each workstation job in the existing
+   Go lane definition. The lane definition remains the single owner of the job
+   identity and its scheduling hint.
+2. Emit selected workstation jobs in ascending creation rank. Reject invalid or
+   repeated ranks, repeated or malformed job identities, and matrices above the
+   existing 32-entry safety bound.
+3. Preserve the exact nineteen job identities, their static package commands,
+   the complete local workstation aggregate, fail-closed plan expansion and the
+   workflow's eight-concurrent-job ceiling.
+4. Treat the ranks as provisional operational data from the two named complete
+   runs. A new job needs an explicit unique rank; repeated live measurements may
+   justify a later reorder.
+5. Keep issue 7 open. Only a complete live run of the revised projection can
+   measure its effect, and no ordering change by itself establishes the
+   remaining three-to-five-minute full-gate target.
+
+## Consequences
+
+- A full plan and a multi-artifact impact plan list their selected longer jobs
+  first without adding runners, commands, tests or workflow privileges.
+- Map iteration and input lane order cannot change the emitted matrix order.
+- Every test, assertion, seed, horizon and result-authority boundary remains
+  unchanged. This scheduling change produces no scientific result.
+- A stale rank can reduce the scheduling benefit but cannot omit or bypass a
+  job; the exact inventory and final success gate remain authoritative.
+
+## Supersession
+
+Supersede this record when repeated live timings justify another fixed order,
+the workstation job inventory changes, or a different runner topology replaces
+the bounded matrix.

--- a/decisions/README.md
+++ b/decisions/README.md
@@ -67,3 +67,4 @@ than silently changing its outcome.
 | [0061](0061-reconcile-managed-status-with-item-lifecycle.md) | Reconcile managed status with item lifecycle | accepted |
 | [0062](0062-impact-scope-comparable-main-pushes.md) | Impact-scope comparable main pushes | accepted |
 | [0065](0065-isolate-fixture-026-ledger-semantics.md) | Isolate Fixture 026 ledger semantics from shard 5 | accepted |
+| [0066](0066-create-longer-workstation-matrix-jobs-first.md) | Create longer workstation matrix jobs first | accepted |

--- a/tooling/internal/ciplan/mapping.go
+++ b/tooling/internal/ciplan/mapping.go
@@ -28,43 +28,66 @@ var (
 	ruleIDPattern = regexp.MustCompile(`^[a-z][a-z0-9-]{0,63}$`)
 	lanePattern   = regexp.MustCompile(`^[a-z][a-z0-9-]{0,63}$`)
 	allowedLanes  = map[string]laneDefinition{
-		"common":                    {},
-		"container":                 {},
-		"dependency":                {},
-		"full":                      {},
-		"go":                        {},
-		"release":                   {},
-		"renderer":                  {},
-		"research":                  {},
-		"site":                      {},
-		"workstation-candidate-010": {WorkstationJobs: []string{"candidate-010"}},
-		"workstation-fixture-007":   {WorkstationJobs: []string{"fixture-007"}},
-		"workstation-fixture-012":   {WorkstationJobs: []string{"fixture-012"}},
-		"workstation-fixture-019":   {WorkstationJobs: []string{"fixture-019"}},
-		"workstation-fixture-022":   {WorkstationJobs: []string{"fixture-022"}},
-		"workstation-fixture-023":   {WorkstationJobs: []string{"fixture-023"}},
-		"workstation-fixture-024":   {WorkstationJobs: []string{"fixture-024"}},
-		"workstation-fixture-025":   {WorkstationJobs: []string{"fixture-025"}},
-		"workstation-fixture-026": {WorkstationJobs: []string{
-			"fixture-026-shard-1",
-			"fixture-026-shard-2",
-			"fixture-026-shard-3",
-			"fixture-026-shard-4",
-			"fixture-026-shard-5",
-			"fixture-026-shard-6",
-			"fixture-026-shard-7",
-			"fixture-026-shard-8",
+		"common":     {},
+		"container":  {},
+		"dependency": {},
+		"full":       {},
+		"go":         {},
+		"release":    {},
+		"renderer":   {},
+		"research":   {},
+		"site":       {},
+		"workstation-candidate-010": {WorkstationJobs: []workstationJobDefinition{
+			{Name: "candidate-010", CreationRank: 10},
 		}},
-		"workstation-fixture-027": {WorkstationJobs: []string{"fixture-027"}},
-		"workstation-fixture-029": {WorkstationJobs: []string{
-			"fixture-029-shard-1",
-			"fixture-029-shard-2",
+		"workstation-fixture-007": {WorkstationJobs: []workstationJobDefinition{
+			{Name: "fixture-007", CreationRank: 18},
+		}},
+		"workstation-fixture-012": {WorkstationJobs: []workstationJobDefinition{
+			{Name: "fixture-012", CreationRank: 14},
+		}},
+		"workstation-fixture-019": {WorkstationJobs: []workstationJobDefinition{
+			{Name: "fixture-019", CreationRank: 12},
+		}},
+		"workstation-fixture-022": {WorkstationJobs: []workstationJobDefinition{
+			{Name: "fixture-022", CreationRank: 15},
+		}},
+		"workstation-fixture-023": {WorkstationJobs: []workstationJobDefinition{
+			{Name: "fixture-023", CreationRank: 17},
+		}},
+		"workstation-fixture-024": {WorkstationJobs: []workstationJobDefinition{
+			{Name: "fixture-024", CreationRank: 13},
+		}},
+		"workstation-fixture-025": {WorkstationJobs: []workstationJobDefinition{
+			{Name: "fixture-025", CreationRank: 19},
+		}},
+		"workstation-fixture-026": {WorkstationJobs: []workstationJobDefinition{
+			{Name: "fixture-026-shard-1", CreationRank: 4},
+			{Name: "fixture-026-shard-2", CreationRank: 2},
+			{Name: "fixture-026-shard-3", CreationRank: 5},
+			{Name: "fixture-026-shard-4", CreationRank: 3},
+			{Name: "fixture-026-shard-5", CreationRank: 6},
+			{Name: "fixture-026-shard-6", CreationRank: 1},
+			{Name: "fixture-026-shard-7", CreationRank: 11},
+			{Name: "fixture-026-shard-8", CreationRank: 9},
+		}},
+		"workstation-fixture-027": {WorkstationJobs: []workstationJobDefinition{
+			{Name: "fixture-027", CreationRank: 16},
+		}},
+		"workstation-fixture-029": {WorkstationJobs: []workstationJobDefinition{
+			{Name: "fixture-029-shard-1", CreationRank: 8},
+			{Name: "fixture-029-shard-2", CreationRank: 7},
 		}},
 	}
 )
 
+type workstationJobDefinition struct {
+	Name         string
+	CreationRank int
+}
+
 type laneDefinition struct {
-	WorkstationJobs []string
+	WorkstationJobs []workstationJobDefinition
 }
 
 // Mapping is the closed path-to-lane authority.

--- a/tooling/internal/ciplan/projection.go
+++ b/tooling/internal/ciplan/projection.go
@@ -71,13 +71,13 @@ func Project(plan Plan) (Projection, error) {
 		WorkstationMatrix: "[]",
 	}
 	if plan.Mode == "full" {
-		jobs := make([]string, 0, maximumWorkstationJobs)
+		jobs := make([]workstationJobDefinition, 0, maximumWorkstationJobs)
 		for _, definition := range allowedLanes {
 			jobs = append(jobs, definition.WorkstationJobs...)
 		}
 		return projectWorkstationJobs(projection, jobs)
 	}
-	jobs := make([]string, 0)
+	jobs := make([]workstationJobDefinition, 0)
 	for _, lane := range plan.Lanes {
 		switch lane {
 		case "common":
@@ -107,7 +107,7 @@ func Project(plan Plan) (Projection, error) {
 	return projectWorkstationJobs(projection, jobs)
 }
 
-func projectWorkstationJobs(projection Projection, jobs []string) (Projection, error) {
+func projectWorkstationJobs(projection Projection, jobs []workstationJobDefinition) (Projection, error) {
 	if len(jobs) > maximumWorkstationJobs {
 		return Projection{}, fmt.Errorf(
 			"workstation projection contains %d jobs, limit is %d",
@@ -115,14 +115,36 @@ func projectWorkstationJobs(projection Projection, jobs []string) (Projection, e
 			maximumWorkstationJobs,
 		)
 	}
-	sort.Strings(jobs)
+	sort.Slice(jobs, func(left, right int) bool {
+		return jobs[left].CreationRank < jobs[right].CreationRank
+	})
+	names := make([]string, len(jobs))
+	seenNames := make(map[string]struct{}, len(jobs))
 	for index, job := range jobs {
-		if !lanePattern.MatchString(job) || (index > 0 && job == jobs[index-1]) {
-			return Projection{}, fmt.Errorf("workstation projection job is invalid or repeated: %q", job)
+		if !lanePattern.MatchString(job.Name) {
+			return Projection{}, fmt.Errorf("workstation projection job is invalid: %q", job.Name)
 		}
+		if job.CreationRank < 1 || job.CreationRank > maximumWorkstationJobs {
+			return Projection{}, fmt.Errorf(
+				"workstation projection job %q has invalid creation rank %d",
+				job.Name,
+				job.CreationRank,
+			)
+		}
+		if _, duplicate := seenNames[job.Name]; duplicate {
+			return Projection{}, fmt.Errorf("workstation projection job is repeated: %q", job.Name)
+		}
+		if index > 0 && job.CreationRank == jobs[index-1].CreationRank {
+			return Projection{}, fmt.Errorf(
+				"workstation projection creation rank is repeated: %d",
+				job.CreationRank,
+			)
+		}
+		seenNames[job.Name] = struct{}{}
+		names[index] = job.Name
 	}
 	projection.WorkstationAny = len(jobs) > 0
-	matrix, err := json.Marshal(jobs)
+	matrix, err := json.Marshal(names)
 	if err != nil {
 		return Projection{}, fmt.Errorf("encode workstation matrix: %w", err)
 	}

--- a/tooling/internal/ciplan/projection_test.go
+++ b/tooling/internal/ciplan/projection_test.go
@@ -30,25 +30,25 @@ func TestProjectEmitsClosedFullSemanticsAndEveryWorkstationJob(t *testing.T) {
 		t.Fatal(err)
 	}
 	wantJobs := []string{
-		"candidate-010",
-		"fixture-007",
-		"fixture-012",
-		"fixture-019",
-		"fixture-022",
-		"fixture-023",
-		"fixture-024",
-		"fixture-025",
-		"fixture-026-shard-1",
-		"fixture-026-shard-2",
-		"fixture-026-shard-3",
-		"fixture-026-shard-4",
-		"fixture-026-shard-5",
 		"fixture-026-shard-6",
-		"fixture-026-shard-7",
-		"fixture-026-shard-8",
-		"fixture-027",
-		"fixture-029-shard-1",
+		"fixture-026-shard-2",
+		"fixture-026-shard-4",
+		"fixture-026-shard-1",
+		"fixture-026-shard-3",
+		"fixture-026-shard-5",
 		"fixture-029-shard-2",
+		"fixture-029-shard-1",
+		"fixture-026-shard-8",
+		"candidate-010",
+		"fixture-026-shard-7",
+		"fixture-019",
+		"fixture-024",
+		"fixture-012",
+		"fixture-022",
+		"fixture-027",
+		"fixture-023",
+		"fixture-007",
+		"fixture-025",
 	}
 	if !reflect.DeepEqual(jobs, wantJobs) {
 		t.Fatalf("full workstation matrix = %v, want %v", jobs, wantJobs)
@@ -60,7 +60,7 @@ func TestProjectEmitsClosedFullSemanticsAndEveryWorkstationJob(t *testing.T) {
 	for _, expected := range []string{
 		"container=false\n", "dependency=false\n", "go=false\n", "release=false\n", "renderer=false\n", "research=false\n",
 		"site=false\n", "workstation_any=true\n",
-		"workstation_matrix=[\"candidate-010\",\"fixture-007\"",
+		"workstation_matrix=[\"fixture-026-shard-6\",\"fixture-026-shard-2\"",
 	} {
 		if !strings.Contains(output.String(), expected) {
 			t.Fatalf("full GitHub outputs = %q, missing %q", output.String(), expected)
@@ -107,16 +107,16 @@ func TestProjectExpandsOnlySelectedShardedArtifacts(t *testing.T) {
 		t.Fatal(err)
 	}
 	want := []string{
-		"fixture-026-shard-1",
-		"fixture-026-shard-2",
-		"fixture-026-shard-3",
-		"fixture-026-shard-4",
-		"fixture-026-shard-5",
 		"fixture-026-shard-6",
-		"fixture-026-shard-7",
-		"fixture-026-shard-8",
-		"fixture-029-shard-1",
+		"fixture-026-shard-2",
+		"fixture-026-shard-4",
+		"fixture-026-shard-1",
+		"fixture-026-shard-3",
+		"fixture-026-shard-5",
 		"fixture-029-shard-2",
+		"fixture-029-shard-1",
+		"fixture-026-shard-8",
+		"fixture-026-shard-7",
 	}
 	if !projection.WorkstationAny || !reflect.DeepEqual(jobs, want) {
 		t.Fatalf("sharded projection = %#v / %v, want %v", projection, jobs, want)
@@ -215,11 +215,27 @@ func TestProjectRejectsMalformedPlanCombinations(t *testing.T) {
 	}
 }
 
-func TestProjectWorkstationJobsRejectsDuplicateAndExcessiveMatrices(t *testing.T) {
+func TestProjectWorkstationJobsRejectsInvalidMatrices(t *testing.T) {
 	t.Parallel()
-	for name, jobs := range map[string][]string{
-		"duplicate": {"fixture-026-shard-1", "fixture-026-shard-1"},
-		"excessive": make([]string, maximumWorkstationJobs+1),
+	for name, jobs := range map[string][]workstationJobDefinition{
+		"duplicate name": {
+			{Name: "fixture-026-shard-1", CreationRank: 1},
+			{Name: "fixture-026-shard-1", CreationRank: 2},
+		},
+		"duplicate creation rank": {
+			{Name: "fixture-026-shard-1", CreationRank: 1},
+			{Name: "fixture-026-shard-2", CreationRank: 1},
+		},
+		"invalid creation rank": {
+			{Name: "fixture-026-shard-1", CreationRank: 0},
+		},
+		"excessive creation rank": {
+			{Name: "fixture-026-shard-1", CreationRank: maximumWorkstationJobs + 1},
+		},
+		"malformed name": {
+			{Name: "fixture/026", CreationRank: 1},
+		},
+		"excessive": make([]workstationJobDefinition, maximumWorkstationJobs+1),
 	} {
 		t.Run(name, func(t *testing.T) {
 			if _, err := projectWorkstationJobs(Projection{}, jobs); err == nil {


### PR DESCRIPTION
## Summary

- emit the existing nineteen workstation matrix jobs in a fixed longer-first creation order derived from two named completed runs
- reject malformed or repeated job names, invalid or repeated creation ranks, and matrices above the existing 32-job bound
- record the operational decision without changing any test command, assertion, seed, horizon, result authority, workflow permission, or the eight-job concurrency ceiling

## Evidence boundary

The source runs had observed workstation-matrix spans of 496 and 511 seconds. Replaying their unchanged job durations through an ideal eight-slot schedule gives 409 and 433 seconds, respectively: projected differences of 87 and 78 seconds. GitHub documents matrix order as job-creation order, but runner availability and duration drift remain external state.

This patch therefore claims only a bounded scheduling hint. It does not claim a measured live improvement or a complete-workflow reduction, and issue #7 remains open pending a post-merge full run.

## Validation

- `npm run check` — pass; 723 workstation tests, 722 pass, one intentional skip, plus the production Pages build and final validation
- `go -C tooling test -race -count=100 ./internal/ciplan` — pass
- `go -C tooling test -race ./...` — pass
- `go -C tooling vet ./...` — pass
- `npm run validate:policy` — pass
- `npm run test:policy` — 69/69 pass
- `npm run check:prose` — pass
- exact full-plan projection and `git diff --check` — pass
- local Qwen3.8-27B read-only review — PASS with no blocking defect; this is supporting automation, not human approval

Tracks #7
