### PR TITLE
fix(ci): await drawer state before reopening

### DIFF
--- a/scripts/github-pages.test.mjs
+++ b/scripts/github-pages.test.mjs
@@ -355,6 +355,7 @@ async function exerciseSearchEscape(cdp) {
     cdp,
     portalStateExpression,
     (snapshot) => !snapshot.drawerOpen
+      && snapshot.triggerExpanded === "false"
       && snapshot.activeId === "portal-corpus-trigger",
     "native empty-search Escape did not close the corpus drawer",
   );


### PR DESCRIPTION
## Summary

- wait for both the native dialog and React's `aria-expanded` state to settle after the empty-search Escape path
- prevent the browser regression from immediately reopening against stale component state
- leave the reader implementation and accessibility behavior unchanged

Tracks #7

## Research traceability

- **Claim IDs:** none
- **Principle bundles:** none; test-harness synchronization only
- **Experiment or fixture IDs:** none
- **Evidence and result authority:** development validation only; no scientific result or authority change
- **Contributors and accountable approver:** Codex implementation and independent diagnosis; maintainer approval through the protected pull-request path
- **Funding, material support, and competing interests:** not applicable
- **Material AI, automation, or external services:** Codex inspected the failure, implemented the bounded change, and ran the listed checks; a second Codex agent independently reproduced and diagnosed the race
- **Ethics, rights, safety, misuse, and data-plan triggers:** no trigger; no research subjects, external data, or claim-bearing output
- **Intended reader:** repository maintainers and contributors
- **Domain-accuracy review:** not applicable; scientific meaning is unchanged
- **Curious-reader review:** not applicable; public prose is unchanged

## Checklist

- [x] I separated source observation, proposed translation, and project hypothesis where applicable.
- [x] New or changed empirical claims have stable `C-` IDs, scoped evidence status, primary sources, and explicit boundary conditions.
- [x] New mechanisms were checked against existing `P-` bundles and the strongest ordinary engineering null.
- [x] Imported, quoted, adapted, or generated material has provenance and a recorded reuse basis; public availability or citation alone was not treated as permission to copy.
- [x] Smoke, construction, development, and specification-only work remains `NO_RESULT`; no result or authority was promoted without an eligible run.
- [x] Quantitative statements define symbols, units, assumptions, uncertainty, and the measured system boundary.
- [x] Contributor credit, support, conflicts, and material tool use are disclosed at the authority this change claims.
- [x] Triggered ethics, misuse, collaboration, and research-object stewardship requirements were satisfied before the affected work began.
- [x] Editable sources and affected generated artifacts, indexes, plots, book files, or manifests were updated together.
- [x] A changed `Scope` gives its intended reader an entry ramp; acronyms and project terms are explained before they carry the argument.
- [x] I ran the relevant validation commands and list them below.

## Validation

```text
PASS (3/3 consecutive): node --test --test-name-pattern='portal document routes preserve native links and focus their destination headings' scripts/github-pages.test.mjs
PASS: npm run test:github-pages
PASS: npx eslint app/components/public-research-portal.tsx scripts/github-pages.test.mjs
PASS: npm run typecheck
PASS: git diff --check
```

The failed aggregate run that exposed this race was not counted as validation. Its final snapshot had a closed native dialog and focused trigger before the queued React close state had settled; the independent diagnosis confirmed the CSS and reader component blobs were unchanged.
