### PR TITLE
feat(site): move corpus navigation into drawer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -254,6 +254,9 @@ the exact diff; this file records why the project changed.
   because the React and JSX accessibility plugins do not yet declare ESLint 10
   support. The exact package graphs and source-bound book provenance are
   regenerated without changing experiment or result status.
+- The document reader now keeps only its section outline beside the article.
+  Corpus search, filters, current-document context and native document links
+  move into a keyboard-operable drawer that returns focus when it closes.
 - A failed two-builder PDF reproducibility check now retains both exact PDF and
   manifest pairs beside its comparison receipt. CI uploads the bounded mismatch
   bundle for 30 days, so a rare renderer disagreement can be byte-diffed without

--- a/app/components/public-research-portal.tsx
+++ b/app/components/public-research-portal.tsx
@@ -24,6 +24,7 @@ import {
   portalDocumentPathFromLocation,
   portalDocuments,
   portalMetrics,
+  type PortalDocumentMetadata,
 } from "../portal-content";
 
 const MarkdownDocument = lazy(() => import("./markdown-document").then(
@@ -189,6 +190,26 @@ function isSectionHeadingMatch(
     .includes(normalizedQuery);
 }
 
+function revealFocusedElement(
+  scroller: HTMLElement | null,
+  target: HTMLElement,
+) {
+  if (!scroller || !target.isConnected) return;
+  const style = window.getComputedStyle(target);
+  const outlineWidth = Number.parseFloat(style.outlineWidth) || 0;
+  const outlineOffset = Math.max(Number.parseFloat(style.outlineOffset) || 0, 0);
+  const clearance = outlineWidth + outlineOffset + 1;
+  const scrollerRect = scroller.getBoundingClientRect();
+  const targetRect = target.getBoundingClientRect();
+  const topDelta = targetRect.top - clearance - scrollerRect.top;
+  if (topDelta < 0) {
+    scroller.scrollTop += topDelta;
+    return;
+  }
+  const bottomDelta = targetRect.bottom + clearance - scrollerRect.bottom;
+  if (bottomDelta > 0) scroller.scrollTop += bottomDelta;
+}
+
 function usePortalSeo(metadata: Parameters<typeof synchronizePortalSeo>[0]) {
   useEffect(() => synchronizePortalSeo(metadata), [metadata]);
 }
@@ -307,6 +328,222 @@ function ResearchStatus({
   );
 }
 
+type CorpusDrawerProps = {
+  assetBasePath: string;
+  documents: PortalDocumentMetadata[];
+  group: LibraryGroup;
+  normalizedQuery: string;
+  onGroupChange: (group: LibraryGroup) => void;
+  onNavigate: (path: string) => void;
+  onQueryChange: (query: string) => void;
+  query: string;
+  selectedDocument: PortalDocumentMetadata;
+};
+
+function CorpusLibrary({
+  assetBasePath,
+  documents,
+  group,
+  libraryRef,
+  normalizedQuery,
+  onGroupChange,
+  onNavigate,
+  onQueryChange,
+  query,
+  searchRef,
+  selectedDocument,
+}: Omit<CorpusDrawerProps, "onNavigate"> & {
+  libraryRef: ElementRef<HTMLElement>;
+  onNavigate: (event: MouseEvent<HTMLAnchorElement>, path: string) => void;
+  searchRef: ElementRef<HTMLInputElement>;
+}) {
+  return (
+    <section
+      aria-label="Document library"
+      className="portal-library"
+      ref={libraryRef}
+    >
+      <label htmlFor="portal-library-search">Find another document</label>
+      <div className="portal-search-control">
+        <span aria-hidden="true">⌕</span>
+        <input
+          aria-controls="portal-corpus-results"
+          id="portal-library-search"
+          onChange={(event) => onQueryChange(event.target.value)}
+          placeholder="routing, memory, energy…"
+          ref={searchRef}
+          type="search"
+          value={query}
+        />
+      </div>
+      <div className="portal-filter-tabs" role="group" aria-label="Document group">
+        {libraryGroups.map((candidate) => (
+          <button
+            type="button"
+            key={candidate}
+            aria-pressed={group === candidate}
+            onClick={() => onGroupChange(candidate)}
+          >{candidate}</button>
+        ))}
+      </div>
+      <p className="portal-result-count" aria-live="polite">
+        {documents.length} matching document{documents.length === 1 ? "" : "s"}
+        {!documents.some((document) => document.path === selectedDocument.path) ? (
+          <span className="portal-filter-context">
+            Current document is outside this filter.
+          </span>
+        ) : null}
+      </p>
+      <nav
+        className="portal-document-list"
+        id="portal-corpus-results"
+        aria-label="Research documents"
+      >
+        {documents.map((document) => (
+          <a
+            href={portalDocumentLocation(document.path, assetBasePath)}
+            key={document.path}
+            aria-current={document.path === selectedDocument.path ? "page" : undefined}
+            onClick={(event) => onNavigate(event, document.path)}
+            onFocus={(event) => {
+              const target = event.currentTarget;
+              window.requestAnimationFrame(() => {
+                revealFocusedElement(libraryRef.current, target);
+              });
+            }}
+          >
+            <span>{document.title}</span>
+            <small>
+              {documentSequence(document.path, document.group)} · {formatNumber(document.words)} words
+              {isSectionHeadingMatch(document, normalizedQuery)
+                ? " · section heading match"
+                : ""}
+            </small>
+          </a>
+        ))}
+        {documents.length === 0 ? (
+          <p className="portal-empty-state">
+            No matching title, file path or section heading.
+          </p>
+        ) : null}
+      </nav>
+    </section>
+  );
+}
+
+function CorpusDrawer({
+  assetBasePath,
+  documents,
+  group,
+  normalizedQuery,
+  onGroupChange,
+  onNavigate,
+  onQueryChange,
+  query,
+  selectedDocument,
+}: CorpusDrawerProps) {
+  const [open, setOpen] = useState(false);
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const invokerRef = useRef<HTMLButtonElement>(null);
+  const libraryRef = useRef<HTMLElement>(null);
+  const restoreInvokerFocus = useRef(true);
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!open || !dialog || dialog.open) return;
+    dialog.showModal();
+    const frame = window.requestAnimationFrame(() => searchRef.current?.focus());
+    return () => window.cancelAnimationFrame(frame);
+  }, [open]);
+
+  const closeDrawer = (restoreFocus = true) => {
+    restoreInvokerFocus.current = restoreFocus;
+    const dialog = dialogRef.current;
+    if (dialog?.open) dialog.close();
+    else setOpen(false);
+  };
+
+  const navigateToDocument = (
+    event: MouseEvent<HTMLAnchorElement>,
+    path: string,
+  ) => {
+    if (!shouldHandleClientNavigation(event)) return;
+    event.preventDefault();
+    closeDrawer(false);
+    onNavigate(path);
+  };
+
+  return (
+    <>
+      <button
+        aria-controls="portal-corpus-drawer"
+        aria-expanded={open}
+        aria-haspopup="dialog"
+        className="portal-reader-browse"
+        id="portal-corpus-trigger"
+        onClick={() => {
+          restoreInvokerFocus.current = true;
+          setOpen(true);
+        }}
+        ref={invokerRef}
+        type="button"
+      >Browse documents</button>
+      <dialog
+        aria-labelledby="portal-corpus-title"
+        className="portal-corpus-drawer"
+        id="portal-corpus-drawer"
+        onCancel={() => { restoreInvokerFocus.current = true; }}
+        onClose={() => {
+          setOpen(false);
+          if (!restoreInvokerFocus.current) {
+            restoreInvokerFocus.current = true;
+            return;
+          }
+          window.requestAnimationFrame(() => invokerRef.current?.focus());
+        }}
+        onKeyDown={(event) => {
+          const search = searchRef.current;
+          if (
+            event.key !== "Escape"
+            || event.target !== search
+            || !search.value
+          ) return;
+          event.preventDefault();
+          closeDrawer();
+        }}
+        ref={dialogRef}
+      >
+        <header className="portal-corpus-header">
+          <div>
+            <p>Research library</p>
+            <h2 id="portal-corpus-title">Browse documents</h2>
+          </div>
+          <button type="button" onClick={() => closeDrawer()}>Close</button>
+        </header>
+        <p className="portal-corpus-current">
+          <span>Currently reading</span>
+          <strong>{selectedDocument.title}</strong>
+          <code>{selectedDocument.path}</code>
+        </p>
+        <CorpusLibrary
+          assetBasePath={assetBasePath}
+          documents={documents}
+          group={group}
+          libraryRef={libraryRef}
+          normalizedQuery={normalizedQuery}
+          onGroupChange={onGroupChange}
+          onNavigate={navigateToDocument}
+          onQueryChange={onQueryChange}
+          query={query}
+          searchRef={searchRef}
+          selectedDocument={selectedDocument}
+        />
+      </dialog>
+    </>
+  );
+}
+
 export function PublicResearchPortal({
   assetBasePath,
 }: {
@@ -329,7 +566,6 @@ export function PublicResearchPortal({
   const overviewRef = useRef<HTMLElement>(null);
   const readerTitleRef = useRef<HTMLHeadingElement>(null);
   const readerPageRef = useRef<HTMLElement>(null);
-  const readerLibraryRef = useRef<HTMLElement>(null);
   const mobileMenuRef = useRef<HTMLDetailsElement>(null);
   const mobileOutlineRef = useRef<HTMLDetailsElement>(null);
   const documentCache = useRef(new Map<string, ResearchDocument>());
@@ -385,18 +621,6 @@ export function PublicResearchPortal({
     && selectedDocumentIndex < portalDocuments.length - 1
     ? portalDocuments[selectedDocumentIndex + 1]
     : null;
-  const readerLibraryDocuments = useMemo(() => {
-    if (libraryDocuments.length <= 15) return libraryDocuments;
-    const activeIndex = selectedPath
-      ? libraryDocuments.findIndex((document) => document.path === selectedPath)
-      : 0;
-    const start = Math.max(0, Math.min(
-      activeIndex < 0 ? 0 : activeIndex - 7,
-      libraryDocuments.length - 15,
-    ));
-    return libraryDocuments.slice(start, start + 15);
-  }, [libraryDocuments, selectedPath]);
-
   const conceptCount = portalDocuments.filter(
     (document) => document.group === "Concept",
   ).length;
@@ -457,22 +681,6 @@ export function PublicResearchPortal({
     selectedPath,
   });
 
-  useEffect(() => {
-    if (!selectedPath) return;
-    const frame = window.requestAnimationFrame(() => {
-      const list = readerLibraryRef.current;
-      const active = list?.querySelector<HTMLElement>('[aria-current="page"]');
-      if (!list || !active) return;
-      const listRect = list.getBoundingClientRect();
-      const activeRect = active.getBoundingClientRect();
-      if (activeRect.top >= listRect.top && activeRect.bottom <= listRect.bottom) return;
-      list.scrollTop += activeRect.top
-        - listRect.top
-        - ((listRect.height - activeRect.height) / 2);
-    });
-    return () => window.cancelAnimationFrame(frame);
-  }, [readerLibraryDocuments, selectedPath]);
-
   const selectDocument = (path: string, hash = "") => {
     if (!documentsByPath.has(path)) {
       window.open(
@@ -497,16 +705,6 @@ export function PublicResearchPortal({
   const selectGroup = (candidate: LibraryGroup) => {
     setGroup(candidate);
     setCatalogLimit(catalogPageSize);
-    if (
-      selectedPath
-      && candidate !== "All"
-      && selectedMetadata?.group !== candidate
-    ) {
-      const firstDocument = portalDocuments.find(
-        (document) => document.group === candidate,
-      );
-      if (firstDocument) selectDocument(firstDocument.path);
-    }
   };
 
   const showOverview = (hash = "") => {
@@ -682,15 +880,31 @@ export function PublicResearchPortal({
             className="portal-reader-toolbar"
             aria-labelledby="portal-reader-title"
           >
-            <a
-              className="portal-reader-back"
-              href={overviewLocation(assetBasePath, "library")}
-              onClick={(event) => {
-                handleClientNavigation(event, () => showOverview("library"));
-              }}
-            >
-              <span aria-hidden="true">←</span> Research overview
-            </a>
+            <div className="portal-reader-context">
+              <a
+                className="portal-reader-back"
+                href={overviewLocation(assetBasePath, "library")}
+                onClick={(event) => {
+                  handleClientNavigation(event, () => showOverview("library"));
+                }}
+              >
+                <span aria-hidden="true">←</span> Research overview
+              </a>
+              <CorpusDrawer
+                assetBasePath={assetBasePath}
+                documents={libraryDocuments}
+                group={group}
+                normalizedQuery={deferredQuery}
+                onGroupChange={selectGroup}
+                onNavigate={selectDocument}
+                onQueryChange={(value) => {
+                  setQuery(value);
+                  setCatalogLimit(catalogPageSize);
+                }}
+                query={query}
+                selectedDocument={selectedMetadata}
+              />
+            </div>
             <div className="portal-reader-toolbar-copy">
               <p>{selectedMetadata.group} · {formatNumber(selectedMetadata.words)} words</p>
               <h1 id="portal-reader-title" ref={readerTitleRef} tabIndex={-1}>
@@ -771,75 +985,6 @@ export function PublicResearchPortal({
               </details>
             ) : null}
             <div className="portal-reader-grid">
-              <aside className="portal-library" aria-label="Document library">
-                <label htmlFor="portal-library-search">Find another document</label>
-                <div className="portal-search-control">
-                  <span aria-hidden="true">⌕</span>
-                  <input
-                    id="portal-library-search"
-                    type="search"
-                    value={query}
-                    onChange={(event) => {
-                      setQuery(event.target.value);
-                      setCatalogLimit(catalogPageSize);
-                    }}
-                    placeholder="routing, memory, energy…"
-                  />
-                </div>
-                <div className="portal-filter-tabs" role="group" aria-label="Document group">
-                  {libraryGroups.map((candidate) => (
-                    <button
-                      type="button"
-                      key={candidate}
-                      aria-pressed={group === candidate}
-                      onClick={() => selectGroup(candidate)}
-                    >{candidate}</button>
-                  ))}
-                </div>
-                <p className="portal-result-count" aria-live="polite">
-                  Showing {readerLibraryDocuments.length} of {libraryDocuments.length} matching documents
-                  {!libraryDocuments.some(
-                    (document) => document.path === selectedMetadata.path,
-                  ) ? (
-                    <span className="portal-filter-context">
-                      Current document is outside this filter.
-                    </span>
-                  ) : null}
-                </p>
-                <nav
-                  className="portal-document-list"
-                  ref={readerLibraryRef}
-                  aria-label="Research documents"
-                >
-                  {readerLibraryDocuments.map((document) => (
-                    <a
-                      href={portalDocumentLocation(document.path, assetBasePath)}
-                      key={document.path}
-                      aria-current={document.path === selectedMetadata.path ? "page" : undefined}
-                      onClick={(event) => {
-                        handleClientNavigation(
-                          event,
-                          () => selectDocument(document.path),
-                        );
-                      }}
-                    >
-                      <span>{document.title}</span>
-                      <small>
-                        {documentSequence(document.path, document.group)} · {formatNumber(document.words)} words
-                        {isSectionHeadingMatch(document, deferredQuery)
-                          ? " · section heading match"
-                          : ""}
-                      </small>
-                    </a>
-                  ))}
-                  {libraryDocuments.length === 0 ? (
-                    <p className="portal-empty-state">
-                      No matching title, file path or section heading.
-                    </p>
-                  ) : null}
-                </nav>
-              </aside>
-
               <article
                 className="portal-reader"
                 id="portal-reader"

--- a/app/globals.css
+++ b/app/globals.css
@@ -3638,6 +3638,10 @@ button {
 
   /* Focused research reader: one publication layout owns every viewport. */
 
+  html:has(.portal-corpus-drawer[open]) {
+    overflow: hidden;
+  }
+
   .portal-reader-page {
     min-height: calc(100dvh - 62px);
     scroll-margin-top: 62px;
@@ -3648,7 +3652,7 @@ button {
     position: static;
     display: grid;
     width: min(calc(100% - 40px), 1260px);
-    grid-template-columns: 140px minmax(240px, 1fr) auto auto;
+    grid-template-columns: 155px minmax(240px, 1fr) auto auto;
     align-items: center;
     gap: 20px;
     min-height: 0;
@@ -3660,11 +3664,35 @@ button {
   }
 
   .portal-reader-back,
-  .portal-reader-toolbar nav a {
+  .portal-reader-toolbar > nav a {
     color: #17633f;
     font-size: 12px;
     font-weight: 750;
     text-decoration: none;
+  }
+
+  .portal-reader-context {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    flex-direction: column;
+  }
+
+  .portal-reader-browse {
+    min-height: 44px;
+    padding: 0 12px;
+    border: 1px solid #397153;
+    background: #e2ebe3;
+    color: #174e31;
+    cursor: pointer;
+    font: inherit;
+    font-size: 12px;
+    font-weight: 800;
+  }
+
+  .portal-reader-browse:hover {
+    border-color: #174e31;
+    background: #d3e3d7;
   }
 
   .portal-reader-toolbar-copy p {
@@ -3685,7 +3713,7 @@ button {
     line-height: 1.08;
   }
 
-  .portal-reader-toolbar nav {
+  .portal-reader-toolbar > nav {
     display: flex;
     gap: 14px;
   }
@@ -3716,8 +3744,8 @@ button {
 
   .portal-reader-grid {
     display: grid;
-    width: min(100%, 1400px);
-    grid-template-columns: 235px minmax(0, 900px) 195px;
+    width: min(100%, 1120px);
+    grid-template-columns: minmax(0, 900px) 195px;
     align-items: start;
     justify-content: center;
     gap: 24px;
@@ -3726,13 +3754,106 @@ button {
     background: transparent;
   }
 
-  .portal-library {
-    position: sticky;
-    top: 82px;
-    display: flex;
-    max-height: calc(100dvh - 102px);
+  .portal-corpus-drawer {
+    position: fixed;
+    inset: 0 0 0 auto;
+    width: min(440px, 100%);
+    height: 100dvh;
+    max-width: none;
+    max-height: none;
+    margin: 0;
+    padding: 0;
     overflow: hidden;
-    padding: 0 0 18px;
+    border: 0;
+    border-left: 1px solid #82978a;
+    background: #f4f1e7;
+    color: #203128;
+    font-family: var(--font-sans);
+    box-shadow: -18px 0 46px rgb(7 20 15 / 28%);
+  }
+
+  .portal-corpus-drawer[open] {
+    display: grid;
+    grid-template-rows: auto auto minmax(0, 1fr);
+  }
+
+  .portal-corpus-drawer::backdrop {
+    background: rgb(7 20 15 / 48%);
+  }
+
+  .portal-corpus-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 20px;
+    padding: 22px 24px;
+    border-bottom: 1px solid #aebbb2;
+  }
+
+  .portal-corpus-header p,
+  .portal-corpus-current > span {
+    display: block;
+    margin: 0;
+    color: #53675a;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    font-weight: 850;
+    letter-spacing: 0.09em;
+    text-transform: uppercase;
+  }
+
+  .portal-corpus-header h2 {
+    margin: 4px 0 0;
+    font-family: var(--font-serif);
+    font-size: 30px;
+    font-weight: 540;
+    line-height: 1.1;
+  }
+
+  .portal-corpus-header button {
+    min-width: 68px;
+    min-height: 44px;
+    padding: 0 12px;
+    border: 1px solid #397153;
+    background: transparent;
+    color: #174e31;
+    cursor: pointer;
+    font: inherit;
+    font-size: 12px;
+    font-weight: 800;
+  }
+
+  .portal-corpus-header button:hover {
+    background: #dce9df;
+  }
+
+  .portal-corpus-current {
+    display: grid;
+    gap: 4px;
+    margin: 0;
+    padding: 16px 24px;
+    border-bottom: 1px solid #c4d0c7;
+    background: #e8ede6;
+  }
+
+  .portal-corpus-current strong {
+    color: #173624;
+    font-size: 14px;
+    line-height: 1.35;
+  }
+
+  .portal-corpus-current code {
+    overflow-wrap: anywhere;
+    color: #5a6c61;
+    font-size: 11px;
+  }
+
+  .portal-library {
+    display: flex;
+    min-height: 0;
+    overflow: hidden auto;
+    overscroll-behavior-y: contain;
+    padding: 20px 24px 24px;
     border: 0;
     background: transparent;
     color: #203128;
@@ -3798,11 +3919,11 @@ button {
   }
 
   .portal-library .portal-document-list {
-    flex: 1;
+    flex: 0 0 auto;
     min-height: 0;
     max-height: none;
-    overflow-y: auto;
-    margin: 8px 0 0;
+    overflow: visible;
+    margin: 8px -8px 0;
     padding: 0;
     scrollbar-color: #8aa092 transparent;
     scrollbar-width: thin;
@@ -3811,7 +3932,7 @@ button {
   .portal-library .portal-document-list a {
     display: block;
     width: 100%;
-    padding: 11px 9px;
+    padding: 11px 10px;
     border: 0;
     border-left: 2px solid transparent;
     background: transparent;
@@ -4072,7 +4193,8 @@ button {
 
 @media screen and (max-width: 1180px) {
   .portal-reader-grid {
-    grid-template-columns: 270px minmax(0, 1fr);
+    width: min(100%, 900px);
+    grid-template-columns: minmax(0, 900px);
   }
 
   .portal-outline {
@@ -4149,12 +4271,8 @@ button {
     border-left: 0;
   }
 
-  .portal-reader-grid {
-    grid-template-columns: 225px minmax(0, 820px);
-  }
-
   .portal-reader-toolbar {
-    grid-template-columns: 140px minmax(240px, 1fr) auto;
+    grid-template-columns: 155px minmax(240px, 1fr) auto;
     row-gap: 12px;
   }
 
@@ -4191,7 +4309,7 @@ button {
     grid-row: 1;
   }
 
-  .portal-reader-back {
+  .portal-reader-context {
     grid-column: 1;
     grid-row: 2;
   }
@@ -4209,14 +4327,6 @@ button {
 
   .portal-reader-workspace {
     padding-top: 22px;
-  }
-
-  .portal-reader-grid {
-    grid-template-columns: minmax(0, 820px);
-  }
-
-  .portal-reader-page .portal-library {
-    display: none;
   }
 
   .portal-mobile-outline {
@@ -4388,7 +4498,7 @@ button {
     padding: 22px 0 18px;
   }
 
-  .portal-reader-toolbar nav {
+  .portal-reader-toolbar > nav {
     flex-wrap: wrap;
   }
 
@@ -4402,6 +4512,18 @@ button {
 }
 
 @media screen and (max-width: 460px) {
+  .portal-corpus-header {
+    padding: 18px 16px;
+  }
+
+  .portal-corpus-current {
+    padding: 14px 16px;
+  }
+
+  .portal-library {
+    padding: 18px 16px 20px;
+  }
+
   .portal-header {
     gap: 10px;
     padding-inline: 14px;

--- a/app/globals.css
+++ b/app/globals.css
@@ -2963,6 +2963,7 @@ button {
 /* Research-publication pass: manuscript first, evidence chrome second. */
 @media screen {
   .portal-shell {
+    --portal-sticky-header-height: 62px;
     --portal-night: #10271b;
     --portal-night-raised: #183426;
     --portal-ink: #18271f;
@@ -2975,7 +2976,7 @@ button {
   }
 
   .portal-header {
-    min-height: 62px;
+    min-height: var(--portal-sticky-header-height);
     gap: 24px;
     padding-inline: max(20px, calc((100vw - 1260px) / 2));
     border-bottom: 1px solid #355243;
@@ -3643,8 +3644,8 @@ button {
   }
 
   .portal-reader-page {
-    min-height: calc(100dvh - 62px);
-    scroll-margin-top: 62px;
+    min-height: calc(100dvh - var(--portal-sticky-header-height));
+    scroll-margin-top: var(--portal-sticky-header-height);
     background: #f1f1eb;
   }
 
@@ -4090,10 +4091,11 @@ button {
     text-transform: none;
   }
 
+  #portal-reader-title,
   .portal-prose h2,
   .portal-prose h3,
   .portal-prose h4 {
-    scroll-margin-top: 78px;
+    scroll-margin-top: calc(var(--portal-sticky-header-height) + 16px);
   }
 
   .portal-prose :is(
@@ -4203,7 +4205,7 @@ button {
 
   .portal-mobile-outline {
     position: sticky;
-    top: 62px;
+    top: var(--portal-sticky-header-height);
     z-index: 32;
     display: block;
     width: min(100%, 1400px);

--- a/public/downloads/book-manifest.json
+++ b/public/downloads/book-manifest.json
@@ -4,7 +4,7 @@
   "version": "0.3.0",
   "source_ref": "main",
   "pdf": "public/downloads/20-watts-was-enough-full-concept-book.pdf",
-  "source_digest": "b8d3cd3021abec7bed966ff079549ed07c06d5a0f336e22a4fc4e2c7ebaf61b2",
+  "source_digest": "931591df306163ca75175cbf74673827b2b045bebcd8a75daf9a33f9d49c2c28",
   "source_files": [
     "app/book-content.ts",
     "app/components/book-edition.tsx",

--- a/public/downloads/book-manifest.json
+++ b/public/downloads/book-manifest.json
@@ -4,7 +4,7 @@
   "version": "0.3.0",
   "source_ref": "main",
   "pdf": "public/downloads/20-watts-was-enough-full-concept-book.pdf",
-  "source_digest": "931591df306163ca75175cbf74673827b2b045bebcd8a75daf9a33f9d49c2c28",
+  "source_digest": "e4e6e7d2d0d527ee816723d5d12145dca6e41f55fbb3daa59e2a5e489971fe58",
   "source_files": [
     "app/book-content.ts",
     "app/components/book-edition.tsx",

--- a/scripts/book-edition-surface.test.mjs
+++ b/scripts/book-edition-surface.test.mjs
@@ -269,12 +269,12 @@ test("portal utility text and card accents retain readable contrast", async () =
   assert.match(publicationPass, /\.portal-dashboard\s*\{[^}]*grid-template-columns:\s*minmax\(0, 650px\) minmax\(380px, 520px\)[^}]*background:\s*var\(--portal-cream\)/s);
   assert.match(publicationPass, /\.portal-status-outcome\s*\{[^}]*border-left:\s*3px solid #b37b1c[^}]*background:\s*transparent/s);
   assert.match(publicationPass, /\.portal-funnel\s*\{[^}]*grid-template-columns:\s*1fr[^}]*border:\s*0/s);
-  assert.match(publicationPass, /\.portal-reader-grid\s*\{[^}]*grid-template-columns:\s*235px minmax\(0, 900px\) 195px[^}]*border:\s*0/s);
+  assert.match(publicationPass, /\.portal-reader-grid\s*\{[^}]*grid-template-columns:\s*minmax\(0, 900px\) 195px[^}]*border:\s*0/s);
   assert.match(publicationPass, /\.portal-prose\s*\{[^}]*font-size:\s*18px[^}]*line-height:\s*1\.66/s);
   assert.match(publicationPass, /@media screen and \(max-width: 460px\)[\s\S]*\.portal-wordmark strong\s*\{[^}]*display:\s*block/s);
 });
 
-test("the focused reader has one publication owner and a non-clipping rail", async () => {
+test("the focused reader has one outline rail and a bounded corpus drawer", async () => {
   const [portalComponent, stylesheet] = await Promise.all([
     source("app/components/public-research-portal.tsx"),
     source("app/globals.css"),
@@ -291,6 +291,11 @@ test("the focused reader has one publication owner and a non-clipping rail", asy
     "portal-reader-toolbar",
     "portal-reader-workspace",
     "portal-reader-grid",
+    "portal-reader-context",
+    "portal-reader-browse",
+    "portal-corpus-drawer",
+    "portal-corpus-header",
+    "portal-corpus-current",
     "portal-library",
     "portal-document-list",
     "portal-reader",
@@ -320,9 +325,23 @@ test("the focused reader has one publication owner and a non-clipping rail", asy
   assert.match(reader, /\.portal-prose > :is\([^)]*\)\s*\{[^}]*max-width:\s*var\(--reading-measure\)/s);
   assert.match(reader, /\.portal-library \.portal-filter-tabs\s*\{[^}]*grid-template-columns:\s*repeat\(2, minmax\(0, 1fr\)\)/s);
   assert.match(reader, /\.portal-library \.portal-filter-tabs button:last-child\s*\{[^}]*grid-column:\s*1 \/ -1/s);
-  assert.match(reader, /@media screen and \(max-width: 1080px\)[\s\S]*\.portal-reader-grid\s*\{[^}]*grid-template-columns:\s*225px minmax\(0, 820px\)/s);
-  assert.match(reader, /@media screen and \(max-width: 880px\)[\s\S]*\.portal-reader-page \.portal-library\s*\{[^}]*display:\s*none/s);
+  assert.match(reader, /\.portal-reader-grid\s*\{[^}]*grid-template-columns:\s*minmax\(0, 900px\) 195px/s);
+  assert.match(reader, /\.portal-corpus-drawer\s*\{[^}]*position:\s*fixed;[^}]*width:\s*min\(440px, 100%\);[^}]*height:\s*100dvh/s);
+  assert.match(reader, /\.portal-corpus-drawer\[open\]\s*\{[^}]*display:\s*grid/s);
+  assert.match(reader, /\.portal-corpus-drawer::backdrop\s*\{[^}]*background:/s);
+  assert.match(reader, /\.portal-library\s*\{[^}]*overflow:\s*hidden auto/s);
+  assert.match(reader, /\.portal-library \.portal-document-list\s*\{[^}]*flex:\s*0 0 auto;[^}]*overflow:\s*visible/s);
+  assert.match(reader, /@media screen and \(max-width: 1180px\)[\s\S]*\.portal-reader-grid\s*\{[^}]*grid-template-columns:\s*minmax\(0, 900px\)/s);
+  assert.match(reader, /@media screen and \(max-width: 1180px\)[\s\S]*\.portal-outline\s*\{[^}]*display:\s*none/s);
+  assert.doesNotMatch(reader, /\.portal-reader-page \.portal-library\s*\{[^}]*display:\s*none/s);
   assert.match(reader, /\.portal-mobile-outline summary\s*\{[^}]*min-height:\s*44px/s);
   assert.match(reader, /\.portal-document-state\s*\{[^}]*font-size:\s*14px/s);
   assert.match(reader, /\.portal-document-state\[role="alert"\]\s*\{[^}]*border-left-color:\s*#a92d31/s);
+
+  assert.match(portalComponent, /aria-controls="portal-corpus-drawer"[\s\S]*aria-haspopup="dialog"/s);
+  assert.match(portalComponent, /<dialog[\s\S]*aria-labelledby="portal-corpus-title"/s);
+  assert.match(portalComponent, /dialog\.showModal\(\)/);
+  assert.match(portalComponent, /invokerRef\.current\?\.focus\(\)/);
+  assert.match(portalComponent, /<span>Currently reading<\/span>/);
+  assert.doesNotMatch(portalComponent, /<aside className="portal-library"/);
 });

--- a/scripts/book-pdf-semantic-baseline.json
+++ b/scripts/book-pdf-semantic-baseline.json
@@ -7,7 +7,7 @@
     "pdf": "public/downloads/20-watts-was-enough-full-concept-book.pdf",
     "manifest": "public/downloads/book-manifest.json",
     "pdf_sha256": "e94ca0c9bc668f90cea769a3e67e8662d0ca674a6254bf74f9ee42f1ef20b548",
-    "manifest_sha256": "20eb52d6ebb3fb20f4ee5bc9bdc194dbcf99711f7c19151b3028fedb3b08db56",
+    "manifest_sha256": "749873a85b65a72288832cb31ccdbc52206601781e8aa0e02c84f820a545bc45",
     "size_bytes": 12778591,
     "pages": 412,
     "page_size_name": "A4",
@@ -18,7 +18,7 @@
     "pdf_version": "1.4",
     "tagged": true,
     "source_ref": "main",
-    "source_digest": "b8d3cd3021abec7bed966ff079549ed07c06d5a0f336e22a4fc4e2c7ebaf61b2",
+    "source_digest": "931591df306163ca75175cbf74673827b2b045bebcd8a75daf9a33f9d49c2c28",
     "version": "0.3.0"
   },
   "tools": {

--- a/scripts/book-pdf-semantic-baseline.json
+++ b/scripts/book-pdf-semantic-baseline.json
@@ -7,7 +7,7 @@
     "pdf": "public/downloads/20-watts-was-enough-full-concept-book.pdf",
     "manifest": "public/downloads/book-manifest.json",
     "pdf_sha256": "e94ca0c9bc668f90cea769a3e67e8662d0ca674a6254bf74f9ee42f1ef20b548",
-    "manifest_sha256": "749873a85b65a72288832cb31ccdbc52206601781e8aa0e02c84f820a545bc45",
+    "manifest_sha256": "a66895b22b9250210544351348eedd7b244432158a80cb9b7c017c3d2a2e9357",
     "size_bytes": 12778591,
     "pages": 412,
     "page_size_name": "A4",
@@ -18,7 +18,7 @@
     "pdf_version": "1.4",
     "tagged": true,
     "source_ref": "main",
-    "source_digest": "931591df306163ca75175cbf74673827b2b045bebcd8a75daf9a33f9d49c2c28",
+    "source_digest": "e4e6e7d2d0d527ee816723d5d12145dca6e41f55fbb3daa59e2a5e489971fe58",
     "version": "0.3.0"
   },
   "tools": {

--- a/scripts/github-pages.test.mjs
+++ b/scripts/github-pages.test.mjs
@@ -97,6 +97,7 @@ async function waitForBrowserState(cdp, expression, accepts, label, timeoutMs = 
 const portalStateExpression = `(() => {
   const active = document.activeElement;
   const title = document.getElementById("portal-reader-title");
+  const header = document.querySelector(".portal-header");
   const drawer = document.getElementById("portal-corpus-drawer");
   const drawerScroller = drawer?.querySelector(".portal-library");
   const documentList = drawer?.querySelector(".portal-document-list");
@@ -108,6 +109,8 @@ const portalStateExpression = `(() => {
   const hashBounds = hashTarget?.getBoundingClientRect();
   const documentLinks = [...document.querySelectorAll(".portal-document-list > a")];
   const activeBounds = active?.getBoundingClientRect();
+  const headerBounds = header?.getBoundingClientRect();
+  const titleBounds = title?.getBoundingClientRect();
   const drawerScrollerBounds = drawerScroller?.getBoundingClientRect();
   const activeStyle = active ? getComputedStyle(active) : null;
   const focusPaintExtent = activeStyle
@@ -138,6 +141,7 @@ const portalStateExpression = `(() => {
     hash: location.hash,
     hashTargetTop: hashBounds?.top ?? null,
     hashTargetVisible: Boolean(hashBounds && hashBounds.bottom > 0 && hashBounds.top < innerHeight),
+    headerBottom: headerBounds?.bottom ?? null,
     pathname: location.pathname,
     pageClientWidth: document.documentElement.clientWidth,
     pageScrollWidth: document.documentElement.scrollWidth,
@@ -148,6 +152,10 @@ const portalStateExpression = `(() => {
     triggerExpanded: document.getElementById("portal-corpus-trigger")?.getAttribute("aria-expanded"),
     titleTabIndex: title?.getAttribute("tabindex") ?? null,
     titleText: title?.textContent?.trim() ?? "",
+    titleFocusTop: titleBounds && active === title
+      ? titleBounds.top - focusPaintExtent
+      : null,
+    titleScrollMarginTop: title ? getComputedStyle(title).scrollMarginTop : null,
     viewportWidth: innerWidth,
   };
 })()`;
@@ -417,6 +425,54 @@ async function exerciseResponsiveCorpusDrawer(cdp) {
     deviceScaleFactor: 1,
     mobile: false,
   });
+}
+
+async function exerciseSkipToDocumentClearance(cdp, portalUrl) {
+  const route = new URL("concept/80-energy-model/", portalUrl);
+  const layouts = [
+    { width: 720, height: 600 },
+    { width: 320, height: 720 },
+  ];
+
+  for (const layout of layouts) {
+    await cdp.send("Emulation.setDeviceMetricsOverride", {
+      width: layout.width,
+      height: layout.height,
+      deviceScaleFactor: 1,
+      mobile: false,
+    });
+    await cdp.send("Page.navigate", { url: route.href });
+    await waitForBrowserState(
+      cdp,
+      portalStateExpression,
+      (snapshot) => snapshot.pathname === route.pathname && snapshot.readerPresent,
+      `energy-model route did not render at ${layout.width}px`,
+    );
+    await evaluateInBrowser(cdp, `(() => {
+      window.scrollTo(0, document.scrollingElement.scrollHeight);
+      document.querySelector(".portal-skip-link").focus({ preventScroll: true });
+    })()`);
+    await waitForBrowserState(
+      cdp,
+      `({ activeClass: document.activeElement?.className ?? "", scrollY })`,
+      (snapshot) => snapshot.activeClass === "portal-skip-link" && snapshot.scrollY > 0,
+      `skip link was not keyboard-ready at ${layout.width}px`,
+    );
+    await dispatchKeyboardKey(cdp, "Enter", "Enter", 13);
+    const state = await waitForBrowserState(
+      cdp,
+      portalStateExpression,
+      (snapshot) => snapshot.hash === "#portal-reader-title"
+        && snapshot.activeId === "portal-reader-title"
+        && snapshot.activeFocusVisible,
+      `skip link did not focus the document title at ${layout.width}px`,
+    );
+    assert.ok(
+      state.titleFocusTop >= state.headerBottom,
+      `focused title starts at ${state.titleFocusTop}px behind a header ending at ${state.headerBottom}px at ${layout.width}px`,
+    );
+    assert.ok(Number.parseFloat(state.titleScrollMarginTop) > state.headerBottom);
+  }
 }
 
 async function openSidebarRoute(cdp) {
@@ -773,6 +829,7 @@ test("portal document routes preserve native links and focus their destination h
     await traverseDocumentHistory(cdp, thesis, thesisState, route);
     const fragment = await openOutlineFragment(cdp);
     await traverseFragmentHistory(cdp, thesis, route, fragment);
+    await exerciseSkipToDocumentClearance(cdp, portalUrl);
   });
 });
 

--- a/scripts/github-pages.test.mjs
+++ b/scripts/github-pages.test.mjs
@@ -34,6 +34,29 @@ async function source(relative) {
   return readFile(path.join(repositoryRoot, relative), "utf8");
 }
 
+function assertCorpusDrawerSource(portal) {
+  assert.match(portal, /const selectGroup = \(candidate: LibraryGroup\)/);
+  assert.match(portal, /setGroup\(candidate\);[\s\S]*setCatalogLimit\(catalogPageSize\);/);
+  assert.match(portal, /className="portal-mobile-menu"/);
+  assert.match(portal, /className="portal-mobile-outline"/);
+  assert.match(portal, /id="portal-corpus-trigger"/);
+  assert.match(portal, /id="portal-corpus-drawer"/);
+  assert.match(portal, /aria-controls="portal-corpus-results"/);
+  assert.match(portal, /closeDrawer\(false\);[\s\S]*onNavigate\(path\);/);
+  assert.match(portal, /mobileMenuRef\.current\?\.removeAttribute\("open"\)/);
+  assert.match(portal, /mobileOutlineRef\.current\?\.removeAttribute\("open"\)/);
+  assert.match(portal, /selectHeading\(heading\.id\)/);
+  assert.doesNotMatch(portal, /--portal-reader-stack-top/);
+  assert.doesNotMatch(portal, /ResizeObserver/);
+  assert.match(portal, /function revealFocusedElement\(/);
+  assert.match(portal, /const clearance = outlineWidth \+ outlineOffset \+ 1/);
+  assert.match(portal, /revealFocusedElement\(libraryRef\.current, target\)/);
+  assert.doesNotMatch(portal, /listRef/);
+  assert.doesNotMatch(portal, /list\.scrollTop/);
+  assert.match(portal, /className="portal-document-list"[\s\S]*<a[\s\S]*href=\{portalDocumentLocation\(document\.path, assetBasePath\)\}/);
+  assert.match(portal, /aria-current=\{document\.path === selectedDocument\.path \? "page" : undefined\}/);
+}
+
 async function reserveLocalPort() {
   const server = createTcpServer();
   await new Promise((resolve, reject) => {
@@ -72,26 +95,60 @@ async function waitForBrowserState(cdp, expression, accepts, label, timeoutMs = 
 }
 
 const portalStateExpression = `(() => {
+  const active = document.activeElement;
   const title = document.getElementById("portal-reader-title");
+  const drawer = document.getElementById("portal-corpus-drawer");
+  const drawerScroller = drawer?.querySelector(".portal-library");
+  const documentList = drawer?.querySelector(".portal-document-list");
+  const mobileOutline = document.querySelector(".portal-mobile-outline");
+  const outline = document.querySelector(".portal-outline");
   const hashTarget = location.hash
     ? document.getElementById(decodeURIComponent(location.hash.slice(1)))
     : null;
   const hashBounds = hashTarget?.getBoundingClientRect();
   const documentLinks = [...document.querySelectorAll(".portal-document-list > a")];
+  const activeBounds = active?.getBoundingClientRect();
+  const drawerScrollerBounds = drawerScroller?.getBoundingClientRect();
+  const activeStyle = active ? getComputedStyle(active) : null;
+  const focusPaintExtent = activeStyle
+    ? (Number.parseFloat(activeStyle.outlineWidth) || 0)
+      + Math.max(Number.parseFloat(activeStyle.outlineOffset) || 0, 0)
+    : 0;
   return {
-    activeId: document.activeElement?.id ?? "",
-    activeTag: document.activeElement?.tagName ?? "",
+    activeFocusPaintFullyVisible: Boolean(
+      activeBounds
+      && drawerScrollerBounds
+      && activeBounds.top - focusPaintExtent >= drawerScrollerBounds.top
+      && activeBounds.bottom + focusPaintExtent <= drawerScrollerBounds.bottom
+    ),
+    activeId: active?.id ?? "",
+    activeIsFirstDocumentLink: active === documentLinks[0],
+    activeTag: active?.tagName ?? "",
+    activeWithinDrawer: Boolean(drawer?.contains(document.activeElement)),
+    activeFocusVisible: Boolean(active?.matches?.(":focus-visible")),
     articleTabIndex: document.getElementById("portal-reader")?.getAttribute("tabindex") ?? null,
     currentLinks: documentLinks.filter((link) => link.getAttribute("aria-current") === "page").length,
     documentLinkCount: documentLinks.length,
     documentLinkTags: [...new Set(documentLinks.map((link) => link.tagName))],
+    documentListOverflowY: documentList ? getComputedStyle(documentList).overflowY : "missing",
+    drawerOpen: Boolean(drawer?.open),
+    drawerScrollerClientHeight: drawerScroller?.clientHeight ?? null,
+    drawerScrollerOverflowY: drawerScroller ? getComputedStyle(drawerScroller).overflowY : "missing",
+    drawerScrollerScrollHeight: drawerScroller?.scrollHeight ?? null,
     hash: location.hash,
     hashTargetTop: hashBounds?.top ?? null,
     hashTargetVisible: Boolean(hashBounds && hashBounds.bottom > 0 && hashBounds.top < innerHeight),
     pathname: location.pathname,
+    pageClientWidth: document.documentElement.clientWidth,
+    pageScrollWidth: document.documentElement.scrollWidth,
     readerPresent: Boolean(document.getElementById("portal-reader")),
+    searchValue: document.getElementById("portal-library-search")?.value ?? null,
+    mobileOutlineDisplay: mobileOutline ? getComputedStyle(mobileOutline).display : "missing",
+    outlineDisplay: outline ? getComputedStyle(outline).display : "missing",
+    triggerExpanded: document.getElementById("portal-corpus-trigger")?.getAttribute("aria-expanded"),
     titleTabIndex: title?.getAttribute("tabindex") ?? null,
     titleText: title?.textContent?.trim() ?? "",
+    viewportWidth: innerWidth,
   };
 })()`;
 
@@ -221,7 +278,149 @@ async function openThesisRoute(cdp, portalUrl) {
   return { state, thesis };
 }
 
+async function dispatchKeyboardKey(cdp, key, code, virtualKeyCode, modifiers = 0) {
+  await cdp.send("Input.dispatchKeyEvent", {
+    type: "rawKeyDown",
+    key,
+    code,
+    modifiers,
+    windowsVirtualKeyCode: virtualKeyCode,
+    nativeVirtualKeyCode: virtualKeyCode,
+  });
+  await cdp.send("Input.dispatchKeyEvent", {
+    type: "keyUp",
+    key,
+    code,
+    modifiers,
+    windowsVirtualKeyCode: virtualKeyCode,
+    nativeVirtualKeyCode: virtualKeyCode,
+  });
+}
+
+async function openCorpusDrawer(cdp) {
+  await evaluateInBrowser(cdp, `document.getElementById("portal-corpus-trigger").click()`);
+  return waitForBrowserState(
+    cdp,
+    portalStateExpression,
+    (snapshot) => snapshot.drawerOpen
+      && snapshot.triggerExpanded === "true"
+      && snapshot.activeId === "portal-library-search"
+      && snapshot.activeWithinDrawer,
+    "corpus drawer did not open and focus its search",
+  );
+}
+
+async function exerciseSearchEscape(cdp) {
+  const query = "concept/";
+  await openCorpusDrawer(cdp);
+  await cdp.send("Input.insertText", { text: query });
+  await waitForBrowserState(
+    cdp,
+    portalStateExpression,
+    (snapshot) => snapshot.searchValue === query,
+    "corpus search did not receive the keyboard query",
+  );
+  await dispatchKeyboardKey(cdp, "Escape", "Escape", 27);
+  await waitForBrowserState(
+    cdp,
+    portalStateExpression,
+    (snapshot) => !snapshot.drawerOpen
+      && snapshot.triggerExpanded === "false"
+      && snapshot.searchValue === query
+      && snapshot.activeId === "portal-corpus-trigger"
+      && snapshot.activeFocusVisible,
+    "Escape from a populated corpus search did not close once and restore its invoker",
+  );
+
+  const reopened = await openCorpusDrawer(cdp);
+  assert.equal(reopened.searchValue, query);
+  await dispatchKeyboardKey(cdp, "a", "KeyA", 65, 2);
+  await dispatchKeyboardKey(cdp, "Backspace", "Backspace", 8);
+  await waitForBrowserState(
+    cdp,
+    portalStateExpression,
+    (snapshot) => snapshot.searchValue === "",
+    "corpus search did not clear after the Escape-state regression",
+  );
+  await dispatchKeyboardKey(cdp, "Escape", "Escape", 27);
+  await waitForBrowserState(
+    cdp,
+    portalStateExpression,
+    (snapshot) => !snapshot.drawerOpen
+      && snapshot.activeId === "portal-corpus-trigger",
+    "native empty-search Escape did not close the corpus drawer",
+  );
+}
+
+async function exerciseResponsiveCorpusDrawer(cdp) {
+  const layouts = [
+    { width: 1440, height: 900, outline: "block", mobileOutline: "none" },
+    { width: 768, height: 1024, outline: "none", mobileOutline: "block" },
+    { width: 720, height: 760, outline: "none", mobileOutline: "block" },
+    { width: 375, height: 844, outline: "none", mobileOutline: "block" },
+    { width: 320, height: 720, outline: "none", mobileOutline: "block" },
+    // Equivalent CSS viewport for a 1440 x 900 browser at 200% page zoom.
+    { width: 720, height: 450, outline: "none", mobileOutline: "block", zoomed: true },
+  ];
+  for (const layout of layouts) {
+    await cdp.send("Emulation.setDeviceMetricsOverride", {
+      width: layout.width,
+      height: layout.height,
+      deviceScaleFactor: 1,
+      mobile: false,
+    });
+    await waitForBrowserState(
+      cdp,
+      portalStateExpression,
+      (snapshot) => snapshot.viewportWidth === layout.width
+        && snapshot.outlineDisplay === layout.outline
+        && snapshot.mobileOutlineDisplay === layout.mobileOutline
+        && snapshot.pageScrollWidth <= snapshot.pageClientWidth,
+      `reader layout did not reflow at ${layout.width}px`,
+    );
+    await openCorpusDrawer(cdp);
+    const tabCount = layout.zoomed ? 4 : 1;
+    for (let index = 0; index < tabCount; index += 1) {
+      await dispatchKeyboardKey(cdp, "Tab", "Tab", 9);
+    }
+    await waitForBrowserState(
+      cdp,
+      portalStateExpression,
+      (snapshot) => snapshot.drawerOpen
+        && snapshot.activeWithinDrawer
+        && snapshot.activeFocusVisible
+        && (!layout.zoomed || (
+          snapshot.activeIsFirstDocumentLink
+          && snapshot.activeFocusPaintFullyVisible
+          && snapshot.drawerScrollerOverflowY === "auto"
+          && snapshot.documentListOverflowY === "visible"
+          && snapshot.drawerScrollerScrollHeight > snapshot.drawerScrollerClientHeight
+        )),
+      layout.zoomed
+        ? "200% zoom clipped the focused corpus result"
+        : `keyboard focus escaped the drawer at ${layout.width}px`,
+    );
+    await dispatchKeyboardKey(cdp, "Escape", "Escape", 27);
+    await waitForBrowserState(
+      cdp,
+      portalStateExpression,
+      (snapshot) => !snapshot.drawerOpen
+        && snapshot.triggerExpanded === "false"
+        && snapshot.activeId === "portal-corpus-trigger"
+        && snapshot.activeFocusVisible,
+      `closing the drawer did not restore visible focus at ${layout.width}px`,
+    );
+  }
+  await cdp.send("Emulation.setDeviceMetricsOverride", {
+    width: 1440,
+    height: 900,
+    deviceScaleFactor: 1,
+    mobile: false,
+  });
+}
+
 async function openSidebarRoute(cdp) {
+  await openCorpusDrawer(cdp);
   const route = await evaluateInBrowser(cdp, `(() => {
     const link = [...document.querySelectorAll(".portal-document-list > a")]
       .find((candidate) => candidate.getAttribute("aria-current") !== "page");
@@ -263,8 +462,9 @@ async function openSidebarRoute(cdp) {
     portalStateExpression,
     (snapshot) => snapshot.pathname === route.pathname
       && snapshot.titleText === route.title
-      && snapshot.activeId === "portal-reader-title",
-    "sidebar route did not focus its title",
+      && snapshot.activeId === "portal-reader-title"
+      && !snapshot.drawerOpen,
+    "drawer route did not close and focus its title",
   );
   assert.equal(state.activeTag, "H1");
   assert.equal(state.currentLinks, 1);
@@ -516,19 +716,7 @@ test("the portal keeps clean-route history and native Markdown links honest on t
   assert.match(portal, />Evidence<\/a>/);
   assert.match(portal, />Experiments /);
   assert.match(portal, />Contribute<\/a>/);
-  assert.match(portal, /const selectGroup = \(candidate: LibraryGroup\)/);
-  assert.match(portal, /selectedMetadata\?\.group !== candidate/);
-  assert.match(portal, /className="portal-mobile-menu"/);
-  assert.match(portal, /className="portal-mobile-outline"/);
-  assert.match(portal, /mobileMenuRef\.current\?\.removeAttribute\("open"\)/);
-  assert.match(portal, /mobileOutlineRef\.current\?\.removeAttribute\("open"\)/);
-  assert.match(portal, /selectHeading\(heading\.id\)/);
-  assert.doesNotMatch(portal, /--portal-reader-stack-top/);
-  assert.doesNotMatch(portal, /ResizeObserver/);
-  assert.match(portal, /readerLibraryRef/);
-  assert.match(portal, /list\.scrollTop \+= activeRect\.top/);
-  assert.match(portal, /className="portal-document-list"[\s\S]*<a[\s\S]*href=\{portalDocumentLocation\(document\.path, assetBasePath\)\}/);
-  assert.match(portal, /aria-current=\{document\.path === selectedMetadata\.path \? "page" : undefined\}/);
+  assertCorpusDrawerSource(portal);
   assert.match(portal, /event\.button === 0[\s\S]*!event\.ctrlKey[\s\S]*!event\.metaKey/);
   assert.match(portal, /section heading match/);
   assert.match(portal, /Open \{step\.label\}/);
@@ -579,6 +767,8 @@ test("portal document routes preserve native links and focus their destination h
 }, async () => {
   await withPortalBrowser(async (cdp, portalUrl) => {
     const { state: thesisState, thesis } = await openThesisRoute(cdp, portalUrl);
+    await exerciseResponsiveCorpusDrawer(cdp);
+    await exerciseSearchEscape(cdp);
     const route = await openSidebarRoute(cdp);
     await traverseDocumentHistory(cdp, thesis, thesisState, route);
     const fragment = await openOutlineFragment(cdp);

--- a/scripts/mermaid-browser.test.mjs
+++ b/scripts/mermaid-browser.test.mjs
@@ -589,9 +589,9 @@ async function assertMobilePortalSurface(cdp, address) {
 }
 
 test("browser rendering keeps Mermaid stable and wide publication content keyboard operable", {
-  // The tighter phase deadlines remain authoritative. This outer budget also
-  // covers cold rendering, the reflow navigations and deterministic cleanup.
-  timeout: 240_000,
+  // The tighter phase deadlines remain authoritative. This outer budget lets
+  // each phase exhaust its own bound and still covers deterministic cleanup.
+  timeout: 360_000,
 }, async () => {
   const browser = await firstExistingChromium();
   const debugPort = await reserveLocalPort();
@@ -634,7 +634,8 @@ test("browser rendering keeps Mermaid stable and wide publication content keyboa
     const navigation = await cdp.send("Page.navigate", { url: bookUrl });
     assert.equal(navigation.errorText, undefined);
 
-    const deadline = Date.now() + 90_000;
+    const deadline = Date.now() + 180_000;
+    let ready = false;
     let snapshot;
     while (Date.now() < deadline) {
       const result = await cdp.send("Runtime.evaluate", {
@@ -648,10 +649,14 @@ test("browser rendering keeps Mermaid stable and wide publication content keyboa
         snapshot.state === "complete" &&
         snapshot.diagrams >= 2 &&
         snapshot.loading === 0
-      ) break;
+      ) {
+        ready = true;
+        break;
+      }
       await new Promise((resolve) => setTimeout(resolve, 250));
     }
 
+    assert.equal(ready, true, `Book diagrams did not become ready: ${JSON.stringify(snapshot)}`);
     assert.ok(snapshot?.diagrams >= 2, `Book diagrams did not render: ${JSON.stringify(snapshot)}`);
     assert.deepEqual(snapshot.errors, []);
     await new Promise((resolve) => setTimeout(resolve, 1_250));


### PR DESCRIPTION
## Summary

- make the article the dominant reader object by keeping only the document outline as a persistent wide-screen rail
- move corpus search, grouping, result counts, current-document context, and native document links into one bounded dialog drawer
- preserve deterministic keyboard focus, populated and empty-search Escape behavior, current-document state, and mobile contents navigation
- keep skip-link and fragment focus targets visibly below the sticky publication header through one shared height token
- reflow the outline and drawer before the reading measure is squeezed at intermediate, narrow, 320 px, and 200% zoom-equivalent viewports

## Evidence boundary

The browser checks establish the implemented interaction and responsive bounds in the pinned test environment. They do not establish reader preference, improved comprehension, or WCAG conformance.

## Validation

- focused source and real-browser drawer tests — pass after replay onto current `main`
- skip-to-document focus clearance — pass at 720x600 and 320x720 CSS px, including focus-paint bounds below the measured sticky header
- Mermaid cold-render readiness — bounded at 180 seconds, with an explicit readiness snapshot on failure; diagram integrity and stability assertions remain unchanged
- TypeScript typecheck and targeted ESLint — pass
- responsive browser coverage — 1440, 768, 720, 375, and 320 CSS px plus a 200% zoom-equivalent viewport
- rendered inspection of the closed reader and open drawer — pass at wide, intermediate, narrow, and 200%-equivalent layouts; receipt retained under the ignored evidence workspace
- deterministic PDF regeneration — two byte-identical PDFs with refreshed source-bound manifest and semantic baseline
- `npm run check` — pass after the final replay

Closes #49
