### PR TITLE
perf(ci): run workstation suite through bounded Go catalogue

### DIFF
--- a/.github/ci-impact.json
+++ b/.github/ci-impact.json
@@ -76,7 +76,8 @@
         "tooling/go.mod",
         "tooling/go.sum",
         "tooling/internal/ciplan/**",
-        "tooling/internal/strictjson/**"
+        "tooling/internal/strictjson/**",
+        "tooling/internal/workstationrunner/**"
       ],
       "lanes": [
         "full"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,7 +369,7 @@ jobs:
       fail-fast: false
       max-parallel: 8
       matrix:
-        artifact: ${{ fromJSON(needs.impact-plan.outputs.workstation_matrix) }}
+        include: ${{ fromJSON(needs.impact-plan.outputs.workstation_matrix) }}
     steps:
       - name: Check out canonical source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -397,31 +397,8 @@ jobs:
         run: npm ci --no-audit
       - name: Run the allowlisted artifact test script
         env:
-          ARTIFACT: ${{ matrix.artifact }}
-        run: |
-          set -euo pipefail
-          case "$ARTIFACT" in
-            candidate-010) npm run test:workstation:candidate-010 ;;
-            fixture-007) npm run test:workstation:fixture-007 ;;
-            fixture-012) npm run test:workstation:fixture-012 ;;
-            fixture-019) npm run test:workstation:fixture-019 ;;
-            fixture-022) npm run test:workstation:fixture-022 ;;
-            fixture-023) npm run test:workstation:fixture-023 ;;
-            fixture-024) npm run test:workstation:fixture-024 ;;
-            fixture-025) npm run test:workstation:fixture-025 ;;
-            fixture-026-shard-1) npm run test:workstation:fixture-026:shard-1 ;;
-            fixture-026-shard-2) npm run test:workstation:fixture-026:shard-2 ;;
-            fixture-026-shard-3) npm run test:workstation:fixture-026:shard-3 ;;
-            fixture-026-shard-4) npm run test:workstation:fixture-026:shard-4 ;;
-            fixture-026-shard-5) npm run test:workstation:fixture-026:shard-5 ;;
-            fixture-026-shard-6) npm run test:workstation:fixture-026:shard-6 ;;
-            fixture-026-shard-7) npm run test:workstation:fixture-026:shard-7 ;;
-            fixture-026-shard-8) npm run test:workstation:fixture-026:shard-8 ;;
-            fixture-027) npm run test:workstation:fixture-027 ;;
-            fixture-029-shard-1) npm run test:workstation:fixture-029:shard-1 ;;
-            fixture-029-shard-2) npm run test:workstation:fixture-029:shard-2 ;;
-            *) echo "::error::unallowlisted workstation artifact: $ARTIFACT"; exit 1 ;;
-          esac
+          SCRIPT: ${{ matrix.script }}
+        run: npm run "$SCRIPT"
 
   container-smoke:
     name: Container smoke paths

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,21 @@ the exact diff; this file records why the project changed.
 
 ### Added
 
+- Decision 0068 makes the Go workstation catalogue own each artifact's exact
+  package script as well as its creation rank in one embedded machine-readable
+  authority. CI consumes the projected, validated `{artifact, script}` objects
+  without repeating a nineteen-arm shell dispatch. The local aggregate now
+  runs core and all nineteen unchanged scripts through the same creation-ordered
+  catalogue with at most eight active process trees, a 30-minute and 2 MiB
+  combined-output bound per job, a closed environment, cancellation and
+  post-wait tree cleanup, and a deterministic complete-failure summary. The
+  strict preflight freezes exact Node argument vectors before concurrency, so a
+  later package-file rewrite and npm lifecycle hooks cannot change execution.
+  It also proves that the catalogue covers every discovered workstation test
+  exactly once and each manifest `full_tests` path exactly once through its own
+  artifact jobs. The test files, assertions, seeds, horizons and `NO_RESULT`
+  boundaries do not change; issue 7 remains open for a measured complete live
+  workflow.
 - The Go CI projection now lists the longer recently measured workstation jobs
   first inside the unchanged eight-job concurrency bound. The exact
   nineteen jobs, static commands, tests and fail-closed success authority stay

--- a/decisions/0068-run-workstation-tests-through-the-bounded-go-catalogue.md
+++ b/decisions/0068-run-workstation-tests-through-the-bounded-go-catalogue.md
@@ -1,0 +1,91 @@
+# 0068 — Run workstation tests through the bounded Go catalogue
+
+- **Status:** accepted
+- **Date:** 2026-09-05
+- **Partly supersedes:** [0044](0044-shard-workstation-ci-without-splitting-test-authority.md),
+  for the serial local aggregate in clause 2 only
+- **Extends:** [0066](0066-create-longer-workstation-matrix-jobs-first.md)
+- **Related:** [issue #7](https://github.com/lusoris/20-watts-was-enough/issues/7)
+
+## Context
+
+The workstation test inventory has two execution descriptions. The Go impact
+planner owns nineteen artifact identities and their creation order, while the
+CI workflow repeats the identity-to-package-script mapping in a nineteen-arm
+shell case. The complete local `test:workstation` command instead starts every
+test file in one serial Node process. Adding or moving a shard therefore
+requires coordinated edits to several command lists, and the local aggregate
+cannot use the same bounded parallelism as CI.
+
+The individual package scripts already preserve the file partitions,
+`--test-concurrency` settings, assertions, seeds and horizons. Scheduling those
+commands concurrently does not require another partition or a change to test
+semantics. It does require explicit limits: a failed job must not hide later
+failures, subprocess output cannot grow without bound, and cancellation must
+stop active work rather than merely suppressing the final status.
+
+## Decision
+
+1. Store the core script and each artifact's lane, exact package-script identity
+   and creation rank in one embedded, machine-readable Go catalogue. The
+   projection emits validated `{artifact, script}` objects. CI consumes those
+   objects through `matrix.include` and invokes the projected script as the
+   quoted script argument to `npm run`; it does not maintain a second dispatch
+   table.
+2. Make `20w ci run-workstation` the complete local aggregate. It runs the core
+   script and all nineteen creation-ordered artifact scripts with at most eight
+   commands active. `package.json` remains the owner of each script body. One
+   strict preflight read freezes every admitted script as its exact Node
+   argument vector; execution does not reread mutable package metadata or run
+   npm lifecycle hooks.
+3. Invoke every command directly with `exec.CommandContext` and isolate its
+   process tree through one absolute Node executable. Cancellation and
+   post-wait cleanup kill the process group on Unix. On Windows, start the
+   process suspended, attach it to a kill-on-close Job Object, then resume it;
+   fail closed if the lifetime container cannot be established. Give each job
+   at most 30 minutes, retain at most 2 MiB of its combined standard output and
+   error, and allow at most two seconds for inherited pipes to close after the
+   command ends or is cancelled. Crossing the output limit cancels and fails
+   that job. Cleanup runs after every started job, including when the parent
+   exits before a pipe-inheriting descendant.
+4. Pass only a fixed set of runtime, path, locale, temporary-directory and
+   colour variables. Reject duplicate retained names, values above 8 KiB, more
+   than 32 retained entries or more than 64 KiB in total. Do not forward
+   arbitrary npm, Node, GitHub or experiment variables from the caller.
+5. Continue after ordinary job failures and report every result in catalogue
+   order. Caller cancellation reaches active command contexts and marks work
+   that has not started as cancelled; it does not start replacement jobs.
+6. Keep `validate:workstation` immediately before the aggregate in the full
+   package gate. Before starting a subprocess, the Go aggregate preflight
+   strictly reads the catalogue, package scripts and workstation manifests. It
+   proves that every discovered workstation test is covered exactly once and
+   that every declared `full_tests` path is covered exactly once by its own
+   artifact jobs. The scheduler changes execution mechanics only. A passing
+   aggregate remains validation evidence, not a scientific result.
+
+## Consequences
+
+- CI and the local aggregate now share one closed artifact-to-script catalogue.
+  Adding a job without a unique artifact, script and creation rank fails before
+  execution.
+- The aggregate no longer treats its package commands as an opaque proof. A
+  catalogue, manifest or package-script omission, duplicate, empty pattern or
+  stale path fails the exact preflight coverage check before tests start.
+- Later package-file mutation cannot replace a frozen command, and npm
+  `pretest:*` or `posttest:*` hooks are outside the admitted execution path.
+- Local and tagged-release validation retain the complete core-plus-artifact
+  inventory but no longer require one serial Node process. Concurrent access to
+  a shared checkout can expose hidden test coupling; such a failure remains a
+  failure to repair rather than a reason to drop coverage.
+- A single failed shard no longer ends diagnosis at the first error. The final
+  summary lists passes, failures and cancellations in a stable order and prints
+  bounded captured output for incomplete jobs.
+- Issue 7 remains open until a complete live workflow meets its wall-time
+  acceptance. This scheduling change does not establish that result.
+
+## Supersession
+
+Supersede this record if the workstation inventory stops using package scripts,
+measured resource contention requires another concurrency ceiling, or a
+containerised runner replaces direct local execution while preserving the same
+closed test authority.

--- a/decisions/README.md
+++ b/decisions/README.md
@@ -49,7 +49,7 @@ than silently changing its outcome.
 | [0041](0041-attest-only-current-run-build-outputs.md) | Attest only current-run build outputs | accepted |
 | [0042](0042-retire-the-host-specific-fixture-012-acquisition-lane.md) | Retire the host-specific Fixture 012 acquisition lane | accepted |
 | [0043](0043-impact-scope-pull-request-ci.md) | Impact-scope pull-request CI | accepted; workstation matrix and full-plan execution shape partly superseded by [0044](0044-shard-workstation-ci-without-splitting-test-authority.md), ready-PR and GitHub-path semantics partly superseded by [0048](0048-gate-ready-pull-requests-with-the-full-ci-matrix.md), `main`-push full-gate rule partly superseded by [0062](0062-impact-scope-comparable-main-pushes.md) |
-| [0044](0044-shard-workstation-ci-without-splitting-test-authority.md) | Shard workstation CI without splitting test authority | accepted; ready-PR gate extended by [0048](0048-gate-ready-pull-requests-with-the-full-ci-matrix.md), six-Fixture-026-shard clauses partly superseded by [0051](0051-add-a-seventh-fixture-026-shard-after-live-timing.md) |
+| [0044](0044-shard-workstation-ci-without-splitting-test-authority.md) | Shard workstation CI without splitting test authority | accepted; ready-PR gate extended by [0048](0048-gate-ready-pull-requests-with-the-full-ci-matrix.md), six-Fixture-026-shard clauses partly superseded by [0051](0051-add-a-seventh-fixture-026-shard-after-live-timing.md), local-serial aggregate partly superseded by [0068](0068-run-workstation-tests-through-the-bounded-go-catalogue.md) |
 | [0045](0045-rewrite-renderer-layer-timestamps-before-recording-image-identity.md) | Rewrite renderer layer timestamps before recording image identity | accepted |
 | [0046](0046-project-the-research-roadmap-into-github-milestones.md) | Project the research roadmap into GitHub milestones | accepted; pull-request exclusion clauses 3 and 6 partly superseded by [0057](0057-project-pull-request-metadata-from-managed-issues.md) |
 | [0047](0047-keep-cloudflare-as-the-public-pages-tls-authority.md) | Keep Cloudflare as the public Pages TLS authority | accepted |
@@ -69,3 +69,4 @@ than silently changing its outcome.
 | [0064](0064-map-chromium-emphasis-tags-for-pdf-1x.md) | Map Chromium emphasis tags for PDF 1.x | accepted |
 | [0065](0065-isolate-fixture-026-ledger-semantics.md) | Isolate Fixture 026 ledger semantics from shard 5 | accepted |
 | [0066](0066-create-longer-workstation-matrix-jobs-first.md) | Create longer workstation matrix jobs first | accepted |
+| [0068](0068-run-workstation-tests-through-the-bounded-go-catalogue.md) | Run workstation tests through the bounded Go catalogue | accepted |

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "validate:math": "node scripts/validate-math.mjs",
     "format:math": "node scripts/normalize-math-delimiters.mjs --write",
     "validate:workstation": "node scripts/validate-workstation.mjs",
-    "test:workstation": "node --test --experimental-test-isolation=none --test-concurrency=1 experiments/workstation/*.test.mjs experiments/workstation/**/*.test.mjs",
+    "test:workstation": "go -C tooling run ./cmd/20w ci run-workstation --root ..",
     "test:workstation:core": "node --test --experimental-test-isolation=none --test-concurrency=1 experiments/workstation/*.test.mjs experiments/workstation/lib/*.test.mjs",
     "test:readiness": "node --test --experimental-test-isolation=none scripts/readiness-summary.test.mjs",
     "test:site": "node --test --test-concurrency=1 --experimental-test-isolation=none scripts/book-route.test.mjs scripts/book-edition-surface.test.mjs scripts/book-fragment-browser.test.mjs scripts/github-pages.test.mjs scripts/language-access.test.mjs scripts/mermaid-browser.test.mjs scripts/pages-base.test.mjs scripts/pages-seo.test.mjs scripts/prepare-reader-artifacts.test.mjs scripts/publication-unification.test.mjs",

--- a/public/downloads/book-manifest.json
+++ b/public/downloads/book-manifest.json
@@ -4,7 +4,7 @@
   "version": "0.3.0",
   "source_ref": "main",
   "pdf": "public/downloads/20-watts-was-enough-full-concept-book.pdf",
-  "source_digest": "73213fb099728f833f154c0f09f35f5f872997b524daacd32705af9c469992b7",
+  "source_digest": "afe7a698d9c03234611ec3ed8245acbaa35e69b454484bf97654ac62ffcfd237",
   "source_files": [
     "app/book-content.ts",
     "app/components/book-edition.tsx",

--- a/scripts/book-pdf-semantic-baseline.json
+++ b/scripts/book-pdf-semantic-baseline.json
@@ -7,7 +7,7 @@
     "pdf": "public/downloads/20-watts-was-enough-full-concept-book.pdf",
     "manifest": "public/downloads/book-manifest.json",
     "pdf_sha256": "e94ca0c9bc668f90cea769a3e67e8662d0ca674a6254bf74f9ee42f1ef20b548",
-    "manifest_sha256": "f45d13411e39745955b547e843995013c446f4ef1989eb26e49e0f26cf2d3fa3",
+    "manifest_sha256": "30d2de9b44acdf8a576a2df84376c2f2f13ade84ef185888b94eebf42918084e",
     "size_bytes": 12778591,
     "pages": 412,
     "page_size_name": "A4",
@@ -18,7 +18,7 @@
     "pdf_version": "1.4",
     "tagged": true,
     "source_ref": "main",
-    "source_digest": "73213fb099728f833f154c0f09f35f5f872997b524daacd32705af9c469992b7",
+    "source_digest": "afe7a698d9c03234611ec3ed8245acbaa35e69b454484bf97654ac62ffcfd237",
     "version": "0.3.0"
   },
   "tools": {

--- a/scripts/engineering-policy.test.mjs
+++ b/scripts/engineering-policy.test.mjs
@@ -198,6 +198,12 @@ test("workstation shard scripts retain their exact disjoint inventories", () => 
     "package.json: check:full-without-workstation must retain the complete non-workstation aggregate gate",
   ));
 
+  const bypassedRunner = structuredClone(manifest);
+  bypassedRunner.scripts["test:workstation"] = bypassedRunner.scripts["test:workstation:core"];
+  assert.ok(validate(bypassedRunner).includes(
+    "package.json: test:workstation must use the bounded Go catalogue runner",
+  ));
+
   const weakenedLocalGate = structuredClone(manifest);
   weakenedLocalGate.scripts.test = weakenedLocalGate.scripts.test.replace(
     "npm run validate:workstation && npm run test:workstation",
@@ -1145,19 +1151,16 @@ test("CI selected-lane aggregation and artifact dispatch fail closed", () => {
   ));
   artifactStep.run = 'eval "$PLAN_COMMAND"';
   assert.ok(validateCiImpactWorkflowObject(dynamicCommand).includes(
-    ".github/workflows/ci.yml: workstation matrix execution must dispatch only the nineteen static test scripts",
+    ".github/workflows/ci.yml: workstation matrix execution must quote the Go-projected script without a second dispatch table",
   ));
 
-  const extraDispatch = structuredClone(valid);
-  const extraArtifactStep = extraDispatch.jobs["workstation-artifacts"].steps.find((step) => (
+  const unquotedDispatch = structuredClone(valid);
+  const unquotedArtifactStep = unquotedDispatch.jobs["workstation-artifacts"].steps.find((step) => (
     step.name === "Run the allowlisted artifact test script"
   ));
-  extraArtifactStep.run = extraArtifactStep.run.replace(
-    "  fixture-026-shard-1) npm run test:workstation:fixture-026:shard-1 ;;",
-    "  fixture-026-shard-1) true ;;\n  fixture-026-shard-1) npm run test:workstation:fixture-026:shard-1 ;;",
-  );
-  assert.ok(validateCiImpactWorkflowObject(extraDispatch).includes(
-    ".github/workflows/ci.yml: workstation matrix execution must dispatch only the nineteen static test scripts",
+  unquotedArtifactStep.run = "npm run $SCRIPT";
+  assert.ok(validateCiImpactWorkflowObject(unquotedDispatch).includes(
+    ".github/workflows/ci.yml: workstation matrix execution must quote the Go-projected script without a second dispatch table",
   ));
 
   const ignoredShardFailure = structuredClone(valid);
@@ -1169,11 +1172,12 @@ test("CI selected-lane aggregation and artifact dispatch fail closed", () => {
   ));
 
   const constantArtifact = structuredClone(valid);
-  constantArtifact.jobs["workstation-artifacts"].steps.find((step) => (
+  const constantArtifactStep = constantArtifact.jobs["workstation-artifacts"].steps.find((step) => (
     step.name === "Run the allowlisted artifact test script"
-  )).env.ARTIFACT = "fixture-026-shard-1";
+  ));
+  constantArtifactStep.env.SCRIPT = "test:workstation:fixture-026:shard-1";
   assert.ok(validateCiImpactWorkflowObject(constantArtifact).includes(
-    ".github/workflows/ci.yml: workstation matrix execution must dispatch only the nineteen static test scripts",
+    ".github/workflows/ci.yml: workstation matrix execution must quote the Go-projected script without a second dispatch table",
   ));
 });
 
@@ -1181,7 +1185,7 @@ test("CI workstation and success authority cannot be conditionally skipped", () 
   const valid = workflow("ci");
   const matrixFinding = ".github/workflows/ci.yml: an empty workstation matrix must skip both workstation jobs and selected tests must use the bounded eight-concurrent-job matrix";
   const coreFinding = ".github/workflows/ci.yml: workstation core must run its complete authority step unconditionally";
-  const dispatchFinding = ".github/workflows/ci.yml: workstation matrix execution must dispatch only the nineteen static test scripts";
+  const dispatchFinding = ".github/workflows/ci.yml: workstation matrix execution must quote the Go-projected script without a second dispatch table";
   const successFinding = ".github/workflows/ci.yml: ci-success must unconditionally inspect the exact fail-closed state vector";
 
   const excludedShard = structuredClone(valid);
@@ -1189,6 +1193,12 @@ test("CI workstation and success authority cannot be conditionally skipped", () 
     { artifact: "fixture-026-shard-1" },
   ];
   assert.ok(validateCiImpactWorkflowObject(excludedShard).includes(matrixFinding));
+
+  const artifactOnlyMatrix = structuredClone(valid);
+  const artifactOnlyStrategy = artifactOnlyMatrix.jobs["workstation-artifacts"].strategy.matrix;
+  artifactOnlyStrategy.artifact = artifactOnlyStrategy.include;
+  delete artifactOnlyStrategy.include;
+  assert.ok(validateCiImpactWorkflowObject(artifactOnlyMatrix).includes(matrixFinding));
 
   const skippedCore = structuredClone(valid);
   skippedCore.jobs["workstation-core"].steps.find((step) => (
@@ -1201,6 +1211,12 @@ test("CI workstation and success authority cannot be conditionally skipped", () 
     step.name === "Run the allowlisted artifact test script"
   )).if = "matrix.artifact != 'fixture-026-shard-1'";
   assert.ok(validateCiImpactWorkflowObject(skippedShard).includes(dispatchFinding));
+
+  const ambientArtifact = structuredClone(valid);
+  ambientArtifact.jobs["workstation-artifacts"].steps.find((step) => (
+    step.name === "Run the allowlisted artifact test script"
+  )).env.ARTIFACT = "${{ matrix.artifact }}";
+  assert.ok(validateCiImpactWorkflowObject(ambientArtifact).includes(dispatchFinding));
 
   const skippedSuccess = structuredClone(valid);
   delete skippedSuccess.jobs["ci-success"].if;

--- a/scripts/lib/workstation-manifests.mjs
+++ b/scripts/lib/workstation-manifests.mjs
@@ -846,11 +846,12 @@ async function artifactProtocolEligibility(root, manifest) {
   }
 }
 
-function coversCompleteWorkstationTestInventory(command) {
-  return typeof command === "string" && [
-    "experiments/workstation/*.test.mjs",
-    "experiments/workstation/**/*.test.mjs",
-  ].every((pattern) => command.includes(pattern));
+async function workstationTestPipelineCovers(root) {
+  const packagePath = await repositoryRegularFile(root, "package.json", "package.json");
+  const packageDocument = JSON.parse(await readFile(packagePath, "utf8"));
+  return packageDocument.scripts?.test?.includes("npm run test:workstation") === true
+    && packageDocument.scripts?.["test:workstation"]
+      === "go -C tooling run ./cmd/20w ci run-workstation --root ..";
 }
 
 export async function workstationPromotionChecks(root, manifest) {
@@ -887,11 +888,7 @@ export async function workstationPromotionChecks(root, manifest) {
   const fullTestPaths = fullTests.map((value) => localPath(root, value));
   let workstationTestPipeline = false;
   try {
-    const packagePath = await repositoryRegularFile(root, "package.json", "package.json");
-    const packageDocument = JSON.parse(await readFile(packagePath, "utf8"));
-    workstationTestPipeline = packageDocument.scripts?.test?.includes("npm run test:workstation") === true
-      && packageDocument.scripts?.["test:workstation"]?.includes("node --test") === true
-      && coversCompleteWorkstationTestInventory(packageDocument.scripts["test:workstation"]);
+    workstationTestPipeline = await workstationTestPipelineCovers(root);
   } catch {
     workstationTestPipeline = false;
   }

--- a/scripts/validate-engineering-policy.mjs
+++ b/scripts/validate-engineering-policy.mjs
@@ -1230,7 +1230,7 @@ function workstationJobsUseBoundedMatrix(core, artifacts, workstationCondition) 
     artifacts?.strategy?.["fail-fast"] === false,
     artifacts?.strategy?.["max-parallel"] === 8,
     Object.keys(matrix ?? {}).length === 1,
-    matrix?.artifact
+    matrix?.include
       === "${{ fromJSON(needs.impact-plan.outputs.workstation_matrix) }}",
   ].every(Boolean);
 }
@@ -1244,12 +1244,12 @@ function workstationJobsFailClosed(core, artifacts) {
   ].every(Boolean);
 }
 
-function workstationDispatchIsExact(step, expectedDispatch) {
+function workstationDispatchIsExact(step) {
   return [
     step?.if === undefined,
     Object.keys(step?.env ?? {}).length === 1,
-    step?.env?.ARTIFACT === "${{ matrix.artifact }}",
-    String(step?.run ?? "").trim() === expectedDispatch,
+    step?.env?.SCRIPT === "${{ matrix.script }}",
+    String(step?.run ?? "").trim() === "npm run \"$SCRIPT\"",
   ].every(Boolean);
 }
 
@@ -1280,38 +1280,10 @@ function validateCiImpactWorkstationJobs(jobs, relativePath, findings) {
         === "npm run validate:workstation && npm run test:workstation:core",
     `${relativePath}: workstation core must run its complete authority step unconditionally`,
   );
-  const artifactScripts = [
-    ["candidate-010", "test:workstation:candidate-010"],
-    ["fixture-007", "test:workstation:fixture-007"],
-    ["fixture-012", "test:workstation:fixture-012"],
-    ["fixture-019", "test:workstation:fixture-019"],
-    ["fixture-022", "test:workstation:fixture-022"],
-    ["fixture-023", "test:workstation:fixture-023"],
-    ["fixture-024", "test:workstation:fixture-024"],
-    ["fixture-025", "test:workstation:fixture-025"],
-    ["fixture-026-shard-1", "test:workstation:fixture-026:shard-1"],
-    ["fixture-026-shard-2", "test:workstation:fixture-026:shard-2"],
-    ["fixture-026-shard-3", "test:workstation:fixture-026:shard-3"],
-    ["fixture-026-shard-4", "test:workstation:fixture-026:shard-4"],
-    ["fixture-026-shard-5", "test:workstation:fixture-026:shard-5"],
-    ["fixture-026-shard-6", "test:workstation:fixture-026:shard-6"],
-    ["fixture-026-shard-7", "test:workstation:fixture-026:shard-7"],
-    ["fixture-026-shard-8", "test:workstation:fixture-026:shard-8"],
-    ["fixture-027", "test:workstation:fixture-027"],
-    ["fixture-029-shard-1", "test:workstation:fixture-029:shard-1"],
-    ["fixture-029-shard-2", "test:workstation:fixture-029:shard-2"],
-  ].map(([job, script]) => `${job}) npm run ${script} ;;`);
-  const expectedDispatch = [
-    "set -euo pipefail",
-    "case \"$ARTIFACT\" in",
-    ...artifactScripts.map((line) => `  ${line}`),
-    "  *) echo \"::error::unallowlisted workstation artifact: $ARTIFACT\"; exit 1 ;;",
-    "esac",
-  ].join("\n");
   recordExpectation(
     findings,
-    workstationDispatchIsExact(artifactStep, expectedDispatch),
-    `${relativePath}: workstation matrix execution must dispatch only the nineteen static test scripts`,
+    workstationDispatchIsExact(artifactStep),
+    `${relativePath}: workstation matrix execution must quote the Go-projected script without a second dispatch table`,
   );
   const pythonSteps = (artifacts?.steps ?? []).filter((step) => (
     step?.uses?.startsWith("actions/setup-python@")
@@ -3466,6 +3438,9 @@ export function validateWorkstationShardScriptsObject(
 ) {
   const scripts = manifest?.scripts ?? {};
   const findings = [];
+  if (scripts["test:workstation"] !== "go -C tooling run ./cmd/20w ci run-workstation --root ..") {
+    findings.push(`${relativePath}: test:workstation must use the bounded Go catalogue runner`);
+  }
   const fullWithoutWorkstation = npmRunChain([
     "validate:runtime",
     ...aggregateTestScripts.filter((script) => ![

--- a/tooling/cmd/20w/main.go
+++ b/tooling/cmd/20w/main.go
@@ -10,8 +10,10 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"os/signal"
 	"regexp"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/lusoris/20-watts-was-enough/tooling/internal/buildinfo"
@@ -29,6 +31,7 @@ import (
 	"github.com/lusoris/20-watts-was-enough/tooling/internal/pdfrender"
 	"github.com/lusoris/20-watts-was-enough/tooling/internal/releasecheck"
 	"github.com/lusoris/20-watts-was-enough/tooling/internal/releaseimage"
+	"github.com/lusoris/20-watts-was-enough/tooling/internal/workstationrunner"
 )
 
 var githubOutputPrefixPattern = regexp.MustCompile(`^[a-z][a-z0-9_]{0,31}$`)
@@ -46,6 +49,7 @@ func usage(writer io.Writer) {
 	fmt.Fprintln(writer, "Usage:")
 	fmt.Fprintln(writer, "  20w ci plan [--root <repository>] [--base <commit> --head <commit> | --full] [--json]")
 	fmt.Fprintln(writer, "  20w ci project")
+	fmt.Fprintln(writer, "  20w ci run-workstation [--root <repository>]")
 	fmt.Fprintln(writer, "  20w validate docs [--root <repository>]")
 	fmt.Fprintln(writer, "  20w experiment list [--root <repository>] [--json]")
 	fmt.Fprintln(writer, "  20w experiment validate [--root <repository>]")
@@ -86,6 +90,9 @@ func run(arguments []string, stdout, stderr io.Writer) int {
 		}
 		if len(arguments) >= 2 && arguments[1] == "project" {
 			return runCIProject(arguments[2:], os.Stdin, stdout, stderr)
+		}
+		if len(arguments) >= 2 && arguments[1] == "run-workstation" {
+			return runCIWorkstation(arguments[2:], stdout, stderr)
 		}
 	case "validate":
 		if len(arguments) >= 2 && arguments[1] == "docs" {
@@ -227,6 +234,22 @@ func runCIPlan(arguments []string, stdout, stderr io.Writer) int {
 	}
 	fmt.Fprintf(stdout, "CI plan: %s (%s)\n", plan.Mode, plan.Reason)
 	fmt.Fprintf(stdout, "CI lanes: %s\n", strings.Join(plan.Lanes, ","))
+	return 0
+}
+
+func runCIWorkstation(arguments []string, stdout, stderr io.Writer) int {
+	flags := flag.NewFlagSet("ci run-workstation", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	root := flags.String("root", ".", "repository root")
+	if err := flags.Parse(arguments); err != nil || flags.NArg() != 0 {
+		return 2
+	}
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+	if err := workstationrunner.Run(ctx, *root, stdout); err != nil {
+		fmt.Fprintf(stderr, "Run bounded workstation suite: %v\n", err)
+		return 1
+	}
 	return 0
 }
 

--- a/tooling/cmd/20w/main_test.go
+++ b/tooling/cmd/20w/main_test.go
@@ -92,6 +92,25 @@ func TestRunCIProjectWritesOnlyFixedValidatedOutputs(t *testing.T) {
 	}
 }
 
+func TestRunCIWorkstationHasAClosedCommandLine(t *testing.T) {
+	t.Parallel()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	if exitCode := run([]string{"ci", "run-workstation", "unexpected"}, &stdout, &stderr); exitCode != 2 {
+		t.Fatalf("run() exit/stderr = %d/%q, want usage failure", exitCode, stderr.String())
+	}
+}
+
+func TestRunCIWorkstationRejectsAnInvalidRepositoryBeforeExecution(t *testing.T) {
+	t.Parallel()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := run([]string{"ci", "run-workstation", "--root", t.TempDir()}, &stdout, &stderr)
+	if exitCode != 1 || !strings.Contains(stderr.String(), "inspect package.json") {
+		t.Fatalf("run() exit/stderr = %d/%q, want repository failure", exitCode, stderr.String())
+	}
+}
+
 func TestRunPackageNodeImageRequiresClosedArguments(t *testing.T) {
 	t.Parallel()
 	var stdout bytes.Buffer

--- a/tooling/internal/ciplan/mapping.go
+++ b/tooling/internal/ciplan/mapping.go
@@ -25,69 +25,20 @@ const (
 )
 
 var (
-	ruleIDPattern = regexp.MustCompile(`^[a-z][a-z0-9-]{0,63}$`)
-	lanePattern   = regexp.MustCompile(`^[a-z][a-z0-9-]{0,63}$`)
-	allowedLanes  = map[string]laneDefinition{
-		"common":     {},
-		"container":  {},
-		"dependency": {},
-		"full":       {},
-		"go":         {},
-		"release":    {},
-		"renderer":   {},
-		"research":   {},
-		"site":       {},
-		"workstation-candidate-010": {WorkstationJobs: []workstationJobDefinition{
-			{Name: "candidate-010", CreationRank: 10},
-		}},
-		"workstation-fixture-007": {WorkstationJobs: []workstationJobDefinition{
-			{Name: "fixture-007", CreationRank: 18},
-		}},
-		"workstation-fixture-012": {WorkstationJobs: []workstationJobDefinition{
-			{Name: "fixture-012", CreationRank: 14},
-		}},
-		"workstation-fixture-019": {WorkstationJobs: []workstationJobDefinition{
-			{Name: "fixture-019", CreationRank: 12},
-		}},
-		"workstation-fixture-022": {WorkstationJobs: []workstationJobDefinition{
-			{Name: "fixture-022", CreationRank: 15},
-		}},
-		"workstation-fixture-023": {WorkstationJobs: []workstationJobDefinition{
-			{Name: "fixture-023", CreationRank: 17},
-		}},
-		"workstation-fixture-024": {WorkstationJobs: []workstationJobDefinition{
-			{Name: "fixture-024", CreationRank: 13},
-		}},
-		"workstation-fixture-025": {WorkstationJobs: []workstationJobDefinition{
-			{Name: "fixture-025", CreationRank: 19},
-		}},
-		"workstation-fixture-026": {WorkstationJobs: []workstationJobDefinition{
-			{Name: "fixture-026-shard-1", CreationRank: 4},
-			{Name: "fixture-026-shard-2", CreationRank: 2},
-			{Name: "fixture-026-shard-3", CreationRank: 5},
-			{Name: "fixture-026-shard-4", CreationRank: 3},
-			{Name: "fixture-026-shard-5", CreationRank: 6},
-			{Name: "fixture-026-shard-6", CreationRank: 1},
-			{Name: "fixture-026-shard-7", CreationRank: 11},
-			{Name: "fixture-026-shard-8", CreationRank: 9},
-		}},
-		"workstation-fixture-027": {WorkstationJobs: []workstationJobDefinition{
-			{Name: "fixture-027", CreationRank: 16},
-		}},
-		"workstation-fixture-029": {WorkstationJobs: []workstationJobDefinition{
-			{Name: "fixture-029-shard-1", CreationRank: 8},
-			{Name: "fixture-029-shard-2", CreationRank: 7},
-		}},
-	}
+	ruleIDPattern            = regexp.MustCompile(`^[a-z][a-z0-9-]{0,63}$`)
+	lanePattern              = regexp.MustCompile(`^[a-z][a-z0-9-]{0,63}$`)
+	workstationScriptPattern = regexp.MustCompile(`^test:workstation:[a-z][a-z0-9-]*(?::[a-z][a-z0-9-]*)?$`)
 )
 
-type workstationJobDefinition struct {
-	Name         string
+// WorkstationJob is one closed artifact-to-script mapping and its creation rank.
+type WorkstationJob struct {
+	Artifact     string
+	Script       string
 	CreationRank int
 }
 
 type laneDefinition struct {
-	WorkstationJobs []workstationJobDefinition
+	WorkstationJobs []WorkstationJob
 }
 
 // Mapping is the closed path-to-lane authority.
@@ -131,6 +82,9 @@ func loadMapping(root string) (Mapping, error) {
 }
 
 func validateMapping(mapping Mapping) error {
+	if embeddedWorkstationCatalogueError != nil {
+		return fmt.Errorf("load embedded workstation catalogue: %w", embeddedWorkstationCatalogueError)
+	}
 	if mapping.Schema != 1 {
 		return fmt.Errorf("impact mapping schema is %d, want 1", mapping.Schema)
 	}

--- a/tooling/internal/ciplan/mapping_test.go
+++ b/tooling/internal/ciplan/mapping_test.go
@@ -43,6 +43,7 @@ func TestRepositoryImpactMappingIsClosedAndRoutesRepresentativeChanges(t *testin
 		{path: "tooling/internal/buildinfo/buildinfo.go", mode: "impact", lanes: []string{"container", "go", "release"}},
 		{path: "tooling/internal/pdfrender/render.go", mode: "impact", lanes: []string{"container", "go", "release", "renderer", "site"}},
 		{path: "tooling/internal/pdfrenderlock/lock.go", mode: "impact", lanes: []string{"container", "go", "release", "renderer", "site"}},
+		{path: "tooling/internal/workstationrunner/runner.go", mode: "full", lanes: []string{"full"}, reason: "full-authority-changed"},
 		{path: "tooling/pdf-tools/apko.yaml", mode: "impact", lanes: []string{"go", "release"}},
 		{path: "tooling/clrs-specialist/Dockerfile", mode: "impact", lanes: []string{"container", "go"}},
 		{path: "tooling/cmd/clrs-specialist/main.go", mode: "impact", lanes: []string{"container", "go"}},

--- a/tooling/internal/ciplan/projection.go
+++ b/tooling/internal/ciplan/projection.go
@@ -61,6 +61,9 @@ func ReadProjection(reader io.Reader) (Projection, error) {
 
 // Project validates a plan before deriving fixed semantic lane outputs.
 func Project(plan Plan) (Projection, error) {
+	if embeddedWorkstationCatalogueError != nil {
+		return Projection{}, fmt.Errorf("load embedded workstation catalogue: %w", embeddedWorkstationCatalogueError)
+	}
 	if err := validatePlan(plan); err != nil {
 		return Projection{}, err
 	}
@@ -71,13 +74,13 @@ func Project(plan Plan) (Projection, error) {
 		WorkstationMatrix: "[]",
 	}
 	if plan.Mode == "full" {
-		jobs := make([]workstationJobDefinition, 0, maximumWorkstationJobs)
+		jobs := make([]WorkstationJob, 0, maximumWorkstationJobs)
 		for _, definition := range allowedLanes {
 			jobs = append(jobs, definition.WorkstationJobs...)
 		}
 		return projectWorkstationJobs(projection, jobs)
 	}
-	jobs := make([]workstationJobDefinition, 0)
+	jobs := make([]WorkstationJob, 0)
 	for _, lane := range plan.Lanes {
 		switch lane {
 		case "common":
@@ -107,49 +110,83 @@ func Project(plan Plan) (Projection, error) {
 	return projectWorkstationJobs(projection, jobs)
 }
 
-func projectWorkstationJobs(projection Projection, jobs []workstationJobDefinition) (Projection, error) {
-	if len(jobs) > maximumWorkstationJobs {
-		return Projection{}, fmt.Errorf(
-			"workstation projection contains %d jobs, limit is %d",
-			len(jobs),
-			maximumWorkstationJobs,
-		)
+type workstationMatrixEntry struct {
+	Artifact string `json:"artifact"`
+	Script   string `json:"script"`
+}
+
+// WorkstationJobs returns an isolated, validated, creation-ordered copy of the
+// complete artifact job catalogue.
+func WorkstationJobs() ([]WorkstationJob, error) {
+	_, jobs, err := WorkstationCatalogue()
+	if err != nil {
+		return nil, err
 	}
-	sort.Slice(jobs, func(left, right int) bool {
-		return jobs[left].CreationRank < jobs[right].CreationRank
-	})
-	names := make([]string, len(jobs))
-	seenNames := make(map[string]struct{}, len(jobs))
-	for index, job := range jobs {
-		if !lanePattern.MatchString(job.Name) {
-			return Projection{}, fmt.Errorf("workstation projection job is invalid: %q", job.Name)
-		}
-		if job.CreationRank < 1 || job.CreationRank > maximumWorkstationJobs {
-			return Projection{}, fmt.Errorf(
-				"workstation projection job %q has invalid creation rank %d",
-				job.Name,
-				job.CreationRank,
-			)
-		}
-		if _, duplicate := seenNames[job.Name]; duplicate {
-			return Projection{}, fmt.Errorf("workstation projection job is repeated: %q", job.Name)
-		}
-		if index > 0 && job.CreationRank == jobs[index-1].CreationRank {
-			return Projection{}, fmt.Errorf(
-				"workstation projection creation rank is repeated: %d",
-				job.CreationRank,
-			)
-		}
-		seenNames[job.Name] = struct{}{}
-		names[index] = job.Name
+	return orderAndValidateWorkstationJobs(jobs)
+}
+
+func projectWorkstationJobs(projection Projection, jobs []WorkstationJob) (Projection, error) {
+	ordered, err := orderAndValidateWorkstationJobs(jobs)
+	if err != nil {
+		return Projection{}, err
 	}
-	projection.WorkstationAny = len(jobs) > 0
-	matrix, err := json.Marshal(names)
+	entries := make([]workstationMatrixEntry, len(ordered))
+	for index, job := range ordered {
+		entries[index] = workstationMatrixEntry{Artifact: job.Artifact, Script: job.Script}
+	}
+	projection.WorkstationAny = len(entries) > 0
+	matrix, err := json.Marshal(entries)
 	if err != nil {
 		return Projection{}, fmt.Errorf("encode workstation matrix: %w", err)
 	}
 	projection.WorkstationMatrix = string(matrix)
 	return projection, nil
+}
+
+func orderAndValidateWorkstationJobs(jobs []WorkstationJob) ([]WorkstationJob, error) {
+	if len(jobs) > maximumWorkstationJobs {
+		return nil, fmt.Errorf(
+			"workstation projection contains %d jobs, limit is %d",
+			len(jobs),
+			maximumWorkstationJobs,
+		)
+	}
+	ordered := append([]WorkstationJob(nil), jobs...)
+	sort.Slice(ordered, func(left, right int) bool {
+		return ordered[left].CreationRank < ordered[right].CreationRank
+	})
+	seenArtifacts := make(map[string]struct{}, len(ordered))
+	seenScripts := make(map[string]struct{}, len(ordered))
+	for index, job := range ordered {
+		if !lanePattern.MatchString(job.Artifact) {
+			return nil, fmt.Errorf("workstation projection artifact is invalid: %q", job.Artifact)
+		}
+		if !workstationScriptPattern.MatchString(job.Script) {
+			return nil, fmt.Errorf("workstation projection script is invalid: %q", job.Script)
+		}
+		if job.CreationRank < 1 || job.CreationRank > maximumWorkstationJobs {
+			return nil, fmt.Errorf(
+				"workstation projection job %q has invalid creation rank %d",
+				job.Artifact,
+				job.CreationRank,
+			)
+		}
+		if _, duplicate := seenArtifacts[job.Artifact]; duplicate {
+			return nil, fmt.Errorf("workstation projection artifact is repeated: %q", job.Artifact)
+		}
+		if _, duplicate := seenScripts[job.Script]; duplicate {
+			return nil, fmt.Errorf("workstation projection script is repeated: %q", job.Script)
+		}
+		if index > 0 && job.CreationRank == ordered[index-1].CreationRank {
+			return nil, fmt.Errorf(
+				"workstation projection creation rank is repeated: %d",
+				job.CreationRank,
+			)
+		}
+		seenArtifacts[job.Artifact] = struct{}{}
+		seenScripts[job.Script] = struct{}{}
+	}
+	return ordered, nil
 }
 
 // WriteGitHubOutputs emits the complete fixed set of GitHub job outputs.

--- a/tooling/internal/ciplan/projection_test.go
+++ b/tooling/internal/ciplan/projection_test.go
@@ -25,30 +25,30 @@ func TestProjectEmitsClosedFullSemanticsAndEveryWorkstationJob(t *testing.T) {
 		projection.Site || !projection.WorkstationAny {
 		t.Fatalf("Project(full) = %#v, want false lane semantics and workstation jobs", projection)
 	}
-	var jobs []string
+	var jobs []workstationMatrixEntry
 	if err := json.Unmarshal([]byte(projection.WorkstationMatrix), &jobs); err != nil {
 		t.Fatal(err)
 	}
-	wantJobs := []string{
-		"fixture-026-shard-6",
-		"fixture-026-shard-2",
-		"fixture-026-shard-4",
-		"fixture-026-shard-1",
-		"fixture-026-shard-3",
-		"fixture-026-shard-5",
-		"fixture-029-shard-2",
-		"fixture-029-shard-1",
-		"fixture-026-shard-8",
-		"candidate-010",
-		"fixture-026-shard-7",
-		"fixture-019",
-		"fixture-024",
-		"fixture-012",
-		"fixture-022",
-		"fixture-027",
-		"fixture-023",
-		"fixture-007",
-		"fixture-025",
+	wantJobs := []workstationMatrixEntry{
+		{Artifact: "fixture-026-shard-6", Script: "test:workstation:fixture-026:shard-6"},
+		{Artifact: "fixture-026-shard-2", Script: "test:workstation:fixture-026:shard-2"},
+		{Artifact: "fixture-026-shard-4", Script: "test:workstation:fixture-026:shard-4"},
+		{Artifact: "fixture-026-shard-1", Script: "test:workstation:fixture-026:shard-1"},
+		{Artifact: "fixture-026-shard-3", Script: "test:workstation:fixture-026:shard-3"},
+		{Artifact: "fixture-026-shard-5", Script: "test:workstation:fixture-026:shard-5"},
+		{Artifact: "fixture-029-shard-2", Script: "test:workstation:fixture-029:shard-2"},
+		{Artifact: "fixture-029-shard-1", Script: "test:workstation:fixture-029:shard-1"},
+		{Artifact: "fixture-026-shard-8", Script: "test:workstation:fixture-026:shard-8"},
+		{Artifact: "candidate-010", Script: "test:workstation:candidate-010"},
+		{Artifact: "fixture-026-shard-7", Script: "test:workstation:fixture-026:shard-7"},
+		{Artifact: "fixture-019", Script: "test:workstation:fixture-019"},
+		{Artifact: "fixture-024", Script: "test:workstation:fixture-024"},
+		{Artifact: "fixture-012", Script: "test:workstation:fixture-012"},
+		{Artifact: "fixture-022", Script: "test:workstation:fixture-022"},
+		{Artifact: "fixture-027", Script: "test:workstation:fixture-027"},
+		{Artifact: "fixture-023", Script: "test:workstation:fixture-023"},
+		{Artifact: "fixture-007", Script: "test:workstation:fixture-007"},
+		{Artifact: "fixture-025", Script: "test:workstation:fixture-025"},
 	}
 	if !reflect.DeepEqual(jobs, wantJobs) {
 		t.Fatalf("full workstation matrix = %v, want %v", jobs, wantJobs)
@@ -60,7 +60,7 @@ func TestProjectEmitsClosedFullSemanticsAndEveryWorkstationJob(t *testing.T) {
 	for _, expected := range []string{
 		"container=false\n", "dependency=false\n", "go=false\n", "release=false\n", "renderer=false\n", "research=false\n",
 		"site=false\n", "workstation_any=true\n",
-		"workstation_matrix=[\"fixture-026-shard-6\",\"fixture-026-shard-2\"",
+		"workstation_matrix=[{\"artifact\":\"fixture-026-shard-6\",\"script\":\"test:workstation:fixture-026:shard-6\"}",
 	} {
 		if !strings.Contains(output.String(), expected) {
 			t.Fatalf("full GitHub outputs = %q, missing %q", output.String(), expected)
@@ -102,21 +102,21 @@ func TestProjectExpandsOnlySelectedShardedArtifacts(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var jobs []string
+	var jobs []workstationMatrixEntry
 	if err := json.Unmarshal([]byte(projection.WorkstationMatrix), &jobs); err != nil {
 		t.Fatal(err)
 	}
-	want := []string{
-		"fixture-026-shard-6",
-		"fixture-026-shard-2",
-		"fixture-026-shard-4",
-		"fixture-026-shard-1",
-		"fixture-026-shard-3",
-		"fixture-026-shard-5",
-		"fixture-029-shard-2",
-		"fixture-029-shard-1",
-		"fixture-026-shard-8",
-		"fixture-026-shard-7",
+	want := []workstationMatrixEntry{
+		{Artifact: "fixture-026-shard-6", Script: "test:workstation:fixture-026:shard-6"},
+		{Artifact: "fixture-026-shard-2", Script: "test:workstation:fixture-026:shard-2"},
+		{Artifact: "fixture-026-shard-4", Script: "test:workstation:fixture-026:shard-4"},
+		{Artifact: "fixture-026-shard-1", Script: "test:workstation:fixture-026:shard-1"},
+		{Artifact: "fixture-026-shard-3", Script: "test:workstation:fixture-026:shard-3"},
+		{Artifact: "fixture-026-shard-5", Script: "test:workstation:fixture-026:shard-5"},
+		{Artifact: "fixture-029-shard-2", Script: "test:workstation:fixture-029:shard-2"},
+		{Artifact: "fixture-029-shard-1", Script: "test:workstation:fixture-029:shard-1"},
+		{Artifact: "fixture-026-shard-8", Script: "test:workstation:fixture-026:shard-8"},
+		{Artifact: "fixture-026-shard-7", Script: "test:workstation:fixture-026:shard-7"},
 	}
 	if !projection.WorkstationAny || !reflect.DeepEqual(jobs, want) {
 		t.Fatalf("sharded projection = %#v / %v, want %v", projection, jobs, want)
@@ -156,11 +156,14 @@ func TestProjectDerivesOnlyFixedAllowlistedOutputs(t *testing.T) {
 		!projection.Site || !projection.WorkstationAny {
 		t.Fatalf("Project(impact) = %#v, want exact lane booleans", projection)
 	}
-	var artifacts []string
+	var artifacts []workstationMatrixEntry
 	if err := json.Unmarshal([]byte(projection.WorkstationMatrix), &artifacts); err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(artifacts, []string{"candidate-010", "fixture-019"}) {
+	if !reflect.DeepEqual(artifacts, []workstationMatrixEntry{
+		{Artifact: "candidate-010", Script: "test:workstation:candidate-010"},
+		{Artifact: "fixture-019", Script: "test:workstation:fixture-019"},
+	}) {
 		t.Fatalf("matrix = %v, want allowlisted artifacts", artifacts)
 	}
 
@@ -170,7 +173,7 @@ func TestProjectDerivesOnlyFixedAllowlistedOutputs(t *testing.T) {
 	}
 	want := "mode=impact\nreason=mapped-change-set\ncontainer=true\ndependency=true\ngo=false\n" +
 		"release=false\nrenderer=true\nresearch=true\nsite=true\nworkstation_any=true\n" +
-		"workstation_matrix=[\"candidate-010\",\"fixture-019\"]\n"
+		"workstation_matrix=[{\"artifact\":\"candidate-010\",\"script\":\"test:workstation:candidate-010\"},{\"artifact\":\"fixture-019\",\"script\":\"test:workstation:fixture-019\"}]\n"
 	if output.String() != want {
 		t.Fatalf("GitHub outputs = %q, want %q", output.String(), want)
 	}
@@ -215,27 +218,65 @@ func TestProjectRejectsMalformedPlanCombinations(t *testing.T) {
 	}
 }
 
+func TestWorkstationJobsReturnsAnIsolatedCompleteCatalogue(t *testing.T) {
+	t.Parallel()
+	first, err := WorkstationJobs()
+	if err != nil {
+		t.Fatal(err)
+	}
+	coreScript, catalogueJobs, err := WorkstationCatalogue()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) != 19 || coreScript != "test:workstation:core" || !reflect.DeepEqual(first, catalogueJobs) {
+		t.Fatalf("workstation catalogue has %d artifacts and core %q", len(first), coreScript)
+	}
+	for index, job := range first {
+		if job.CreationRank != index+1 {
+			t.Fatalf("workstation job %d has creation rank %d", index, job.CreationRank)
+		}
+	}
+	first[0] = WorkstationJob{}
+	second, err := WorkstationJobs()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second[0].Artifact != "fixture-026-shard-6" || second[0].Script != "test:workstation:fixture-026:shard-6" {
+		t.Fatalf("WorkstationJobs() exposed mutable catalogue state: %#v", second[0])
+	}
+}
+
 func TestProjectWorkstationJobsRejectsInvalidMatrices(t *testing.T) {
 	t.Parallel()
-	for name, jobs := range map[string][]workstationJobDefinition{
+	for name, jobs := range map[string][]WorkstationJob{
 		"duplicate name": {
-			{Name: "fixture-026-shard-1", CreationRank: 1},
-			{Name: "fixture-026-shard-1", CreationRank: 2},
+			{Artifact: "fixture-026-shard-1", Script: "test:workstation:fixture-026:shard-1", CreationRank: 1},
+			{Artifact: "fixture-026-shard-1", Script: "test:workstation:fixture-026:shard-2", CreationRank: 2},
+		},
+		"duplicate script": {
+			{Artifact: "fixture-026-shard-1", Script: "test:workstation:fixture-026:shard-1", CreationRank: 1},
+			{Artifact: "fixture-026-shard-2", Script: "test:workstation:fixture-026:shard-1", CreationRank: 2},
 		},
 		"duplicate creation rank": {
-			{Name: "fixture-026-shard-1", CreationRank: 1},
-			{Name: "fixture-026-shard-2", CreationRank: 1},
+			{Artifact: "fixture-026-shard-1", Script: "test:workstation:fixture-026:shard-1", CreationRank: 1},
+			{Artifact: "fixture-026-shard-2", Script: "test:workstation:fixture-026:shard-2", CreationRank: 1},
 		},
 		"invalid creation rank": {
-			{Name: "fixture-026-shard-1", CreationRank: 0},
+			{Artifact: "fixture-026-shard-1", Script: "test:workstation:fixture-026:shard-1", CreationRank: 0},
+		},
+		"negative creation rank": {
+			{Artifact: "fixture-026-shard-1", Script: "test:workstation:fixture-026:shard-1", CreationRank: -1},
 		},
 		"excessive creation rank": {
-			{Name: "fixture-026-shard-1", CreationRank: maximumWorkstationJobs + 1},
+			{Artifact: "fixture-026-shard-1", Script: "test:workstation:fixture-026:shard-1", CreationRank: maximumWorkstationJobs + 1},
 		},
 		"malformed name": {
-			{Name: "fixture/026", CreationRank: 1},
+			{Artifact: "fixture/026", Script: "test:workstation:fixture-026", CreationRank: 1},
 		},
-		"excessive": make([]workstationJobDefinition, maximumWorkstationJobs+1),
+		"malformed script": {
+			{Artifact: "fixture-026", Script: "preinstall", CreationRank: 1},
+		},
+		"excessive": make([]WorkstationJob, maximumWorkstationJobs+1),
 	} {
 		t.Run(name, func(t *testing.T) {
 			if _, err := projectWorkstationJobs(Projection{}, jobs); err == nil {

--- a/tooling/internal/ciplan/workstation-catalogue.json
+++ b/tooling/internal/ciplan/workstation-catalogue.json
@@ -1,0 +1,25 @@
+{
+  "schema": 1,
+  "core_script": "test:workstation:core",
+  "jobs": [
+    { "lane": "workstation-fixture-026", "artifact": "fixture-026-shard-6", "script": "test:workstation:fixture-026:shard-6", "creation_rank": 1 },
+    { "lane": "workstation-fixture-026", "artifact": "fixture-026-shard-2", "script": "test:workstation:fixture-026:shard-2", "creation_rank": 2 },
+    { "lane": "workstation-fixture-026", "artifact": "fixture-026-shard-4", "script": "test:workstation:fixture-026:shard-4", "creation_rank": 3 },
+    { "lane": "workstation-fixture-026", "artifact": "fixture-026-shard-1", "script": "test:workstation:fixture-026:shard-1", "creation_rank": 4 },
+    { "lane": "workstation-fixture-026", "artifact": "fixture-026-shard-3", "script": "test:workstation:fixture-026:shard-3", "creation_rank": 5 },
+    { "lane": "workstation-fixture-026", "artifact": "fixture-026-shard-5", "script": "test:workstation:fixture-026:shard-5", "creation_rank": 6 },
+    { "lane": "workstation-fixture-029", "artifact": "fixture-029-shard-2", "script": "test:workstation:fixture-029:shard-2", "creation_rank": 7 },
+    { "lane": "workstation-fixture-029", "artifact": "fixture-029-shard-1", "script": "test:workstation:fixture-029:shard-1", "creation_rank": 8 },
+    { "lane": "workstation-fixture-026", "artifact": "fixture-026-shard-8", "script": "test:workstation:fixture-026:shard-8", "creation_rank": 9 },
+    { "lane": "workstation-candidate-010", "artifact": "candidate-010", "script": "test:workstation:candidate-010", "creation_rank": 10 },
+    { "lane": "workstation-fixture-026", "artifact": "fixture-026-shard-7", "script": "test:workstation:fixture-026:shard-7", "creation_rank": 11 },
+    { "lane": "workstation-fixture-019", "artifact": "fixture-019", "script": "test:workstation:fixture-019", "creation_rank": 12 },
+    { "lane": "workstation-fixture-024", "artifact": "fixture-024", "script": "test:workstation:fixture-024", "creation_rank": 13 },
+    { "lane": "workstation-fixture-012", "artifact": "fixture-012", "script": "test:workstation:fixture-012", "creation_rank": 14 },
+    { "lane": "workstation-fixture-022", "artifact": "fixture-022", "script": "test:workstation:fixture-022", "creation_rank": 15 },
+    { "lane": "workstation-fixture-027", "artifact": "fixture-027", "script": "test:workstation:fixture-027", "creation_rank": 16 },
+    { "lane": "workstation-fixture-023", "artifact": "fixture-023", "script": "test:workstation:fixture-023", "creation_rank": 17 },
+    { "lane": "workstation-fixture-007", "artifact": "fixture-007", "script": "test:workstation:fixture-007", "creation_rank": 18 },
+    { "lane": "workstation-fixture-025", "artifact": "fixture-025", "script": "test:workstation:fixture-025", "creation_rank": 19 }
+  ]
+}

--- a/tooling/internal/ciplan/workstation_catalogue.go
+++ b/tooling/internal/ciplan/workstation_catalogue.go
@@ -1,0 +1,137 @@
+package ciplan
+
+import (
+	"bytes"
+	_ "embed"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/lusoris/20-watts-was-enough/tooling/internal/strictjson"
+)
+
+const maximumWorkstationCatalogueBytes = 16 << 10
+
+//go:embed workstation-catalogue.json
+var workstationCatalogueBody []byte
+
+type workstationCatalogueDocument struct {
+	Schema     int                       `json:"schema"`
+	CoreScript string                    `json:"core_script"`
+	Jobs       []workstationCatalogueJob `json:"jobs"`
+}
+
+type workstationCatalogueJob struct {
+	Lane         string `json:"lane"`
+	Artifact     string `json:"artifact"`
+	Script       string `json:"script"`
+	CreationRank int    `json:"creation_rank"`
+}
+
+var (
+	embeddedWorkstationCatalogue, embeddedWorkstationCatalogueError = parseWorkstationCatalogue(workstationCatalogueBody)
+	allowedLanes                                                    = workstationLaneDefinitions(embeddedWorkstationCatalogue)
+)
+
+func parseWorkstationCatalogue(body []byte) (workstationCatalogueDocument, error) {
+	if len(body) == 0 || len(body) > maximumWorkstationCatalogueBytes {
+		return workstationCatalogueDocument{}, fmt.Errorf(
+			"workstation catalogue size is outside 1..%d bytes",
+			maximumWorkstationCatalogueBytes,
+		)
+	}
+	if err := strictjson.Validate(body, 6); err != nil {
+		return workstationCatalogueDocument{}, fmt.Errorf("validate unambiguous workstation catalogue JSON: %w", err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.DisallowUnknownFields()
+	var document workstationCatalogueDocument
+	if err := decoder.Decode(&document); err != nil {
+		return workstationCatalogueDocument{}, fmt.Errorf("decode workstation catalogue: %w", err)
+	}
+	if decoder.Decode(&struct{}{}) != io.EOF {
+		return workstationCatalogueDocument{}, errors.New("workstation catalogue contains trailing data")
+	}
+	if err := validateWorkstationCatalogue(document); err != nil {
+		return workstationCatalogueDocument{}, err
+	}
+	return document, nil
+}
+
+func validateWorkstationCatalogue(document workstationCatalogueDocument) error {
+	if document.Schema != 1 {
+		return fmt.Errorf("workstation catalogue schema is %d, want 1", document.Schema)
+	}
+	if !workstationScriptPattern.MatchString(document.CoreScript) {
+		return fmt.Errorf("workstation core script is invalid: %q", document.CoreScript)
+	}
+	if len(document.Jobs) == 0 || len(document.Jobs) > maximumWorkstationJobs {
+		return fmt.Errorf(
+			"workstation catalogue contains %d jobs, limit is 1..%d",
+			len(document.Jobs),
+			maximumWorkstationJobs,
+		)
+	}
+	seenArtifacts := make(map[string]struct{}, len(document.Jobs))
+	seenScripts := map[string]struct{}{document.CoreScript: {}}
+	for index, job := range document.Jobs {
+		if !strings.HasPrefix(job.Lane, "workstation-") || !lanePattern.MatchString(job.Lane) {
+			return fmt.Errorf("workstation catalogue lane is invalid: %q", job.Lane)
+		}
+		if !lanePattern.MatchString(job.Artifact) {
+			return fmt.Errorf("workstation catalogue artifact is invalid: %q", job.Artifact)
+		}
+		if !workstationScriptPattern.MatchString(job.Script) {
+			return fmt.Errorf("workstation catalogue script is invalid: %q", job.Script)
+		}
+		if job.CreationRank != index+1 {
+			return fmt.Errorf(
+				"workstation catalogue job %q has creation rank %d, want %d",
+				job.Artifact,
+				job.CreationRank,
+				index+1,
+			)
+		}
+		if _, duplicate := seenArtifacts[job.Artifact]; duplicate {
+			return fmt.Errorf("workstation catalogue artifact is repeated: %q", job.Artifact)
+		}
+		if _, duplicate := seenScripts[job.Script]; duplicate {
+			return fmt.Errorf("workstation catalogue script is repeated: %q", job.Script)
+		}
+		seenArtifacts[job.Artifact] = struct{}{}
+		seenScripts[job.Script] = struct{}{}
+	}
+	return nil
+}
+
+func workstationLaneDefinitions(document workstationCatalogueDocument) map[string]laneDefinition {
+	definitions := map[string]laneDefinition{
+		"common": {}, "container": {}, "dependency": {}, "full": {}, "go": {},
+		"release": {}, "renderer": {}, "research": {}, "site": {},
+	}
+	for _, entry := range document.Jobs {
+		definition := definitions[entry.Lane]
+		definition.WorkstationJobs = append(definition.WorkstationJobs, WorkstationJob{
+			Artifact: entry.Artifact, Script: entry.Script, CreationRank: entry.CreationRank,
+		})
+		definitions[entry.Lane] = definition
+	}
+	return definitions
+}
+
+// WorkstationCatalogue returns the core script and an isolated copy of every
+// creation-ordered artifact job in the embedded machine-readable authority.
+func WorkstationCatalogue() (string, []WorkstationJob, error) {
+	if embeddedWorkstationCatalogueError != nil {
+		return "", nil, embeddedWorkstationCatalogueError
+	}
+	jobs := make([]WorkstationJob, len(embeddedWorkstationCatalogue.Jobs))
+	for index, entry := range embeddedWorkstationCatalogue.Jobs {
+		jobs[index] = WorkstationJob{
+			Artifact: entry.Artifact, Script: entry.Script, CreationRank: entry.CreationRank,
+		}
+	}
+	return embeddedWorkstationCatalogue.CoreScript, jobs, nil
+}

--- a/tooling/internal/ciplan/workstation_catalogue_test.go
+++ b/tooling/internal/ciplan/workstation_catalogue_test.go
@@ -1,0 +1,50 @@
+package ciplan
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseWorkstationCatalogueRejectsAmbiguousAndMalformedAuthority(t *testing.T) {
+	t.Parallel()
+	valid := `{"schema":1,"core_script":"test:workstation:core","jobs":[{"lane":"workstation-fixture-007","artifact":"fixture-007","script":"test:workstation:fixture-007","creation_rank":1}]}`
+	for name, body := range map[string]string{
+		"duplicate field": strings.Replace(valid, `"schema":1`, `"schema":1,"schema":1`, 1),
+		"unknown field": strings.Replace(valid, `"schema":1`, `"schema":1,"unknown":true`, 1),
+		"invalid core": strings.Replace(valid, "test:workstation:core", "pretest", 1),
+		"invalid lane": strings.Replace(valid, "workstation-fixture-007", "fixture-007", 1),
+		"invalid artifact": strings.Replace(valid, `"artifact":"fixture-007"`, `"artifact":"fixture/007"`, 1),
+		"invalid script": strings.Replace(valid, "test:workstation:fixture-007", "postinstall", 1),
+		"invalid rank": strings.Replace(valid, `"creation_rank":1`, `"creation_rank":2`, 1),
+		"repeated core": strings.Replace(valid, "test:workstation:fixture-007", "test:workstation:core", 1),
+		"trailing data": valid + `{}`,
+		"oversized": strings.Repeat(" ", maximumWorkstationCatalogueBytes+1),
+	} {
+		name, body := name, body
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := parseWorkstationCatalogue([]byte(body)); err == nil {
+				t.Fatalf("parseWorkstationCatalogue(%s) accepted malformed authority", name)
+			}
+		})
+	}
+}
+
+func TestParseWorkstationCatalogueReturnsIsolatedData(t *testing.T) {
+	t.Parallel()
+	parsed, err := parseWorkstationCatalogue(workstationCatalogueBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsed.CoreScript != "test:workstation:core" || len(parsed.Jobs) != 19 {
+		t.Fatalf("embedded catalogue = %q/%d jobs", parsed.CoreScript, len(parsed.Jobs))
+	}
+	parsed.Jobs[0] = workstationCatalogueJob{}
+	core, jobs, err := WorkstationCatalogue()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if core != "test:workstation:core" || jobs[0].Artifact != "fixture-026-shard-6" {
+		t.Fatalf("WorkstationCatalogue() exposed mutable authority: %q/%#v", core, jobs[0])
+	}
+}

--- a/tooling/internal/workstationrunner/inventory.go
+++ b/tooling/internal/workstationrunner/inventory.go
@@ -1,0 +1,395 @@
+package workstationrunner
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	pathpkg "path"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/lusoris/20-watts-was-enough/tooling/internal/strictjson"
+)
+
+const (
+	workstationAggregateCommand     = "go -C tooling run ./cmd/20w ci run-workstation --root .."
+	maximumWorkstationTreeEntries   = 4096
+	maximumWorkstationTreeDepth     = 16
+	maximumWorkstationManifestFiles = 32
+	maximumWorkstationManifestBytes = 1 << 20
+)
+
+var workstationTestPathPattern = regexp.MustCompile(
+	`^experiments/workstation/[A-Za-z0-9_./*-]+\.test\.mjs$`,
+)
+
+type packageDocument struct {
+	Scripts map[string]string `json:"scripts"`
+}
+
+type workstationManifestDocument struct {
+	Artifact       string `json:"artifact"`
+	Implementation struct {
+		FullTests []string `json:"full_tests"`
+	} `json:"implementation"`
+}
+
+type manifestFullTest struct {
+	artifact string
+	path     string
+}
+
+type admittedWorkstationCommand struct {
+	arguments []string
+	patterns  []string
+}
+
+func freezeWorkstationInventory(root string, jobs []job) ([]job, error) {
+	manifest, err := loadPackageDocument(root)
+	if err != nil {
+		return nil, err
+	}
+	if manifest.Scripts["test:workstation"] != workstationAggregateCommand {
+		return nil, errors.New("package.json test:workstation does not invoke the bounded Go runner")
+	}
+	frozenJobs := make([]job, len(jobs))
+	patterns := make([]string, 0, len(jobs)*2)
+	patternsByArtifact := make(map[string][]string)
+	for index, current := range jobs {
+		command, parseErr := parseWorkstationCommand(manifest.Scripts[current.script])
+		if parseErr != nil {
+			return nil, fmt.Errorf("package.json script %s: %w", current.script, parseErr)
+		}
+		frozenJobs[index] = job{
+			artifact:  current.artifact,
+			script:    current.script,
+			arguments: append([]string(nil), command.arguments...),
+		}
+		patterns = append(patterns, command.patterns...)
+		artifact := workstationManifestArtifact(current.artifact)
+		if artifact != "core" {
+			patternsByArtifact[artifact] = append(patternsByArtifact[artifact], command.patterns...)
+		}
+	}
+	discovered, err := discoverWorkstationTests(root)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateExactTestCoverage(patterns, discovered); err != nil {
+		return nil, err
+	}
+	fullTests, err := loadManifestFullTests(root, jobs)
+	if err != nil {
+		return nil, err
+	}
+	discoveredSet := make(map[string]struct{}, len(discovered))
+	for _, testPath := range discovered {
+		discoveredSet[testPath] = struct{}{}
+	}
+	for _, declared := range fullTests {
+		if _, present := discoveredSet[declared.path]; !present {
+			return nil, fmt.Errorf("manifest full_tests path is not a discovered workstation test: %s", declared.path)
+		}
+		coverage := 0
+		for _, pattern := range patternsByArtifact[declared.artifact] {
+			if workstationPatternCovers(pattern, declared.path) {
+				coverage++
+			}
+		}
+		if coverage != 1 {
+			return nil, fmt.Errorf(
+				"manifest %s full_tests path %s is scheduled %d times by its catalogue jobs, want exactly once",
+				declared.artifact,
+				declared.path,
+				coverage,
+			)
+		}
+	}
+	return frozenJobs, nil
+}
+
+func loadPackageDocument(root string) (packageDocument, error) {
+	body, err := readStableBoundedFile(
+		filepath.Join(root, "package.json"),
+		maximumPackageManifestBytes,
+	)
+	if err != nil {
+		return packageDocument{}, fmt.Errorf("read package.json: %w", err)
+	}
+	if err := strictjson.Validate(body, 32); err != nil {
+		return packageDocument{}, fmt.Errorf("validate unambiguous package.json: %w", err)
+	}
+	var manifest packageDocument
+	if err := json.Unmarshal(body, &manifest); err != nil {
+		return packageDocument{}, fmt.Errorf("decode package.json: %w", err)
+	}
+	if manifest.Scripts == nil {
+		return packageDocument{}, errors.New("package.json has no scripts object")
+	}
+	return manifest, nil
+}
+
+func parseWorkstationCommand(command string) (admittedWorkstationCommand, error) {
+	fields := strings.Fields(command)
+	if len(fields) < 4 || fields[0] != "node" || fields[1] != "--test" ||
+		fields[2] != "--experimental-test-isolation=none" {
+		return admittedWorkstationCommand{}, errors.New("command must start with the closed Node test invocation")
+	}
+	index := 3
+	if fields[index] == "--test-concurrency=1" {
+		index++
+	}
+	if index == len(fields) {
+		return admittedWorkstationCommand{}, errors.New("command has no test paths")
+	}
+	patterns := append([]string(nil), fields[index:]...)
+	for _, pattern := range patterns {
+		if !workstationTestPathPattern.MatchString(pattern) || strings.Contains(pattern, "\\") ||
+			pathpkg.Clean(pattern) != pattern || strings.Contains(pattern, "..") {
+			return admittedWorkstationCommand{}, fmt.Errorf("command contains an invalid test path %q", pattern)
+		}
+		if strings.Contains(pattern, "*") &&
+			(strings.Count(pattern, "*") != 1 || !strings.HasSuffix(pattern, "/*.test.mjs")) {
+			return admittedWorkstationCommand{}, fmt.Errorf("command contains an invalid test glob %q", pattern)
+		}
+	}
+	return admittedWorkstationCommand{
+		arguments: append([]string(nil), fields[1:]...),
+		patterns:  patterns,
+	}, nil
+}
+
+func discoverWorkstationTests(root string) ([]string, error) {
+	directory := filepath.Join(root, "experiments", "workstation")
+	if err := requireRealPath(directory, true); err != nil {
+		return nil, fmt.Errorf("inspect workstation test root: %w", err)
+	}
+	tests := make([]string, 0)
+	visited := 0
+	err := filepath.WalkDir(directory, func(current string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		visited++
+		if visited > maximumWorkstationTreeEntries {
+			return fmt.Errorf("workstation tree exceeds %d entries", maximumWorkstationTreeEntries)
+		}
+		relativeToTree, err := filepath.Rel(directory, current)
+		if err != nil {
+			return err
+		}
+		if relativeToTree != "." && len(strings.Split(filepath.ToSlash(relativeToTree), "/")) > maximumWorkstationTreeDepth {
+			return fmt.Errorf("workstation tree exceeds %d levels", maximumWorkstationTreeDepth)
+		}
+		information, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if information.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("workstation tree contains a symbolic link: %s", filepath.ToSlash(relativeToTree))
+		}
+		if !information.IsDir() && !information.Mode().IsRegular() {
+			return fmt.Errorf("workstation tree contains a special file: %s", filepath.ToSlash(relativeToTree))
+		}
+		if information.Mode().IsRegular() && strings.HasSuffix(entry.Name(), ".test.mjs") {
+			relative, err := filepath.Rel(root, current)
+			if err != nil {
+				return err
+			}
+			tests = append(tests, filepath.ToSlash(relative))
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("discover workstation tests: %w", err)
+	}
+	if len(tests) == 0 {
+		return nil, errors.New("workstation tree contains no tests")
+	}
+	sort.Strings(tests)
+	return tests, nil
+}
+
+func validateExactTestCoverage(patterns, discovered []string) error {
+	for _, pattern := range patterns {
+		matched := false
+		for _, testPath := range discovered {
+			if workstationPatternCovers(pattern, testPath) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return fmt.Errorf("workstation test pattern matches no discovered test: %s", pattern)
+		}
+	}
+	for _, testPath := range discovered {
+		coverage := 0
+		for _, pattern := range patterns {
+			if workstationPatternCovers(pattern, testPath) {
+				coverage++
+			}
+		}
+		if coverage != 1 {
+			return fmt.Errorf("workstation test %s is scheduled %d times, want exactly once", testPath, coverage)
+		}
+	}
+	return nil
+}
+
+func workstationPatternCovers(pattern, testPath string) bool {
+	if pattern == testPath {
+		return true
+	}
+	if !strings.HasSuffix(pattern, "/*.test.mjs") {
+		return false
+	}
+	directory := strings.TrimSuffix(pattern, "*.test.mjs")
+	relative := strings.TrimPrefix(testPath, directory)
+	return strings.HasPrefix(testPath, directory) && strings.HasSuffix(relative, ".test.mjs") &&
+		!strings.Contains(relative, "/")
+}
+
+func loadManifestFullTests(root string, jobs []job) ([]manifestFullTest, error) {
+	directory := filepath.Join(root, "experiments", "workstation", "manifests")
+	if err := requireRealPath(directory, true); err != nil {
+		return nil, fmt.Errorf("inspect workstation manifest root: %w", err)
+	}
+	entries, err := os.ReadDir(directory)
+	if err != nil {
+		return nil, fmt.Errorf("read workstation manifest root: %w", err)
+	}
+	if len(entries) == 0 || len(entries) > maximumWorkstationManifestFiles {
+		return nil, fmt.Errorf(
+			"workstation manifest root contains %d entries, limit is 1..%d",
+			len(entries), maximumWorkstationManifestFiles,
+		)
+	}
+	expected := make(map[string]struct{})
+	for _, current := range jobs {
+		artifact := workstationManifestArtifact(current.artifact)
+		if artifact != "core" {
+			expected[artifact] = struct{}{}
+		}
+	}
+	seenManifests := make(map[string]struct{}, len(entries))
+	seenTests := make(map[string]struct{})
+	fullTests := make([]manifestFullTest, 0)
+	for _, entry := range entries {
+		if entry.Type()&os.ModeSymlink != 0 || !entry.Type().IsRegular() || !strings.HasSuffix(entry.Name(), ".json") {
+			return nil, fmt.Errorf("workstation manifest root contains an unsupported entry: %s", entry.Name())
+		}
+		artifact := strings.TrimSuffix(entry.Name(), ".json")
+		if _, known := expected[artifact]; !known {
+			return nil, fmt.Errorf("workstation manifest has no catalogue job: %s", artifact)
+		}
+		body, err := readStableBoundedFile(filepath.Join(directory, entry.Name()), maximumWorkstationManifestBytes)
+		if err != nil {
+			return nil, fmt.Errorf("read workstation manifest %s: %w", artifact, err)
+		}
+		if err := strictjson.Validate(body, 64); err != nil {
+			return nil, fmt.Errorf("validate unambiguous workstation manifest %s: %w", artifact, err)
+		}
+		var document workstationManifestDocument
+		if err := json.Unmarshal(body, &document); err != nil {
+			return nil, fmt.Errorf("decode workstation manifest %s: %w", artifact, err)
+		}
+		if document.Artifact != artifact || len(document.Implementation.FullTests) == 0 {
+			return nil, fmt.Errorf("workstation manifest %s has an invalid artifact or empty full_tests", artifact)
+		}
+		seenManifests[artifact] = struct{}{}
+		for _, testPath := range document.Implementation.FullTests {
+			if !workstationTestPathPattern.MatchString(testPath) || strings.Contains(testPath, "*") ||
+				strings.Contains(testPath, "\\") || pathpkg.Clean(testPath) != testPath || strings.Contains(testPath, "..") {
+				return nil, fmt.Errorf("workstation manifest %s has an invalid full_tests path %q", artifact, testPath)
+			}
+			if _, duplicate := seenTests[testPath]; duplicate {
+				return nil, fmt.Errorf("workstation manifests repeat full_tests path: %s", testPath)
+			}
+			seenTests[testPath] = struct{}{}
+			fullTests = append(fullTests, manifestFullTest{artifact: artifact, path: testPath})
+		}
+	}
+	for artifact := range expected {
+		if _, present := seenManifests[artifact]; !present {
+			return nil, fmt.Errorf("workstation catalogue artifact has no manifest: %s", artifact)
+		}
+	}
+	sort.Slice(fullTests, func(left, right int) bool {
+		return fullTests[left].artifact < fullTests[right].artifact ||
+			(fullTests[left].artifact == fullTests[right].artifact && fullTests[left].path < fullTests[right].path)
+	})
+	return fullTests, nil
+}
+
+func workstationManifestArtifact(artifact string) string {
+	if marker := strings.Index(artifact, "-shard-"); marker >= 0 {
+		return artifact[:marker]
+	}
+	return artifact
+}
+
+func requireRealPath(path string, directory bool) error {
+	clean := filepath.Clean(path)
+	resolved, err := filepath.EvalSymlinks(clean)
+	if err != nil || !sameCanonicalPath(resolved, clean) {
+		return errors.New("path must not contain symbolic links")
+	}
+	information, err := os.Lstat(clean)
+	if err != nil {
+		return err
+	}
+	if information.Mode()&os.ModeSymlink != 0 || (directory && !information.IsDir()) ||
+		(!directory && !information.Mode().IsRegular()) {
+		return errors.New("path has the wrong file type")
+	}
+	return nil
+}
+
+func readStableBoundedFile(path string, maximumBytes int64) ([]byte, error) {
+	if maximumBytes < 1 {
+		return nil, errors.New("file-size bound must be positive")
+	}
+	if err := requireRealPath(path, false); err != nil {
+		return nil, err
+	}
+	before, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if before.Size() <= 0 || before.Size() > maximumBytes {
+		return nil, fmt.Errorf("file size is outside 1..%d bytes", maximumBytes)
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	opened, err := file.Stat()
+	if err != nil || !opened.Mode().IsRegular() || !os.SameFile(before, opened) {
+		return nil, errors.New("file changed before it was opened")
+	}
+	body, err := io.ReadAll(io.LimitReader(file, maximumBytes+1))
+	if err != nil || int64(len(body)) > maximumBytes {
+		return nil, fmt.Errorf("read bounded file of at most %d bytes", maximumBytes)
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return nil, err
+	}
+	confirmation, err := io.ReadAll(io.LimitReader(file, maximumBytes+1))
+	if err != nil || !bytes.Equal(body, confirmation) {
+		return nil, errors.New("file changed while it was read")
+	}
+	after, err := os.Lstat(path)
+	if err != nil || !after.Mode().IsRegular() || !os.SameFile(opened, after) ||
+		after.Size() != opened.Size() || !after.ModTime().Equal(opened.ModTime()) {
+		return nil, errors.New("file changed while it was read")
+	}
+	return body, nil
+}

--- a/tooling/internal/workstationrunner/inventory_test.go
+++ b/tooling/internal/workstationrunner/inventory_test.go
@@ -1,0 +1,325 @@
+package workstationrunner
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRepositoryWorkstationInventoryCoversEveryTestExactlyOnce(t *testing.T) {
+	t.Parallel()
+	root, err := resolveRepositoryRoot(filepath.Clean(filepath.Join("..", "..", "..")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	jobs, err := productionJobs()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := freezeWorkstationInventory(root, jobs); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestValidateWorkstationInventoryRejectsCoverageAndManifestDrift(t *testing.T) {
+	t.Parallel()
+	for name, mutate := range map[string]func(*testing.T, string){
+		"missing discovered test": func(t *testing.T, root string) {
+			writeInventoryPackage(t, root, "node --test --experimental-test-isolation=none experiments/workstation/core.test.mjs", fixtureCommand)
+		},
+		"duplicate discovered test": func(t *testing.T, root string) {
+			writeInventoryPackage(t, root, coreCommand, fixtureCommand+" experiments/workstation/core.test.mjs")
+		},
+		"empty pattern": func(t *testing.T, root string) {
+			writeInventoryPackage(t, root, coreCommand, "node --test --experimental-test-isolation=none experiments/workstation/fixture-007/missing.test.mjs")
+		},
+		"missing full_tests path": func(t *testing.T, root string) {
+			writeInventoryManifest(t, root, []string{"experiments/workstation/fixture-007/missing.test.mjs"})
+		},
+		"foreign full_tests path": func(t *testing.T, root string) {
+			writeInventoryManifest(t, root, []string{"experiments/workstation/core.test.mjs"})
+		},
+		"aggregate bypass": func(t *testing.T, root string) {
+			writeInventoryPackage(t, root, coreCommand, fixtureCommand)
+			body, err := os.ReadFile(filepath.Join(root, "package.json"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			body = []byte(strings.ReplaceAll(string(body), workstationAggregateCommand, "npm run test:workstation:core"))
+			if err := os.WriteFile(filepath.Join(root, "package.json"), body, 0o600); err != nil {
+				t.Fatal(err)
+			}
+		},
+		"missing artifact manifest": func(t *testing.T, root string) {
+			if err := os.Remove(filepath.Join(root, "experiments", "workstation", "manifests", "fixture-007.json")); err != nil {
+				t.Fatal(err)
+			}
+		},
+		"ambiguous package json": func(t *testing.T, root string) {
+			body := `{"scripts":{"test:workstation":"` + workstationAggregateCommand +
+				`","test:workstation":"` + workstationAggregateCommand + `"}}`
+			if err := os.WriteFile(filepath.Join(root, "package.json"), []byte(body), 0o600); err != nil {
+				t.Fatal(err)
+			}
+		},
+	} {
+		name, mutate := name, mutate
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			root, jobs := workstationInventoryFixture(t)
+			mutate(t, root)
+			if _, err := freezeWorkstationInventory(root, jobs); err == nil {
+				t.Fatal("freezeWorkstationInventory accepted drift")
+			}
+		})
+	}
+}
+
+func TestParseWorkstationCommandRequiresClosedNodeTestPaths(t *testing.T) {
+	t.Parallel()
+	valid, err := parseWorkstationCommand(
+		"node --test --experimental-test-isolation=none --test-concurrency=1 " +
+			"experiments/workstation/fixture-007/*.test.mjs",
+	)
+	if err != nil || len(valid.patterns) != 1 || len(valid.arguments) != 4 {
+		t.Fatalf("parseWorkstationCommand(valid) = %q/%v", valid, err)
+	}
+	for _, command := range []string{
+		"node --test experiments/workstation/fixture-007/*.test.mjs",
+		"node --test --experimental-test-isolation=none",
+		"node --test --experimental-test-isolation=none experiments/workstation/**/*.test.mjs",
+		"node --test --experimental-test-isolation=none experiments/workstation/fixture-007/*.test.mjs && true",
+		"node --test --experimental-test-isolation=none ../outside.test.mjs",
+	} {
+		if _, err := parseWorkstationCommand(command); err == nil {
+			t.Fatalf("parseWorkstationCommand(%q) accepted an open command", command)
+		}
+	}
+}
+
+func TestFrozenArgumentsSurvivePackageRewriteAndExcludeLifecycleHooks(t *testing.T) {
+	root, jobs, originalPackage := frozenMutationFixture(t)
+	frozen, err := freezeWorkstationInventory(root, jobs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantSafeArgument := "experiments/workstation/fixture-007/safe-later.test.mjs"
+	if len(frozen) != 2 || frozen[1].arguments[len(frozen[1].arguments)-1] != wantSafeArgument {
+		t.Fatalf("frozen jobs = %#v, want exact safe-later argv", frozen)
+	}
+
+	options := helperOptions(t, 2)
+	var summary bytes.Buffer
+	if err := runSuite(t.Context(), root, frozen, options, &summary); err != nil {
+		t.Fatalf("runSuite() error/summary = %v/%q", err, summary.String())
+	}
+	currentPackage, err := os.ReadFile(filepath.Join(root, "package.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(currentPackage, originalPackage) {
+		t.Fatal("mutation helper did not restore package.json byte for byte")
+	}
+	safeArguments, err := os.ReadFile(filepath.Join(root, "safe-later.ran"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(safeArguments), wantSafeArgument) || strings.Contains(string(safeArguments), "hostile") {
+		t.Fatalf("later job arguments = %q, want only frozen safe path", safeArguments)
+	}
+	for _, forbidden := range []string{"hostile-later.ran", "pre-hook.ran", "post-hook.ran"} {
+		if _, err := os.Lstat(filepath.Join(root, forbidden)); !os.IsNotExist(err) {
+			t.Fatalf("unvalidated package script executed via %s: %v", forbidden, err)
+		}
+	}
+}
+
+const (
+	coreCommand = "node --test --experimental-test-isolation=none --test-concurrency=1 " +
+		"experiments/workstation/*.test.mjs experiments/workstation/lib/*.test.mjs"
+	fixtureCommand = "node --test --experimental-test-isolation=none " +
+		"experiments/workstation/fixture-007/*.test.mjs"
+)
+
+func workstationInventoryFixture(t *testing.T) (string, []job) {
+	t.Helper()
+	root := t.TempDir()
+	for _, directory := range []string{
+		filepath.Join(root, "experiments", "workstation", "lib"),
+		filepath.Join(root, "experiments", "workstation", "fixture-007"),
+		filepath.Join(root, "experiments", "workstation", "manifests"),
+	} {
+		if err := os.MkdirAll(directory, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, relative := range []string{
+		"experiments/workstation/core.test.mjs",
+		"experiments/workstation/lib/helper.test.mjs",
+		"experiments/workstation/fixture-007/runner.test.mjs",
+	} {
+		if err := os.WriteFile(filepath.Join(root, filepath.FromSlash(relative)), []byte("export {};\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeInventoryPackage(t, root, coreCommand, fixtureCommand)
+	writeInventoryManifest(t, root, []string{"experiments/workstation/fixture-007/runner.test.mjs"})
+	return root, []job{
+		{artifact: "core", script: "test:workstation:core"},
+		{artifact: "fixture-007", script: "test:workstation:fixture-007"},
+	}
+}
+
+func frozenMutationFixture(t *testing.T) (string, []job, []byte) {
+	t.Helper()
+	root := t.TempDir()
+	for _, directory := range []string{
+		filepath.Join(root, "experiments", "workstation", "fixture-007"),
+		filepath.Join(root, "experiments", "workstation", "manifests"),
+	} {
+		if err := os.MkdirAll(directory, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, relative := range []string{
+		"experiments/workstation/mutation-gate.test.mjs",
+		"experiments/workstation/fixture-007/safe-later.test.mjs",
+	} {
+		if err := os.WriteFile(filepath.Join(root, filepath.FromSlash(relative)), []byte("export {};\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	document := map[string]any{"scripts": map[string]string{
+		"test:workstation":                 workstationAggregateCommand,
+		"test:workstation:core":            "node --test --experimental-test-isolation=none experiments/workstation/mutation-gate.test.mjs",
+		"test:workstation:fixture-007":     "node --test --experimental-test-isolation=none experiments/workstation/fixture-007/safe-later.test.mjs",
+		"pretest:workstation:fixture-007":  "node experiments/workstation/pre-hook.mjs",
+		"posttest:workstation:fixture-007": "node experiments/workstation/post-hook.mjs",
+	}}
+	writeInventoryJSON(t, filepath.Join(root, "package.json"), document)
+	writeInventoryManifest(t, root, []string{"experiments/workstation/fixture-007/safe-later.test.mjs"})
+	original, err := os.ReadFile(filepath.Join(root, "package.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return root, []job{
+		{artifact: "core", script: "test:workstation:core"},
+		{artifact: "fixture-007", script: "test:workstation:fixture-007"},
+	}, original
+}
+
+func runFrozenNodeHelper(arguments []string) error {
+	joined := strings.Join(arguments, " ")
+	switch {
+	case strings.Contains(joined, "mutation-gate.test.mjs"):
+		return mutatePackageDuringFrozenRun()
+	case strings.Contains(joined, "safe-later.test.mjs"):
+		if err := waitForHelperFile("package.mutated"); err != nil {
+			return err
+		}
+		body, err := os.ReadFile("package.json")
+		if err != nil {
+			return err
+		}
+		if !strings.Contains(string(body), "hostile-later.test.mjs") {
+			return errors.New("later job did not overlap the hostile package mutation")
+		}
+		return os.WriteFile("safe-later.ran", []byte(joined+"\n"), 0o600)
+	case strings.Contains(joined, "hostile-later.test.mjs"):
+		return os.WriteFile("hostile-later.ran", []byte("executed\n"), 0o600)
+	case strings.Contains(joined, "pre-hook.mjs"):
+		return os.WriteFile("pre-hook.ran", []byte("executed\n"), 0o600)
+	case strings.Contains(joined, "post-hook.mjs"):
+		return os.WriteFile("post-hook.ran", []byte("executed\n"), 0o600)
+	default:
+		return fmt.Errorf("unexpected frozen Node helper arguments: %q", arguments)
+	}
+}
+
+func mutatePackageDuringFrozenRun() error {
+	original, err := os.ReadFile("package.json")
+	if err != nil {
+		return err
+	}
+	hostile := []byte(`{"scripts":{"test:workstation:fixture-007":"node --test --experimental-test-isolation=none experiments/workstation/fixture-007/hostile-later.test.mjs","pretest:workstation:fixture-007":"node experiments/workstation/pre-hook.mjs","posttest:workstation:fixture-007":"node experiments/workstation/post-hook.mjs"}}` + "\n")
+	if err := os.WriteFile("package.json", hostile, 0o600); err != nil {
+		return err
+	}
+	if err := os.WriteFile("package.mutated", []byte("ready\n"), 0o600); err != nil {
+		return errors.Join(err, os.WriteFile("package.json", original, 0o600))
+	}
+	waitErr := waitForHelperFile("safe-later.ran")
+	restoreErr := os.WriteFile("package.json", original, 0o600)
+	return errors.Join(waitErr, restoreErr)
+}
+
+func waitForHelperFile(filename string) error {
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Lstat(filename); err == nil {
+			return nil
+		} else if !os.IsNotExist(err) {
+			return err
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return fmt.Errorf("timed out waiting for %s", filename)
+}
+
+func writeInventoryPackage(t *testing.T, root, core, fixture string) {
+	t.Helper()
+	document := map[string]any{"scripts": map[string]string{
+		"test":                         "npm run validate:workstation && npm run test:workstation",
+		"test:workstation":             workstationAggregateCommand,
+		"test:workstation:core":        core,
+		"test:workstation:fixture-007": fixture,
+	}}
+	writeInventoryJSON(t, filepath.Join(root, "package.json"), document)
+}
+
+func writeInventoryManifest(t *testing.T, root string, fullTests []string) {
+	t.Helper()
+	document := map[string]any{
+		"artifact":       "fixture-007",
+		"implementation": map[string]any{"full_tests": fullTests},
+	}
+	writeInventoryJSON(
+		t,
+		filepath.Join(root, "experiments", "workstation", "manifests", "fixture-007.json"),
+		document,
+	)
+}
+
+func writeInventoryJSON(t *testing.T, filename string, document any) {
+	t.Helper()
+	body, err := json.Marshal(document)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filename, append(body, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestWorkstationPatternCoversOnlyOneDirectoryLevel(t *testing.T) {
+	t.Parallel()
+	pattern := "experiments/workstation/fixture-007/*.test.mjs"
+	if !workstationPatternCovers(pattern, "experiments/workstation/fixture-007/runner.test.mjs") {
+		t.Fatal("direct test did not match")
+	}
+	for _, testPath := range []string{
+		"experiments/workstation/fixture-007/nested/runner.test.mjs",
+		"experiments/workstation/fixture-007/runner.mjs",
+		strings.TrimSuffix(pattern, "*.test.mjs"),
+	} {
+		if workstationPatternCovers(pattern, testPath) {
+			t.Fatalf("pattern unexpectedly covered %q", testPath)
+		}
+	}
+}

--- a/tooling/internal/workstationrunner/path_identity.go
+++ b/tooling/internal/workstationrunner/path_identity.go
@@ -1,0 +1,20 @@
+package workstationrunner
+
+import (
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func sameCanonicalPath(left, right string) bool {
+	return sameCanonicalPathForOS(runtime.GOOS, left, right)
+}
+
+func sameCanonicalPathForOS(goos, left, right string) bool {
+	left = filepath.Clean(left)
+	right = filepath.Clean(right)
+	if goos == "windows" {
+		return strings.EqualFold(left, right)
+	}
+	return left == right
+}

--- a/tooling/internal/workstationrunner/path_identity_test.go
+++ b/tooling/internal/workstationrunner/path_identity_test.go
@@ -1,0 +1,18 @@
+package workstationrunner
+
+import "testing"
+
+func TestSameCanonicalPathUsesWindowsCaseFoldingOnly(t *testing.T) {
+	t.Parallel()
+	left := `C:\Users\Research\Repository`
+	right := `c:\users\research\repository`
+	if !sameCanonicalPathForOS("windows", left, right) {
+		t.Fatal("Windows case variant was not treated as the same canonical path")
+	}
+	if sameCanonicalPathForOS("linux", left, right) {
+		t.Fatal("non-Windows path comparison unexpectedly ignored case")
+	}
+	if sameCanonicalPathForOS("windows", left, `C:\Users\Research\Other`) {
+		t.Fatal("Windows comparison accepted a different canonical path")
+	}
+}

--- a/tooling/internal/workstationrunner/process_tree.go
+++ b/tooling/internal/workstationrunner/process_tree.go
@@ -1,0 +1,6 @@
+package workstationrunner
+
+type processTree interface {
+	attach() error
+	cleanup() error
+}

--- a/tooling/internal/workstationrunner/process_tree_other.go
+++ b/tooling/internal/workstationrunner/process_tree_other.go
@@ -1,0 +1,13 @@
+//go:build !aix && !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !solaris && !windows
+
+package workstationrunner
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+)
+
+func configureProcessTree(*exec.Cmd) (processTree, error) {
+	return nil, fmt.Errorf("bounded process-tree cancellation is unavailable on %s", runtime.GOOS)
+}

--- a/tooling/internal/workstationrunner/process_tree_unix.go
+++ b/tooling/internal/workstationrunner/process_tree_unix.go
@@ -1,0 +1,43 @@
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+package workstationrunner
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+type unixProcessTree struct {
+	command *exec.Cmd
+}
+
+func configureProcessTree(command *exec.Cmd) (processTree, error) {
+	command.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	tree := &unixProcessTree{command: command}
+	command.Cancel = func() error {
+		err := tree.terminate()
+		if errors.Is(err, syscall.ESRCH) {
+			return os.ErrProcessDone
+		}
+		return err
+	}
+	return tree, nil
+}
+
+func (*unixProcessTree) attach() error { return nil }
+
+func (tree *unixProcessTree) cleanup() error {
+	if err := tree.terminate(); err != nil && !errors.Is(err, syscall.ESRCH) && !errors.Is(err, os.ErrProcessDone) {
+		return err
+	}
+	return nil
+}
+
+func (tree *unixProcessTree) terminate() error {
+	if tree.command.Process == nil {
+		return os.ErrProcessDone
+	}
+	return syscall.Kill(-tree.command.Process.Pid, syscall.SIGKILL)
+}

--- a/tooling/internal/workstationrunner/process_tree_windows.go
+++ b/tooling/internal/workstationrunner/process_tree_windows.go
@@ -1,0 +1,222 @@
+//go:build windows
+
+package workstationrunner
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"sync"
+	"syscall"
+	"unsafe"
+)
+
+const (
+	createSuspended                   = 0x00000004
+	jobObjectExtendedLimitInformation = 9
+	jobObjectLimitKillOnJobClose      = 0x00002000
+	processSetQuota                   = 0x0100
+	processTerminate                  = 0x0001
+	threadSuspendResume               = 0x0002
+)
+
+var (
+	kernel32                     = syscall.NewLazyDLL("kernel32.dll")
+	procAssignProcessToJobObject = kernel32.NewProc("AssignProcessToJobObject")
+	procCreateJobObjectW         = kernel32.NewProc("CreateJobObjectW")
+	procOpenThread               = kernel32.NewProc("OpenThread")
+	procResumeThread             = kernel32.NewProc("ResumeThread")
+	procSetInformationJobObject  = kernel32.NewProc("SetInformationJobObject")
+	procTerminateJobObject       = kernel32.NewProc("TerminateJobObject")
+	procThread32First            = kernel32.NewProc("Thread32First")
+	procThread32Next             = kernel32.NewProc("Thread32Next")
+)
+
+type windowsBasicLimitInformation struct {
+	perProcessUserTimeLimit int64
+	perJobUserTimeLimit     int64
+	limitFlags              uint32
+	minimumWorkingSetSize   uintptr
+	maximumWorkingSetSize   uintptr
+	activeProcessLimit      uint32
+	affinity                uintptr
+	priorityClass           uint32
+	schedulingClass         uint32
+}
+
+type windowsIOCounters struct {
+	readOperationCount  uint64
+	writeOperationCount uint64
+	otherOperationCount uint64
+	readTransferCount   uint64
+	writeTransferCount  uint64
+	otherTransferCount  uint64
+}
+
+type windowsExtendedLimitInformation struct {
+	basicLimitInformation windowsBasicLimitInformation
+	ioInfo                windowsIOCounters
+	processMemoryLimit    uintptr
+	jobMemoryLimit        uintptr
+	peakProcessMemoryUsed uintptr
+	peakJobMemoryUsed     uintptr
+}
+
+type windowsThreadEntry struct {
+	size           uint32
+	usage          uint32
+	threadID       uint32
+	ownerProcessID uint32
+	basePriority   int32
+	deltaPriority  int32
+	flags          uint32
+}
+
+type windowsProcessTree struct {
+	mutex    sync.Mutex
+	command  *exec.Cmd
+	job      syscall.Handle
+	attached bool
+	closed   bool
+}
+
+func configureProcessTree(command *exec.Cmd) (processTree, error) {
+	jobValue, _, callErr := procCreateJobObjectW.Call(0, 0)
+	if jobValue == 0 {
+		return nil, windowsAPIFailure("create process job", callErr)
+	}
+	job := syscall.Handle(jobValue)
+	limits := windowsExtendedLimitInformation{}
+	limits.basicLimitInformation.limitFlags = jobObjectLimitKillOnJobClose
+	configured, _, callErr := procSetInformationJobObject.Call(
+		uintptr(job),
+		jobObjectExtendedLimitInformation,
+		uintptr(unsafe.Pointer(&limits)),
+		unsafe.Sizeof(limits),
+	)
+	if configured == 0 {
+		_ = syscall.CloseHandle(job)
+		return nil, windowsAPIFailure("configure kill-on-close process job", callErr)
+	}
+	tree := &windowsProcessTree{command: command, job: job}
+	command.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP | createSuspended,
+		HideWindow:    true,
+	}
+	command.Cancel = tree.cancel
+	return tree, nil
+}
+
+func (tree *windowsProcessTree) attach() error {
+	tree.mutex.Lock()
+	defer tree.mutex.Unlock()
+	if tree.closed || tree.command.Process == nil {
+		return errors.New("Windows process job cannot attach to an unavailable process")
+	}
+	process, err := syscall.OpenProcess(
+		processSetQuota|processTerminate,
+		false,
+		uint32(tree.command.Process.Pid),
+	)
+	if err != nil {
+		return fmt.Errorf("open suspended Windows process: %w", err)
+	}
+	assigned, _, callErr := procAssignProcessToJobObject.Call(uintptr(tree.job), uintptr(process))
+	closeErr := syscall.CloseHandle(process)
+	if assigned == 0 {
+		return errors.Join(windowsAPIFailure("assign suspended process to job", callErr), closeErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("close assigned Windows process handle: %w", closeErr)
+	}
+	tree.attached = true
+	if err := resumeWindowsProcess(uint32(tree.command.Process.Pid)); err != nil {
+		_, _, _ = procTerminateJobObject.Call(uintptr(tree.job), 1)
+		return err
+	}
+	return nil
+}
+
+func (tree *windowsProcessTree) cancel() error {
+	tree.mutex.Lock()
+	defer tree.mutex.Unlock()
+	if tree.closed || tree.command.Process == nil {
+		return os.ErrProcessDone
+	}
+	if !tree.attached {
+		return tree.command.Process.Kill()
+	}
+	terminated, _, callErr := procTerminateJobObject.Call(uintptr(tree.job), 1)
+	if terminated == 0 {
+		return windowsAPIFailure("terminate Windows process job", callErr)
+	}
+	return nil
+}
+
+func (tree *windowsProcessTree) cleanup() error {
+	tree.mutex.Lock()
+	defer tree.mutex.Unlock()
+	if tree.closed {
+		return nil
+	}
+	tree.closed = true
+	if err := syscall.CloseHandle(tree.job); err != nil {
+		return fmt.Errorf("close kill-on-close Windows process job: %w", err)
+	}
+	return nil
+}
+
+func resumeWindowsProcess(processID uint32) error {
+	snapshot, err := syscall.CreateToolhelp32Snapshot(syscall.TH32CS_SNAPTHREAD, 0)
+	if err != nil {
+		return fmt.Errorf("snapshot suspended Windows process threads: %w", err)
+	}
+	defer syscall.CloseHandle(snapshot)
+	entry := windowsThreadEntry{size: uint32(unsafe.Sizeof(windowsThreadEntry{}))}
+	first, _, callErr := procThread32First.Call(uintptr(snapshot), uintptr(unsafe.Pointer(&entry)))
+	if first == 0 {
+		return windowsAPIFailure("enumerate suspended Windows process threads", callErr)
+	}
+	resumed := 0
+	for {
+		if entry.ownerProcessID == processID {
+			if err := resumeWindowsThread(entry.threadID); err != nil {
+				return err
+			}
+			resumed++
+		}
+		next, _, _ := procThread32Next.Call(uintptr(snapshot), uintptr(unsafe.Pointer(&entry)))
+		if next == 0 {
+			break
+		}
+	}
+	if resumed == 0 {
+		return errors.New("suspended Windows process has no resumable thread")
+	}
+	return nil
+}
+
+func resumeWindowsThread(threadID uint32) error {
+	threadValue, _, callErr := procOpenThread.Call(threadSuspendResume, 0, uintptr(threadID))
+	if threadValue == 0 {
+		return windowsAPIFailure("open suspended Windows process thread", callErr)
+	}
+	thread := syscall.Handle(threadValue)
+	resumed, _, callErr := procResumeThread.Call(uintptr(thread))
+	closeErr := syscall.CloseHandle(thread)
+	if uint32(resumed) == ^uint32(0) {
+		return errors.Join(windowsAPIFailure("resume Windows process thread", callErr), closeErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("close resumed Windows process thread: %w", closeErr)
+	}
+	return nil
+}
+
+func windowsAPIFailure(action string, callErr error) error {
+	if errno, ok := callErr.(syscall.Errno); ok && errno != 0 {
+		return fmt.Errorf("%s: %w", action, errno)
+	}
+	return errors.New(action)
+}

--- a/tooling/internal/workstationrunner/runner.go
+++ b/tooling/internal/workstationrunner/runner.go
@@ -1,0 +1,536 @@
+// Package workstationrunner executes the closed workstation test catalogue.
+package workstationrunner
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/lusoris/20-watts-was-enough/tooling/internal/ciplan"
+)
+
+const (
+	expectedArtifactJobs         = 19
+	maximumSuiteJobs             = 32
+	maximumConcurrency           = 8
+	maximumJobDuration           = 30 * time.Minute
+	maximumJobOutputBytes        = 2 << 20
+	maximumCommandWaitDelay      = 2 * time.Second
+	maximumJobArguments          = 32
+	maximumJobArgumentBytes      = 8 << 10
+	maximumJobArgumentsBytes     = 64 << 10
+	maximumEnvironmentEntries    = 32
+	maximumEnvironmentBytes      = 64 << 10
+	maximumEnvironmentValueBytes = 8 << 10
+	maximumPackageManifestBytes  = 1 << 20
+)
+
+var allowedEnvironmentNames = map[string]struct{}{
+	"APPDATA": {}, "CI": {}, "COMSPEC": {}, "FORCE_COLOR": {}, "HOME": {},
+	"LANG": {}, "LC_ALL": {}, "LC_CTYPE": {}, "LOCALAPPDATA": {},
+	"NO_COLOR": {}, "PATH": {}, "PATHEXT": {}, "SYSTEMROOT": {}, "TEMP": {},
+	"TMP": {}, "TMPDIR": {}, "TZ": {}, "HOMEDRIVE": {}, "HOMEPATH": {},
+	"SYSTEMDRIVE": {}, "USERPROFILE": {}, "WINDIR": {}, "XDG_CACHE_HOME": {},
+}
+
+type job struct {
+	artifact  string
+	script    string
+	arguments []string
+}
+
+type runOptions struct {
+	concurrency int
+	jobDuration time.Duration
+	outputBytes int
+	waitDelay   time.Duration
+	executable  string
+	environment []string
+}
+
+type resultStatus string
+
+const (
+	statusPassed    resultStatus = "PASS"
+	statusFailed    resultStatus = "FAIL"
+	statusCancelled resultStatus = "CANCELLED"
+)
+
+type jobResult struct {
+	job      job
+	status   resultStatus
+	detail   string
+	output   []byte
+	exceeded bool
+}
+
+type boundedOutput struct {
+	mutex    sync.Mutex
+	buffer   bytes.Buffer
+	limit    int
+	exceeded bool
+	cancel   context.CancelFunc
+}
+
+func newBoundedOutput(limit int, cancel context.CancelFunc) *boundedOutput {
+	return &boundedOutput{limit: limit, cancel: cancel}
+}
+
+func (output *boundedOutput) Write(body []byte) (int, error) {
+	output.mutex.Lock()
+	available := output.limit - output.buffer.Len()
+	if available > len(body) {
+		available = len(body)
+	}
+	if available > 0 {
+		_, _ = output.buffer.Write(body[:available])
+	}
+	firstOverflow := available < len(body) && !output.exceeded
+	if available < len(body) {
+		output.exceeded = true
+	}
+	output.mutex.Unlock()
+	if firstOverflow {
+		output.cancel()
+	}
+	return len(body), nil
+}
+
+func (output *boundedOutput) snapshot() ([]byte, bool) {
+	output.mutex.Lock()
+	defer output.mutex.Unlock()
+	return bytes.Clone(output.buffer.Bytes()), output.exceeded
+}
+
+// Run executes core and every closed artifact script, then writes one ordered
+// summary. Ordinary job failures do not cancel the remaining catalogue.
+func Run(ctx context.Context, repositoryRoot string, summary io.Writer) error {
+	if ctx == nil {
+		return errors.New("workstation runner requires a context")
+	}
+	if summary == nil {
+		return errors.New("workstation runner requires a summary writer")
+	}
+	root, err := resolveRepositoryRoot(repositoryRoot)
+	if err != nil {
+		return err
+	}
+	jobs, err := productionJobs()
+	if err != nil {
+		return err
+	}
+	jobs, err = freezeWorkstationInventory(root, jobs)
+	if err != nil {
+		return fmt.Errorf("freeze workstation inventory: %w", err)
+	}
+	nodeExecutable, err := exec.LookPath("node")
+	if err != nil {
+		return errors.New("locate Node executable")
+	}
+	nodeExecutable, err = filepath.Abs(nodeExecutable)
+	if err != nil {
+		return fmt.Errorf("resolve Node executable: %w", err)
+	}
+	return runSuite(ctx, root, jobs, runOptions{
+		concurrency: maximumConcurrency,
+		jobDuration: maximumJobDuration,
+		outputBytes: maximumJobOutputBytes,
+		waitDelay:   maximumCommandWaitDelay,
+		executable:  nodeExecutable,
+		environment: os.Environ(),
+	}, summary)
+}
+
+func productionJobs() ([]job, error) {
+	coreScript, artifacts, err := ciplan.WorkstationCatalogue()
+	if err != nil {
+		return nil, fmt.Errorf("load workstation job catalogue: %w", err)
+	}
+	if len(artifacts) != expectedArtifactJobs {
+		return nil, fmt.Errorf(
+			"workstation catalogue contains %d artifact jobs, want %d",
+			len(artifacts),
+			expectedArtifactJobs,
+		)
+	}
+	jobs := make([]job, 1, len(artifacts)+1)
+	jobs[0] = job{artifact: "core", script: coreScript}
+	for _, artifact := range artifacts {
+		jobs = append(jobs, job{artifact: artifact.Artifact, script: artifact.Script})
+	}
+	return jobs, nil
+}
+
+func runSuite(
+	ctx context.Context,
+	root string,
+	jobs []job,
+	options runOptions,
+	summary io.Writer,
+) error {
+	if err := validateRunOptions(jobs, options); err != nil {
+		return err
+	}
+	environment, err := filteredEnvironment(options.environment)
+	if err != nil {
+		return fmt.Errorf("prepare bounded workstation environment: %w", err)
+	}
+	options.environment = environment
+	if _, err := fmt.Fprintf(
+		summary,
+		"Workstation suite: running %d jobs with at most %d concurrent commands; timeout %s and combined output limit %d bytes per job.\n",
+		len(jobs),
+		options.concurrency,
+		options.jobDuration,
+		options.outputBytes,
+	); err != nil {
+		return fmt.Errorf("write workstation plan: %w", err)
+	}
+	results := executeJobs(ctx, root, jobs, options)
+	failed, cancelled := countIncomplete(results)
+	writeErr := writeSummary(summary, results)
+	var suiteErr error
+	if failed > 0 || cancelled > 0 {
+		suiteErr = fmt.Errorf(
+			"workstation suite incomplete: %d failed, %d cancelled out of %d jobs",
+			failed,
+			cancelled,
+			len(results),
+		)
+	}
+	if writeErr != nil {
+		writeErr = fmt.Errorf("write workstation summary: %w", writeErr)
+	}
+	return errors.Join(suiteErr, writeErr)
+}
+
+func validateRunOptions(jobs []job, options runOptions) error {
+	if len(jobs) == 0 || len(jobs) > maximumSuiteJobs {
+		return fmt.Errorf("workstation suite contains %d jobs, limit is 1..%d", len(jobs), maximumSuiteJobs)
+	}
+	if options.concurrency < 1 || options.concurrency > maximumConcurrency {
+		return fmt.Errorf("workstation concurrency %d is outside 1..%d", options.concurrency, maximumConcurrency)
+	}
+	if options.jobDuration <= 0 || options.jobDuration > maximumJobDuration {
+		return fmt.Errorf("workstation job duration %s is outside (0,%s]", options.jobDuration, maximumJobDuration)
+	}
+	if options.outputBytes < 1 || options.outputBytes > maximumJobOutputBytes {
+		return fmt.Errorf("workstation output limit %d is outside 1..%d", options.outputBytes, maximumJobOutputBytes)
+	}
+	if options.waitDelay <= 0 || options.waitDelay > maximumCommandWaitDelay {
+		return fmt.Errorf("workstation wait delay %s is outside (0,%s]", options.waitDelay, maximumCommandWaitDelay)
+	}
+	if options.executable == "" {
+		return errors.New("workstation runner requires an executable")
+	}
+	seenArtifacts := make(map[string]struct{}, len(jobs))
+	seenScripts := make(map[string]struct{}, len(jobs))
+	for _, current := range jobs {
+		if current.artifact == "" || current.script == "" {
+			return errors.New("workstation job has an empty artifact or script")
+		}
+		if len(current.arguments) == 0 || len(current.arguments) > maximumJobArguments {
+			return fmt.Errorf(
+				"workstation job %q contains %d arguments, limit is 1..%d",
+				current.artifact,
+				len(current.arguments),
+				maximumJobArguments,
+			)
+		}
+		argumentBytes := 0
+		for _, argument := range current.arguments {
+			if argument == "" || strings.IndexByte(argument, 0) >= 0 || len(argument) > maximumJobArgumentBytes {
+				return fmt.Errorf("workstation job %q contains an invalid argument", current.artifact)
+			}
+			argumentBytes += len(argument)
+		}
+		if argumentBytes > maximumJobArgumentsBytes {
+			return fmt.Errorf(
+				"workstation job %q arguments exceed %d bytes",
+				current.artifact,
+				maximumJobArgumentsBytes,
+			)
+		}
+		if _, duplicate := seenArtifacts[current.artifact]; duplicate {
+			return fmt.Errorf("workstation artifact is repeated: %q", current.artifact)
+		}
+		if _, duplicate := seenScripts[current.script]; duplicate {
+			return fmt.Errorf("workstation script is repeated: %q", current.script)
+		}
+		seenArtifacts[current.artifact] = struct{}{}
+		seenScripts[current.script] = struct{}{}
+	}
+	return nil
+}
+
+func executeJobs(ctx context.Context, root string, jobs []job, options runOptions) []jobResult {
+	results := make([]jobResult, len(jobs))
+	work := make(chan int)
+	workerCount := options.concurrency
+	if workerCount > len(jobs) {
+		workerCount = len(jobs)
+	}
+	var workers sync.WaitGroup
+	workers.Add(workerCount)
+	for range workerCount {
+		go func() {
+			defer workers.Done()
+			for index := range work {
+				results[index] = executeJob(ctx, root, jobs[index], options)
+			}
+		}()
+	}
+
+	next := 0
+dispatch:
+	for next < len(jobs) {
+		select {
+		case work <- next:
+			next++
+		case <-ctx.Done():
+			break dispatch
+		}
+	}
+	close(work)
+	for index := next; index < len(jobs); index++ {
+		results[index] = cancelledResult(jobs[index], ctx.Err())
+	}
+	workers.Wait()
+	return results
+}
+
+func executeJob(ctx context.Context, root string, current job, options runOptions) jobResult {
+	if err := ctx.Err(); err != nil {
+		return cancelledResult(current, err)
+	}
+	jobContext, cancel := context.WithTimeout(ctx, options.jobDuration)
+	defer cancel()
+	output := newBoundedOutput(options.outputBytes, cancel)
+	command := exec.CommandContext(jobContext, options.executable, current.arguments...)
+	command.Dir = root
+	command.Env = options.environment
+	command.Stdout = output
+	command.Stderr = output
+	command.WaitDelay = options.waitDelay
+	tree, err := configureProcessTree(command)
+	if err != nil {
+		return jobResult{
+			job: current, status: statusFailed,
+			detail: fmt.Sprintf("configure bounded process tree: %v", err),
+		}
+	}
+	if err := command.Start(); err != nil {
+		return failedJobResult(current, errors.Join(err, tree.cleanup()))
+	}
+	if err := tree.attach(); err != nil {
+		killErr := command.Process.Kill()
+		waitErr := command.Wait()
+		return failedJobResult(current, errors.Join(
+			fmt.Errorf("attach bounded process tree: %w", err),
+			killErr,
+			waitErr,
+			tree.cleanup(),
+		))
+	}
+	runErr := command.Wait()
+	cleanupErr := tree.cleanup()
+	captured, exceeded := output.snapshot()
+	result := jobResult{job: current, output: captured, exceeded: exceeded}
+	switch {
+	case cleanupErr != nil:
+		result.status = statusFailed
+		result.detail = errors.Join(runErr, fmt.Errorf("clean bounded process tree: %w", cleanupErr)).Error()
+	case exceeded:
+		result.status = statusFailed
+		result.detail = fmt.Sprintf("combined output exceeded %d bytes", options.outputBytes)
+	case runErr == nil:
+		result.status = statusPassed
+	case ctx.Err() != nil:
+		return cancelledResultWithOutput(current, ctx.Err(), captured)
+	case errors.Is(jobContext.Err(), context.DeadlineExceeded):
+		result.status = statusFailed
+		result.detail = fmt.Sprintf("exceeded %s timeout", options.jobDuration)
+	default:
+		result.status = statusFailed
+		result.detail = runErr.Error()
+	}
+	return result
+}
+
+func failedJobResult(current job, err error) jobResult {
+	detail := "command failed"
+	if err != nil {
+		detail = err.Error()
+	}
+	return jobResult{job: current, status: statusFailed, detail: detail}
+}
+
+func cancelledResult(current job, err error) jobResult {
+	return cancelledResultWithOutput(current, err, nil)
+}
+
+func cancelledResultWithOutput(current job, err error, output []byte) jobResult {
+	detail := context.Canceled.Error()
+	if err != nil {
+		detail = err.Error()
+	}
+	return jobResult{job: current, status: statusCancelled, detail: detail, output: output}
+}
+
+func countIncomplete(results []jobResult) (failed, cancelled int) {
+	for _, result := range results {
+		switch result.status {
+		case statusFailed:
+			failed++
+		case statusCancelled:
+			cancelled++
+		}
+	}
+	return failed, cancelled
+}
+
+func writeSummary(writer io.Writer, results []jobResult) error {
+	passed := 0
+	failed := 0
+	cancelled := 0
+	for _, result := range results {
+		if _, writeErr := fmt.Fprintf(writer, "%s %s (%s)", result.status, result.job.artifact, result.job.script); writeErr != nil {
+			return writeErr
+		}
+		if result.detail != "" {
+			if _, writeErr := fmt.Fprintf(writer, ": %s", result.detail); writeErr != nil {
+				return writeErr
+			}
+		}
+		if _, writeErr := io.WriteString(writer, "\n"); writeErr != nil {
+			return writeErr
+		}
+		switch result.status {
+		case statusPassed:
+			passed++
+		case statusFailed:
+			failed++
+		case statusCancelled:
+			cancelled++
+		}
+		if result.status != statusPassed && len(result.output) > 0 {
+			if _, writeErr := fmt.Fprintf(writer, "--- %s output ---\n", result.job.artifact); writeErr != nil {
+				return writeErr
+			}
+			if _, writeErr := writer.Write(result.output); writeErr != nil {
+				return writeErr
+			}
+			if result.output[len(result.output)-1] != '\n' {
+				if _, writeErr := io.WriteString(writer, "\n"); writeErr != nil {
+					return writeErr
+				}
+			}
+			if _, writeErr := fmt.Fprintf(writer, "--- end %s output ---\n", result.job.artifact); writeErr != nil {
+				return writeErr
+			}
+		}
+	}
+	_, err := fmt.Fprintf(
+		writer,
+		"Workstation suite: %d passed, %d failed, %d cancelled.\n",
+		passed,
+		failed,
+		cancelled,
+	)
+	return err
+}
+
+func filteredEnvironment(environment []string) ([]string, error) {
+	values := make(map[string]string, len(allowedEnvironmentNames))
+	for _, entry := range environment {
+		if entry == "" {
+			return nil, errors.New("environment contains a malformed entry")
+		}
+		// Windows drive-current-directory entries begin with '='; find the
+		// separator after the first byte so they can be discarded by the allowlist.
+		separator := strings.IndexByte(entry[1:], '=')
+		if separator < 0 {
+			return nil, errors.New("environment contains a malformed entry")
+		}
+		separator++
+		name, value := entry[:separator], entry[separator+1:]
+		canonicalName := strings.ToUpper(name)
+		if _, allowed := allowedEnvironmentNames[canonicalName]; !allowed {
+			continue
+		}
+		if _, duplicate := values[canonicalName]; duplicate {
+			return nil, fmt.Errorf("environment repeats %s", canonicalName)
+		}
+		if strings.IndexByte(value, 0) >= 0 {
+			return nil, fmt.Errorf("environment value for %s contains NUL", canonicalName)
+		}
+		if len(value) > maximumEnvironmentValueBytes {
+			return nil, fmt.Errorf("environment value for %s exceeds %d bytes", canonicalName, maximumEnvironmentValueBytes)
+		}
+		values[canonicalName] = value
+	}
+	if values["PATH"] == "" {
+		return nil, errors.New("environment requires a non-empty PATH")
+	}
+	if len(values) > maximumEnvironmentEntries {
+		return nil, fmt.Errorf("environment contains %d retained entries, limit is %d", len(values), maximumEnvironmentEntries)
+	}
+	names := make([]string, 0, len(values))
+	for name := range values {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	filtered := make([]string, 0, len(names))
+	totalBytes := 0
+	for _, name := range names {
+		entry := name + "=" + values[name]
+		totalBytes += len(entry)
+		if totalBytes > maximumEnvironmentBytes {
+			return nil, fmt.Errorf("environment exceeds %d retained bytes", maximumEnvironmentBytes)
+		}
+		filtered = append(filtered, entry)
+	}
+	return filtered, nil
+}
+
+func resolveRepositoryRoot(root string) (string, error) {
+	if root == "" {
+		return "", errors.New("workstation runner requires a repository root")
+	}
+	absolute, err := filepath.Abs(root)
+	if err != nil {
+		return "", fmt.Errorf("resolve repository root: %w", err)
+	}
+	resolved, err := filepath.EvalSymlinks(absolute)
+	if err != nil {
+		return "", fmt.Errorf("resolve repository root symlinks: %w", err)
+	}
+	if !sameCanonicalPath(absolute, resolved) {
+		return "", errors.New("repository root must not traverse symlinks")
+	}
+	information, err := os.Lstat(resolved)
+	if err != nil {
+		return "", fmt.Errorf("inspect repository root: %w", err)
+	}
+	if !information.IsDir() || information.Mode()&os.ModeSymlink != 0 {
+		return "", errors.New("repository root is not a real directory")
+	}
+	packagePath := filepath.Join(resolved, "package.json")
+	packageInformation, err := os.Lstat(packagePath)
+	if err != nil {
+		return "", fmt.Errorf("inspect package.json: %w", err)
+	}
+	if !packageInformation.Mode().IsRegular() || packageInformation.Size() <= 0 || packageInformation.Size() > maximumPackageManifestBytes {
+		return "", fmt.Errorf("package.json is not a regular file of at most %d bytes", maximumPackageManifestBytes)
+	}
+	return resolved, nil
+}

--- a/tooling/internal/workstationrunner/runner_test.go
+++ b/tooling/internal/workstationrunner/runner_test.go
@@ -1,0 +1,593 @@
+package workstationrunner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestMain(testingMain *testing.M) {
+	if len(os.Args) >= 2 && os.Args[1] == "--test" {
+		if err := runFrozenNodeHelper(os.Args[2:]); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(23)
+		}
+		os.Exit(0)
+	}
+	if len(os.Args) == 3 && os.Args[1] == "workstation-grandchild" {
+		time.Sleep(400 * time.Millisecond)
+		if err := os.WriteFile(os.Args[2], []byte("survived\n"), 0o600); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(20)
+		}
+		os.Exit(0)
+	}
+	if len(os.Args) == 3 && os.Args[1] == "workstation-orphan-grandchild" {
+		// A race-instrumented parent sleeps for about one second during exit.
+		// Keep this descendant alive beyond that delay so post-wait cleanup,
+		// rather than the helper's natural exit, determines the outcome.
+		time.Sleep(2 * time.Second)
+		if err := os.WriteFile(os.Args[2], []byte("survived\n"), 0o600); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(25)
+		}
+		os.Exit(0)
+	}
+	if len(os.Args) == 3 && os.Args[1] == "run" && strings.HasPrefix(os.Args[2], "test:workstation:") {
+		runHelper(os.Args[2])
+		os.Exit(0)
+	}
+	os.Exit(testingMain.Run())
+}
+
+func runHelper(script string) {
+	switch {
+	case strings.Contains(script, "tree"):
+		grandchild := exec.Command(
+			os.Args[0],
+			"workstation-grandchild",
+			filepath.Join(".", "grandchild.survived"),
+		)
+		grandchild.Stdout = os.Stdout
+		grandchild.Stderr = os.Stderr
+		if err := grandchild.Start(); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(21)
+		}
+		if err := os.WriteFile("grandchild.ready", []byte("ready\n"), 0o600); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(22)
+		}
+		time.Sleep(time.Hour)
+	case strings.Contains(script, "orphan"):
+		grandchild := exec.Command(
+			os.Args[0],
+			"workstation-orphan-grandchild",
+			filepath.Join(".", "grandchild.survived"),
+		)
+		grandchild.Stdout = os.Stdout
+		grandchild.Stderr = os.Stderr
+		if err := grandchild.Start(); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(24)
+		}
+		return
+	case strings.Contains(script, "environment"):
+		fmt.Printf(
+			"secret=%q node_options=%q path=%q\n",
+			os.Getenv("WORKSTATION_RUNNER_SECRET"),
+			os.Getenv("NODE_OPTIONS"),
+			os.Getenv("PATH"),
+		)
+		os.Exit(17)
+	case strings.Contains(script, "overflow"):
+		fmt.Print(strings.Repeat("x", 4096))
+	case strings.Contains(script, "block"):
+		time.Sleep(time.Hour)
+	case strings.Contains(script, "fail"):
+		fmt.Printf("failure from %s\n", script)
+		os.Exit(17)
+	case strings.Contains(script, "gate"):
+		marker := strings.NewReplacer(":", "-", "/", "-").Replace(script) + ".ready"
+		if err := os.WriteFile(marker, []byte("ready\n"), 0o600); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(18)
+		}
+		for {
+			if _, err := os.Lstat("release"); err == nil {
+				break
+			} else if !os.IsNotExist(err) {
+				fmt.Fprintln(os.Stderr, err)
+				os.Exit(19)
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+	case strings.Contains(script, "slow"):
+		time.Sleep(40 * time.Millisecond)
+	}
+	fmt.Printf("completed %s\n", script)
+}
+
+func TestProductionJobsUseTheCompleteClosedCatalogue(t *testing.T) {
+	t.Parallel()
+	jobs, err := productionJobs()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(jobs) != expectedArtifactJobs+1 {
+		t.Fatalf("productionJobs() returned %d jobs, want %d", len(jobs), expectedArtifactJobs+1)
+	}
+	if jobs[0].artifact != "core" || jobs[0].script != "test:workstation:core" || jobs[0].arguments != nil {
+		t.Fatalf("first production job = %#v, want core", jobs[0])
+	}
+	for index, current := range jobs[1:] {
+		if current.artifact == "" || current.script == "" {
+			t.Fatalf("production job %d is incomplete: %#v", index+1, current)
+		}
+	}
+
+	root := filepath.Clean(filepath.Join("..", "..", ".."))
+	body, err := os.ReadFile(filepath.Join(root, "package.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var manifest struct {
+		Scripts map[string]string `json:"scripts"`
+	}
+	if err := json.Unmarshal(body, &manifest); err != nil {
+		t.Fatal(err)
+	}
+	if got := manifest.Scripts["test:workstation"]; got != "go -C tooling run ./cmd/20w ci run-workstation --root .." {
+		t.Fatalf("test:workstation = %q, want bounded Go runner", got)
+	}
+	for _, current := range jobs {
+		if manifest.Scripts[current.script] == "" {
+			t.Fatalf("package.json has no command for %s", current.script)
+		}
+	}
+}
+
+func TestRunRejectsMissingPublicBoundaries(t *testing.T) {
+	t.Parallel()
+	if err := Run(nil, ".", &bytes.Buffer{}); err == nil || !strings.Contains(err.Error(), "requires a context") {
+		t.Fatalf("Run(nil context) error = %v", err)
+	}
+	if err := Run(context.Background(), ".", nil); err == nil || !strings.Contains(err.Error(), "summary writer") {
+		t.Fatalf("Run(nil writer) error = %v", err)
+	}
+}
+
+func TestRunSuiteCollectsEveryFailureAndOrdersTheSummary(t *testing.T) {
+	t.Parallel()
+	root := repositoryFixture(t)
+	options := helperOptions(t, 2)
+	jobs := []job{
+		helperJob("slow-first", "test:workstation:slow-first"),
+		helperJob("fail-second", "test:workstation:fail-second"),
+		helperJob("fail-third", "test:workstation:fail-third"),
+		helperJob("pass-fourth", "test:workstation:pass-fourth"),
+	}
+	var summary bytes.Buffer
+	err := runSuite(context.Background(), root, jobs, options, &summary)
+	if err == nil || !strings.Contains(err.Error(), "2 failed, 0 cancelled out of 4 jobs") {
+		t.Fatalf("runSuite() error = %v, want complete failure count", err)
+	}
+	lines := strings.Split(summary.String(), "\n")
+	wantPrefixes := []string{
+		"Workstation suite: running 4 jobs with at most 2 concurrent commands; timeout 5s and combined output limit 16384 bytes per job.",
+		"PASS slow-first (test:workstation:slow-first)",
+		"FAIL fail-second (test:workstation:fail-second): exit status 17",
+		"--- fail-second output ---",
+		"failure from test:workstation:fail-second",
+		"--- end fail-second output ---",
+		"FAIL fail-third (test:workstation:fail-third): exit status 17",
+		"--- fail-third output ---",
+		"failure from test:workstation:fail-third",
+		"--- end fail-third output ---",
+		"PASS pass-fourth (test:workstation:pass-fourth)",
+		"Workstation suite: 2 passed, 2 failed, 0 cancelled.",
+	}
+	if !reflect.DeepEqual(lines[:len(wantPrefixes)], wantPrefixes) {
+		t.Fatalf("ordered summary =\n%s\nwant prefixes = %#v", summary.String(), wantPrefixes)
+	}
+}
+
+func TestRunSuiteCapsConcurrentCommands(t *testing.T) {
+	t.Parallel()
+	root := repositoryFixture(t)
+	options := helperOptions(t, 2)
+	jobs := []job{
+		helperJob("gate-one", "test:workstation:gate-one"),
+		helperJob("gate-two", "test:workstation:gate-two"),
+		helperJob("gate-three", "test:workstation:gate-three"),
+	}
+	done := make(chan error, 1)
+	go func() {
+		done <- runSuite(context.Background(), root, jobs, options, &bytes.Buffer{})
+	}()
+	waitForMarkerCount(t, root, 2)
+	if got := markerCount(t, root); got != 2 {
+		t.Fatalf("active command markers = %d, want exactly 2 before release", got)
+	}
+	if err := os.WriteFile(filepath.Join(root, "release"), []byte("release\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("bounded concurrent suite did not finish")
+	}
+	if got := markerCount(t, root); got != len(jobs) {
+		t.Fatalf("completed command markers = %d, want %d", got, len(jobs))
+	}
+}
+
+func TestRunSuiteRejectsConcurrencyAboveEight(t *testing.T) {
+	t.Parallel()
+	options := helperOptions(t, maximumConcurrency+1)
+	err := runSuite(context.Background(), repositoryFixture(t), []job{
+		helperJob("one", "test:workstation:one"),
+	}, options, &bytes.Buffer{})
+	if err == nil || !strings.Contains(err.Error(), "outside 1..8") {
+		t.Fatalf("runSuite() error = %v, want concurrency rejection", err)
+	}
+}
+
+func TestRunSuiteRejectsInvalidBoundsAndDuplicateJobs(t *testing.T) {
+	t.Parallel()
+	valid := helperOptions(t, 1)
+	for name, testCase := range map[string]struct {
+		jobs    []job
+		options runOptions
+	}{
+		"empty jobs": {
+			jobs:    nil,
+			options: valid,
+		},
+		"too many jobs": {
+			jobs:    makeUniqueJobs(maximumSuiteJobs + 1),
+			options: valid,
+		},
+		"duplicate artifact": {
+			jobs: []job{
+				helperJob("same", "test:workstation:one"),
+				helperJob("same", "test:workstation:two"),
+			},
+			options: valid,
+		},
+		"duplicate script": {
+			jobs: []job{
+				helperJob("one", "test:workstation:same"),
+				helperJob("two", "test:workstation:same"),
+			},
+			options: valid,
+		},
+		"missing frozen arguments": {
+			jobs:    []job{{artifact: "one", script: "test:workstation:one"}},
+			options: valid,
+		},
+		"long timeout": {
+			jobs:    []job{helperJob("one", "test:workstation:one")},
+			options: withJobDuration(valid, maximumJobDuration+time.Nanosecond),
+		},
+		"large output": {
+			jobs:    []job{helperJob("one", "test:workstation:one")},
+			options: withOutputBytes(valid, maximumJobOutputBytes+1),
+		},
+	} {
+		name, testCase := name, testCase
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if err := runSuite(
+				context.Background(),
+				repositoryFixture(t),
+				testCase.jobs,
+				testCase.options,
+				&bytes.Buffer{},
+			); err == nil {
+				t.Fatal("runSuite() accepted an invalid execution boundary")
+			}
+		})
+	}
+}
+
+func TestRunSuiteEnforcesPerJobTimeout(t *testing.T) {
+	t.Parallel()
+	options := helperOptions(t, 1)
+	options.jobDuration = 50 * time.Millisecond
+	var summary bytes.Buffer
+	started := time.Now()
+	err := runSuite(context.Background(), repositoryFixture(t), []job{
+		helperJob("block", "test:workstation:block"),
+	}, options, &summary)
+	if err == nil || !strings.Contains(summary.String(), "exceeded 50ms timeout") {
+		t.Fatalf("runSuite() error/summary = %v/%q, want timeout failure", err, summary.String())
+	}
+	if elapsed := time.Since(started); elapsed > 2*time.Second {
+		t.Fatalf("timed-out command returned after %s", elapsed)
+	}
+}
+
+func TestRunSuiteCancelsInflightAndUnscheduledJobs(t *testing.T) {
+	t.Parallel()
+	options := helperOptions(t, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	time.AfterFunc(50*time.Millisecond, cancel)
+	var summary bytes.Buffer
+	err := runSuite(ctx, repositoryFixture(t), []job{
+		helperJob("block", "test:workstation:block"),
+		helperJob("later", "test:workstation:later"),
+	}, options, &summary)
+	if err == nil || strings.Count(summary.String(), "CANCELLED ") != 2 {
+		t.Fatalf("runSuite() error/summary = %v/%q, want two cancellations", err, summary.String())
+	}
+}
+
+func TestRunSuiteCancellationTerminatesTheDescendantProcessTree(t *testing.T) {
+	root := repositoryFixture(t)
+	options := helperOptions(t, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var summary bytes.Buffer
+	done := make(chan error, 1)
+	go func() {
+		done <- runSuite(ctx, root, []job{
+			helperJob("tree", "test:workstation:tree"),
+		}, options, &summary)
+	}()
+	waitForPath(t, filepath.Join(root, "grandchild.ready"))
+	cancel()
+	select {
+	case err := <-done:
+		if err == nil || !strings.Contains(summary.String(), "CANCELLED tree") {
+			t.Fatalf("runSuite() error/summary = %v/%q, want tree cancellation", err, summary.String())
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("process-tree cancellation did not return")
+	}
+	time.Sleep(800 * time.Millisecond)
+	if _, err := os.Lstat(filepath.Join(root, "grandchild.survived")); !os.IsNotExist(err) {
+		t.Fatalf("cancelled descendant survived: %v", err)
+	}
+}
+
+func TestRunSuiteCleansDescendantsAfterTheirParentExitsFirst(t *testing.T) {
+	root := repositoryFixture(t)
+	options := helperOptions(t, 1)
+	options.waitDelay = 100 * time.Millisecond
+	var summary bytes.Buffer
+	err := runSuite(t.Context(), root, []job{
+		helperJob("orphan", "test:workstation:orphan"),
+	}, options, &summary)
+	if err == nil || !strings.Contains(summary.String(), "FAIL orphan") {
+		t.Fatalf("runSuite() error/summary = %v/%q, want leaked-pipe failure", err, summary.String())
+	}
+	time.Sleep(2200 * time.Millisecond)
+	if _, err := os.Lstat(filepath.Join(root, "grandchild.survived")); !os.IsNotExist(err) {
+		t.Fatalf("parent-exit descendant survived cleanup: %v", err)
+	}
+}
+
+func TestRunSuiteBoundsCombinedOutputAndFailsTheJob(t *testing.T) {
+	t.Parallel()
+	options := helperOptions(t, 1)
+	options.outputBytes = 128
+	jobs := []job{helperJob("overflow", "test:workstation:overflow")}
+	results := executeJobs(context.Background(), repositoryFixture(t), jobs, options)
+	if len(results) != 1 || results[0].status != statusFailed || !results[0].exceeded {
+		t.Fatalf("executeJobs() = %#v, want output-limit failure", results)
+	}
+	if len(results[0].output) != options.outputBytes || !strings.Contains(results[0].detail, "exceeded 128 bytes") {
+		t.Fatalf("bounded output = %d bytes / %q", len(results[0].output), results[0].detail)
+	}
+}
+
+func TestRunSuiteFiltersAmbientEnvironmentBeforeExecution(t *testing.T) {
+	t.Parallel()
+	options := helperOptions(t, 1)
+	options.environment = append(options.environment,
+		"WORKSTATION_RUNNER_SECRET=do-not-pass",
+		"NODE_OPTIONS=--import=/tmp/hostile.mjs",
+	)
+	var summary bytes.Buffer
+	err := runSuite(context.Background(), repositoryFixture(t), []job{
+		helperJob("environment", "test:workstation:environment"),
+	}, options, &summary)
+	if err == nil {
+		t.Fatal("environment helper unexpectedly passed")
+	}
+	if strings.Contains(summary.String(), "do-not-pass") || strings.Contains(summary.String(), "hostile.mjs") {
+		t.Fatalf("filtered secrets reached the child: %q", summary.String())
+	}
+	if !strings.Contains(summary.String(), `secret="" node_options="" path="`) {
+		t.Fatalf("environment helper did not report the closed environment: %q", summary.String())
+	}
+}
+
+func TestFilteredEnvironmentIsClosedBoundedAndSorted(t *testing.T) {
+	t.Parallel()
+	filtered, err := filteredEnvironment([]string{
+		"=C:=C:\\workspace",
+		"WORKSTATION_RUNNER_SECRET=do-not-pass",
+		"TZ=Europe/Berlin",
+		"PATH=/usr/bin",
+		"HOME=/tmp/home",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"HOME=/tmp/home", "PATH=/usr/bin", "TZ=Europe/Berlin"}
+	if !reflect.DeepEqual(filtered, want) {
+		t.Fatalf("filteredEnvironment() = %q, want %q", filtered, want)
+	}
+	if !slices.IsSorted(filtered) {
+		t.Fatalf("filtered environment is not sorted: %q", filtered)
+	}
+
+	for name, environment := range map[string][]string{
+		"missing path": {"HOME=/tmp"},
+		"duplicate":    {"PATH=/usr/bin", "Path=/bin"},
+		"oversized":    {"PATH=/usr/bin", "HOME=" + strings.Repeat("x", maximumEnvironmentValueBytes+1)},
+		"nul":          {"PATH=/usr/bin\x00hostile"},
+		"oversized total": {
+			"PATH=/usr/bin",
+			"HOME=" + strings.Repeat("x", maximumEnvironmentValueBytes),
+			"TEMP=" + strings.Repeat("x", maximumEnvironmentValueBytes),
+			"TMP=" + strings.Repeat("x", maximumEnvironmentValueBytes),
+			"TMPDIR=" + strings.Repeat("x", maximumEnvironmentValueBytes),
+			"APPDATA=" + strings.Repeat("x", maximumEnvironmentValueBytes),
+			"LOCALAPPDATA=" + strings.Repeat("x", maximumEnvironmentValueBytes),
+			"USERPROFILE=" + strings.Repeat("x", maximumEnvironmentValueBytes),
+			"XDG_CACHE_HOME=" + strings.Repeat("x", maximumEnvironmentValueBytes),
+		},
+		"malformed": {"PATH=/usr/bin", "BROKEN"},
+	} {
+		name, environment := name, environment
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := filteredEnvironment(environment); err == nil {
+				t.Fatalf("filteredEnvironment(%q) succeeded", environment)
+			}
+		})
+	}
+}
+
+func TestResolveRepositoryRootRejectsPackageAndPathSymlinks(t *testing.T) {
+	t.Parallel()
+	realRoot := repositoryFixture(t)
+	packagePath := filepath.Join(realRoot, "package.json")
+	if err := os.Remove(packagePath); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join("nested", "package.json"), packagePath); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := resolveRepositoryRoot(realRoot); err == nil {
+		t.Fatal("resolveRepositoryRoot() accepted a package.json symlink")
+	}
+
+	parent := t.TempDir()
+	linkedRoot := filepath.Join(parent, "repository")
+	if err := os.Symlink(realRoot, linkedRoot); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := resolveRepositoryRoot(linkedRoot); err == nil || !strings.Contains(err.Error(), "must not traverse symlinks") {
+		t.Fatalf("resolveRepositoryRoot() error = %v, want root-symlink rejection", err)
+	}
+}
+
+func TestRunSuiteReturnsSummaryWriterFailure(t *testing.T) {
+	t.Parallel()
+	err := runSuite(context.Background(), repositoryFixture(t), []job{
+		helperJob("pass", "test:workstation:pass"),
+	}, helperOptions(t, 1), failingWriter{})
+	if err == nil || !strings.Contains(err.Error(), "write workstation") {
+		t.Fatalf("runSuite() error = %v, want writer failure", err)
+	}
+}
+
+type failingWriter struct{}
+
+func (failingWriter) Write([]byte) (int, error) {
+	return 0, errors.New("closed")
+}
+
+func makeUniqueJobs(count int) []job {
+	jobs := make([]job, count)
+	for index := range count {
+		jobs[index] = job{
+			artifact:  fmt.Sprintf("job-%d", index),
+			script:    fmt.Sprintf("test:workstation:job-%d", index),
+			arguments: []string{"run", fmt.Sprintf("test:workstation:job-%d", index)},
+		}
+	}
+	return jobs
+}
+
+func helperJob(artifact, script string) job {
+	return job{artifact: artifact, script: script, arguments: []string{"run", script}}
+}
+
+func withJobDuration(options runOptions, duration time.Duration) runOptions {
+	options.jobDuration = duration
+	return options
+}
+
+func withOutputBytes(options runOptions, outputBytes int) runOptions {
+	options.outputBytes = outputBytes
+	return options
+}
+
+func helperOptions(t *testing.T, concurrency int) runOptions {
+	t.Helper()
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return runOptions{
+		concurrency: concurrency,
+		jobDuration: 5 * time.Second,
+		outputBytes: 16 << 10,
+		waitDelay:   100 * time.Millisecond,
+		executable:  executable,
+		environment: []string{"PATH=" + os.Getenv("PATH")},
+	}
+}
+
+func repositoryFixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "package.json"), []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func waitForMarkerCount(t *testing.T, root string, want int) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if markerCount(t, root) == want {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("did not observe %d concurrent command markers", want)
+}
+
+func waitForPath(t *testing.T, path string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Lstat(path); err == nil {
+			return
+		} else if !os.IsNotExist(err) {
+			t.Fatal(err)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("did not observe %s", path)
+}
+
+func markerCount(t *testing.T, root string) int {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(root, "*.ready"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return len(matches)
+}


### PR DESCRIPTION
## Outcome

- moves the complete local workstation aggregate behind one embedded Go catalogue;
- runs core plus all 19 unchanged artifact scripts with at most eight active process trees;
- projects the same `{artifact, script}` catalogue into CI, removing the duplicated 19-arm shell dispatch;
- freezes direct Node argument vectors before concurrency, filters ambient environment state, and bounds each job to 30 minutes and 2 MiB of combined output;
- kills descendant process trees on cancellation and after parent exit on Unix and Windows;
- proves every discovered workstation test and every manifest `full_tests` entry is scheduled exactly once.

The final integrated local aggregate completed 20/20 jobs with zero failures or cancellations in about 2m54s. The former serial aggregate took roughly 21 minutes on the same development path. This is implementation feedback evidence only: test assertions, seeds, horizons, claim authority, and `NO_RESULT` remain unchanged, and the live full-gate GitHub timing criterion stays open.

## Verification

- `go -C tooling test -race ./internal/ciplan ./internal/workstationrunner ./cmd/20w`
- `go -C tooling vet ./internal/ciplan ./internal/workstationrunner ./cmd/20w`
- Windows amd64 CLI plus Darwin and FreeBSD runner cross-compiles
- engineering policy 69/69; code-shape 8/8; prose 8/8
- complete local workstation aggregate: 20 passed, 0 failed, 0 cancelled
- full repository gate, resumed after correcting one Markdown math-delimiter ambiguity: all affected and remaining gates green
- PDF renderer produced byte-identical output twice; PDF SHA-256 remains `e94ca0c9bc668f90cea769a3e67e8662d0ca674a6254bf74f9ee42f1ef20b548`
- `npm run validate:book-pdf`: 173 source files
- production Pages build validation: 383 files

## Review and disclosure

Codex implemented and reviewed the slice. A separate Codex agent performed a read-only adversarial review and found four process/inventory defects that were fixed before the final PASS. The local Qwen3.8-27B model was used only as an additional bounded reviewer; repository tests, source inspection, and GitHub remain authoritative.

Tracks #7
