### PR TITLE
fix(site): preserve reviewed-language route parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,6 +315,7 @@ jobs:
       - name: Check out canonical source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          fetch-depth: 0
           persist-credentials: false
       - name: Use Node.js 26
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Check out canonical source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          fetch-depth: 0
           persist-credentials: false
       - name: Use Node.js 26
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -266,6 +266,13 @@ the exact diff; this file records why the project changed.
 - The document reader now keeps only its section outline beside the article.
   Corpus search, filters, current-document context and native document links
   move into a keyboard-operable drawer that returns focus when it closes.
+- The shared language control and no-JavaScript reading fallback now list only
+  English and reviewed translations published for the current source route.
+  Other EU languages use a separate source-bound contribution route instead of
+  appearing as readable editions. Canonical and translated routes expose the
+  same self-and-peer language metadata, and hydrated navigation retains an
+  explicit Pages subpath. This does not publish or assess a German translation;
+  that pilot still requires the review recorded in issue 51.
 - A failed two-builder PDF reproducibility check now retains both exact PDF and
   manifest pairs beside its comparison receipt. CI uploads the bounded mismatch
   bundle for 30 days, so a rare renderer disagreement can be byte-diffed without

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -271,8 +271,11 @@ the exact diff; this file records why the project changed.
   Other EU languages use a separate source-bound contribution route instead of
   appearing as readable editions. Canonical and translated routes expose the
   same self-and-peer language metadata, and hydrated navigation retains an
-  explicit Pages subpath. This does not publish or assess a German translation;
-  that pilot still requires the review recorded in issue 51.
+  explicit Pages subpath. Schema-2 entries now also require an exact source
+  commit and canonical UTC review instant, and translated pages expose those
+  maintained values instead of inferring them from the build. This does not
+  publish or assess a German translation; that pilot still requires the human
+  language/domain review recorded in issue 51.
 - A failed two-builder PDF reproducibility check now retains both exact PDF and
   manifest pairs beside its comparison receipt. CI uploads the bounded mismatch
   bundle for 30 days, so a rare renderer disagreement can be byte-diffed without

--- a/app/components/book-edition.tsx
+++ b/app/components/book-edition.tsx
@@ -216,7 +216,7 @@ export function BookEdition({
         </a>
         <button type="button" onClick={() => window.print()}>
           Print this edition
-        </button>{!isPublicPdf && <LanguageAccess />}
+        </button>{!isPublicPdf && <LanguageAccess basePath={assetBasePath} />}
       </nav>
 
       <header className="book-cover">

--- a/app/components/language-access.tsx
+++ b/app/components/language-access.tsx
@@ -2,49 +2,65 @@
 
 import { useState } from "react";
 import {
-  officialEuLanguages,
-  reviewedTranslationUrl,
+  languageAvailability,
+  languageDestinationUrl,
   translationContributionUrl,
 } from "../lib/language-access.mjs";
 
-export function LanguageAccess() {
+export function LanguageAccess({ basePath = "/" }: { basePath?: string }) {
   const [language, setLanguage] = useState("en");
-  const translationHref = typeof window === "undefined"
+  const location = typeof window === "undefined"
+    ? { pathname: "/", hash: "" }
+    : window.location;
+  const availability = languageAvailability(location, { basePath });
+  const selectedLanguage = availability.available.some(
+    (entry) => entry.code === language,
+  ) ? language : availability.currentLanguage;
+  const destinationHref = typeof window === "undefined"
     ? null
-    : reviewedTranslationUrl(language, window.location);
-  const contributionHref = typeof window === "undefined"
-    ? null
-    : translationContributionUrl(language, window.location);
+    : languageDestinationUrl(selectedLanguage, location, { basePath });
+  const contributionHref = translationContributionUrl(location, { basePath });
+  const current = availability.available.find((entry) => entry.current);
 
   return (
     <details className="language-access">
       <summary>Language</summary>
       <div className="language-access-panel">
-        <label htmlFor="site-language">Read in another EU language</label>
+        <label htmlFor="site-language">Read this page</label>
         <select
           id="site-language"
-          value={language}
+          value={selectedLanguage}
           onChange={(event) => setLanguage(event.target.value)}
         >
-          {officialEuLanguages.map(([code, label]) => (
-            <option key={code} value={code}>{label}</option>
+          {availability.available.map(({ code, label }) => (
+            <option key={code} lang={code} value={code}>{label}</option>
           ))}
         </select>
-        {translationHref ? (
-          <a href={translationHref}>
-            Open reviewed translation
-          </a>
-        ) : contributionHref ? (
-          <a href={contributionHref} target="_blank" rel="noreferrer">
-            Help translate or review this page
+        {destinationHref ? (
+          <a href={destinationHref}>
+            {selectedLanguage === "en"
+              ? "Open canonical English"
+              : "Open reviewed translation"}
           </a>
         ) : (
-          <span className="language-access-current">English is the canonical text.</span>
+          <span className="language-access-current">
+            {current?.code === "en"
+              ? "English is the canonical text."
+              : `${current?.label ?? "This language"} is the current reviewed edition.`}
+          </span>
         )}
         <small>
-          Translations are published from Git only after source-version checks
-          and human review. No automatic translation is presented as project text.
+          Only translations tied to this source version and recorded after
+          human review appear as reading options.
         </small>
+        <a
+          className="language-access-help"
+          href={contributionHref}
+          target="_blank"
+          rel="noreferrer"
+        >
+          Help add or review a language
+        </a>
       </div>
     </details>
   );

--- a/app/components/public-research-portal.tsx
+++ b/app/components/public-research-portal.tsx
@@ -822,7 +822,7 @@ export function PublicResearchPortal({
       <a className="portal-source-link" href={repositoryUrl} target="_blank" rel="noreferrer">
         Source <span aria-hidden="true">↗</span>
       </a>
-      <LanguageAccess />
+      <LanguageAccess basePath={assetBasePath} />
       <details className="portal-mobile-menu" ref={mobileMenuRef}>
         <summary>Menu</summary>
         <nav aria-label="Mobile navigation">

--- a/app/lib/language-access.mjs
+++ b/app/lib/language-access.mjs
@@ -8,27 +8,144 @@ import { publication, repositoryIssueUrl } from "./publication.mjs";
 export const canonicalPublicOrigin = publication.canonicalSite;
 export { officialEuLanguages };
 
-function canonicalPath(location) {
-  const pathname = location.pathname || "/";
-  return pathname.startsWith("/") ? pathname : `/${pathname}`;
+const maximumTranslationDocuments = 4096;
+const publicationRoutePattern = /^\/(?:concept|math)\/(?:[a-z0-9][a-z0-9-]*\/)*[a-z0-9][a-z0-9-]*\/$/u;
+
+function withLeadingSlash(value) {
+  return value.startsWith("/") ? value : `/${value}`;
 }
 
-export function reviewedTranslationUrl(language, location) {
-  if (language === "en" || !isOfficialEuLanguageCode(language)) return null;
-  const sourceRoute = canonicalPath(location);
-  const translation = translationManifest.documents.find(
-    (entry) => entry.language === language && entry.sourceRoute === sourceRoute,
+function normalizedBasePath(value) {
+  const base = withLeadingSlash(value || "/");
+  return base.endsWith("/") ? base : `${base}/`;
+}
+
+function canonicalPath(location, basePath = "/") {
+  const pathname = withLeadingSlash(location.pathname || "/");
+  const base = normalizedBasePath(basePath);
+  if (base === "/") return pathname;
+  if (pathname === base.slice(0, -1)) return "/";
+  return pathname.startsWith(base)
+    ? withLeadingSlash(pathname.slice(base.length))
+    : pathname;
+}
+
+function availabilityRecord(entry, index) {
+  if (
+    entry === null
+    || typeof entry !== "object"
+    || Array.isArray(entry)
+    || typeof entry.language !== "string"
+    || entry.language === "en"
+    || !isOfficialEuLanguageCode(entry.language)
+    || typeof entry.sourceRoute !== "string"
+    || typeof entry.route !== "string"
+  ) {
+    throw new Error(`Translation availability record ${index} is malformed.`);
+  }
+  const sourceRoute = withLeadingSlash(entry.sourceRoute);
+  const route = withLeadingSlash(entry.route);
+  if (
+    !publicationRoutePattern.test(sourceRoute)
+    || route !== `/${entry.language}${sourceRoute}`
+  ) {
+    throw new Error(`Translation availability record ${index} has unsafe routes.`);
+  }
+  return Object.freeze({ language: entry.language, sourceRoute, route });
+}
+
+function availabilityRecords(documents) {
+  if (!Array.isArray(documents) || documents.length > maximumTranslationDocuments) {
+    throw new Error(
+      `Translation availability requires at most ${maximumTranslationDocuments} records.`,
+    );
+  }
+  const identities = new Set();
+  const routes = new Set();
+  return documents.map((entry, index) => {
+    const record = availabilityRecord(entry, index);
+    const identity = `${record.language}:${record.sourceRoute}`;
+    if (identities.has(identity) || routes.has(record.route)) {
+      throw new Error(`Translation availability repeats ${identity}.`);
+    }
+    identities.add(identity);
+    routes.add(record.route);
+    return record;
+  });
+}
+
+export function languageAvailabilityForRoute(route, documents = translationManifest.documents) {
+  const currentRoute = withLeadingSlash(route || "/");
+  const records = availabilityRecords(documents);
+  const currentTranslation = records.find((entry) => entry.route === currentRoute) ?? null;
+  const sourceRoute = currentTranslation?.sourceRoute ?? currentRoute;
+  const translations = new Map(
+    records
+      .filter((entry) => entry.sourceRoute === sourceRoute)
+      .map((entry) => [entry.language, entry]),
   );
-  if (!translation) return null;
-  const translated = new URL(translation.route, canonicalPublicOrigin);
-  translated.hash = location.hash || "";
-  return translated.toString();
+  const currentLanguage = currentTranslation?.language ?? "en";
+  const available = officialEuLanguages
+    .filter(([code]) => code === "en" || translations.has(code))
+    .map(([code, label]) => Object.freeze({
+      code,
+      label,
+      route: code === "en" ? sourceRoute : translations.get(code).route,
+      current: code === currentLanguage,
+    }));
+  const unavailable = officialEuLanguages
+    .filter(([code]) => code !== "en" && !translations.has(code))
+    .map(([code, label]) => Object.freeze({ code, label }));
+  return Object.freeze({
+    currentLanguage,
+    sourceRoute,
+    available: Object.freeze(available),
+    unavailable: Object.freeze(unavailable),
+  });
 }
 
-export function translationContributionUrl(language, location) {
-  if (language === "en" || !isOfficialEuLanguageCode(language)) return null;
+export function languageAvailability(location, { documents, basePath = "/" } = {}) {
+  return languageAvailabilityForRoute(
+    canonicalPath(location, basePath),
+    documents ?? translationManifest.documents,
+  );
+}
+
+export function languageAlternateLinksForRoute(
+  route,
+  documents = translationManifest.documents,
+) {
+  const availability = languageAvailabilityForRoute(route, documents);
+  if (availability.available.length < 2) return Object.freeze([]);
+  return Object.freeze(availability.available.map((destination) => Object.freeze({
+    language: destination.code,
+    href: new URL(destination.route, canonicalPublicOrigin).toString(),
+  })));
+}
+
+export function languageDestinationUrl(language, location, options = {}) {
+  const availability = languageAvailability(location, options);
+  const destination = availability.available.find((entry) => entry.code === language);
+  if (!destination || destination.current) return null;
+  const base = normalizedBasePath(options.basePath ?? "/");
+  const route = `${base}${destination.route.replace(/^\/+/, "")}`;
+  const url = new URL(route, canonicalPublicOrigin);
+  url.hash = location.hash || "";
+  return `${url.pathname}${url.search}${url.hash}`;
+}
+
+export function reviewedTranslationUrl(language, location, options = {}) {
+  if (language === "en") return null;
+  return languageDestinationUrl(language, location, options);
+}
+
+export function translationContributionUrl(location, options = {}) {
+  const availability = languageAvailability(location, options);
   return repositoryIssueUrl(
     "translation-problem.yml",
-    `[Translation] ${language}: ${canonicalPath(location)}`,
+    `[Translation] ${availability.sourceRoute}`,
+    {
+      source: `${new URL(availability.sourceRoute, canonicalPublicOrigin)} at commit or release:`,
+    },
   );
 }

--- a/app/lib/portal-seo.ts
+++ b/app/lib/portal-seo.ts
@@ -1,3 +1,4 @@
+import { languageAlternateLinksForRoute } from "./language-access.mjs";
 import { publication } from "./publication.mjs";
 
 const canonicalSite = publication.canonicalSite;
@@ -13,11 +14,18 @@ type PortalSeoDocument = {
   words: number;
 };
 
-export function portalSeoDescriptor(metadata: PortalSeoDocument | null) {
+export function portalSeoDescriptor(
+  metadata: PortalSeoDocument | null,
+  translationDocuments?: Parameters<typeof languageAlternateLinksForRoute>[1],
+) {
   if (metadata) {
     const canonical = `${canonicalSite}${metadata.route}`;
     return {
       canonical,
+      languageAlternates: languageAlternateLinksForRoute(
+        metadata.route,
+        translationDocuments,
+      ),
       title: `${metadata.title} — ${siteName}`,
       description: metadata.description,
       ogType: "article",
@@ -39,6 +47,7 @@ export function portalSeoDescriptor(metadata: PortalSeoDocument | null) {
   }
   return {
     canonical: canonicalSite,
+    languageAlternates: [],
     title: `${siteName} — Research Portal`,
     description: portalDescription,
     ogType: "website",
@@ -91,6 +100,25 @@ function upsertCanonical(href: string) {
   if (!existing) head.append(element);
 }
 
+function replaceLanguageAlternates(
+  alternatives: readonly { language: string; href: string }[],
+) {
+  const head = window.document.head;
+  for (const existing of head.querySelectorAll<HTMLLinkElement>(
+    'link[rel="alternate"][hreflang][data-language-alternate]',
+  )) {
+    existing.remove();
+  }
+  for (const alternative of alternatives) {
+    const element = window.document.createElement("link");
+    element.rel = "alternate";
+    element.hreflang = alternative.language;
+    element.href = alternative.href;
+    element.dataset.languageAlternate = "";
+    head.append(element);
+  }
+}
+
 function upsertStructuredData(value: object) {
   const head = window.document.head;
   const scripts = [...head.querySelectorAll<HTMLScriptElement>(
@@ -129,5 +157,6 @@ export function synchronizePortalSeo(metadata: PortalSeoDocument | null) {
     upsertMeta(attribute, key, content);
   }
   upsertCanonical(descriptor.canonical);
+  replaceLanguageAlternates(descriptor.languageAlternates);
   upsertStructuredData(descriptor.structuredData);
 }

--- a/app/portal.css
+++ b/app/portal.css
@@ -381,6 +381,54 @@
 
 @media screen {
 
+  .seo-language-access {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 10px 18px;
+    padding: 16px 18px;
+    border: 1px solid var(--line, #c5cec5);
+    background: var(--paper-raised, #fffdf7);
+  }
+
+  .seo-language-access ul {
+    display: flex;
+    flex: 1 1 220px;
+    flex-wrap: wrap;
+    gap: 8px 16px;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .seo-language-access li {
+    margin: 0;
+  }
+
+  .seo-language-access > a {
+    font-weight: 700;
+  }
+
+  .language-access > summary:focus-visible,
+  .language-access-panel select:focus-visible,
+  .language-access-panel a:focus-visible {
+    outline: 3px solid #2f7df4;
+    outline-offset: 3px;
+  }
+
+  .language-access-panel .language-access-help {
+    border-color: #668174;
+    background: transparent;
+    color: #f8fff9;
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 3px;
+  }
+
+  .language-access-panel .language-access-help:hover {
+    border-color: #24d17e;
+  }
+
   .portal-result-count,
   .portal-footer nav a {
     font-size: 12px;

--- a/decisions/0058-expose-only-route-available-reviewed-translations.md
+++ b/decisions/0058-expose-only-route-available-reviewed-translations.md
@@ -40,6 +40,10 @@ would misstate the public corpus.
 5. The Pages artifact validator compares each document's complete alternate
    set with the validated manifest projection. Missing, extra, asymmetric or
    stale language metadata blocks publication.
+6. Each reviewed-manifest entry records the exact lowercase 40-character Git
+   source commit and a canonical UTC review instant. The translated page shows
+   both maintained values and links its canonical source at that commit;
+   malformed or omitted review provenance blocks publication.
 
 This decision does not publish or assess a German translation. Issue 51 remains
 blocked until a competent human reviewer accepts a source-bound German pilot
@@ -52,6 +56,8 @@ under decision 0035.
   semantics.
 - Search metadata describes reviewed public editions without converting a
   translation request or draft into a publication claim.
+- A reader can inspect which immutable source revision was reviewed and when,
+  without trusting the build checkout as an inferred review record.
 - Decision 0035 remains authoritative for review competence, source and target
   digests, disclosure and publication admission.
 
@@ -60,9 +66,10 @@ under decision 0035.
 - [Google Search Central, *Tell Google about localized versions of your page*](https://developers.google.com/search/docs/specialty/international/localized-versions)
 - [W3C, *Authoring HTML: Language declarations*](https://www.w3.org/TR/i18n-html-tech-lang/)
 
-OpenAI Codex was materially used on 2026-09-04 for implementation, testing and
-drafting under maintainer direction. It is not an author or accountable
-approver. No translation was generated, reviewed or published by this change.
+OpenAI Codex was materially used on 2026-09-04 and 2026-09-05 for
+implementation, testing and drafting under maintainer direction. It is not an
+author or accountable approver. No translation was generated, reviewed or
+published by this change.
 
 ## Supersession
 

--- a/decisions/0058-expose-only-route-available-reviewed-translations.md
+++ b/decisions/0058-expose-only-route-available-reviewed-translations.md
@@ -1,0 +1,71 @@
+# 0058 — Expose only route-available reviewed translations
+
+- **Status:** accepted
+- **Date:** 2026-09-04
+- **Partly supersedes:** [0035](0035-publish-only-reviewed-source-bound-translations.md),
+  language-control presentation only
+- **Related:** [issue #51](https://github.com/lusoris/20-watts-was-enough/issues/51)
+
+## Context
+
+Decision 0035 required every published translation to be reviewed and bound to
+the exact English source, but its language-control description still mixed two
+different tasks. A reader choosing an available edition and a contributor
+offering an unavailable language should not pass through the same list of
+options.
+
+The publication also needs one discoverable relationship between each
+canonical document and its reviewed translations. Search guidance requires
+each localized page to identify itself and all of its peers, with the links
+returned by every member of that set. A one-sided or unreviewed language link
+would misstate the public corpus.
+
+## Decision
+
+1. The reading control lists English and only the reviewed translations
+   registered for the current source route. Other official EU languages remain
+   reachable through the separate, source-bound contribution route; they are
+   not presented as readable editions.
+2. When a source route has at least one reviewed translation, every generated
+   canonical and translated page emits the same fully qualified set of
+   `rel="alternate"` links: one self link and one link for every reviewed peer.
+   Unavailable, unreviewed and stale translations emit no language alternate.
+3. The publication build validates the complete translation manifest and file
+   digests before deriving its bounded availability projection. Static Pages,
+   no-JavaScript navigation and hydrated navigation consume that same route
+   model; malformed or duplicate projections fail closed.
+4. Hydrated reading links retain the validated `PAGES_BASE_PATH` for supported
+   subpath previews. Canonical and language-alternate discovery URLs remain at
+   the production custom-domain root established by decision 0029.
+5. The Pages artifact validator compares each document's complete alternate
+   set with the validated manifest projection. Missing, extra, asymmetric or
+   stale language metadata blocks publication.
+
+This decision does not publish or assess a German translation. Issue 51 remains
+blocked until a competent human reviewer accepts a source-bound German pilot
+under decision 0035.
+
+## Consequences
+
+- Readers see only destinations that the project can actually serve.
+- Static and hydrated reading controls preserve the same route and hosting-base
+  semantics.
+- Search metadata describes reviewed public editions without converting a
+  translation request or draft into a publication claim.
+- Decision 0035 remains authoritative for review competence, source and target
+  digests, disclosure and publication admission.
+
+## References and disclosure
+
+- [Google Search Central, *Tell Google about localized versions of your page*](https://developers.google.com/search/docs/specialty/international/localized-versions)
+- [W3C, *Authoring HTML: Language declarations*](https://www.w3.org/TR/i18n-html-tech-lang/)
+
+OpenAI Codex was materially used on 2026-09-04 for implementation, testing and
+drafting under maintainer direction. It is not an author or accountable
+approver. No translation was generated, reviewed or published by this change.
+
+## Supersession
+
+Supersede this record if the project adopts a different public translation
+authority, changes the canonical hosting root, or deliberately presents
+unavailable languages inside the reading control again.

--- a/decisions/README.md
+++ b/decisions/README.md
@@ -40,7 +40,7 @@ than silently changing its outcome.
 | [0032](0032-adopt-a-deduplicated-european-research-integrity-baseline.md) | Adopt a deduplicated European research-integrity baseline | accepted |
 | [0033](0033-retire-the-owner-only-reader.md) | Retire the owner-only reader | accepted |
 | [0034](0034-release-bounded-experiment-containers.md) | Release bounded experiment containers | superseded by [0037](0037-release-go-tooling-and-scope-experiment-images.md) |
-| [0035](0035-publish-only-reviewed-source-bound-translations.md) | Publish only reviewed, source-bound translations | accepted |
+| [0035](0035-publish-only-reviewed-source-bound-translations.md) | Publish only reviewed, source-bound translations | accepted; language-control presentation partly superseded by [0058](0058-expose-only-route-available-reviewed-translations.md) |
 | [0036](0036-use-one-source-to-publication-and-feedback-graph.md) | Use one source-to-publication-and-feedback graph | accepted; CI aggregate-gate sentence partly superseded by [0043](0043-impact-scope-pull-request-ci.md) |
 | [0037](0037-release-go-tooling-and-scope-experiment-images.md) | Release one scoped image per experiment | accepted; clause 3 partly superseded by [0038](0038-publish-only-release-exercised-container-platforms.md), clause 8 superseded by [0042](0042-retire-the-host-specific-fixture-012-acquisition-lane.md) |
 | [0038](0038-publish-only-release-exercised-container-platforms.md) | Publish only release-exercised container platforms | accepted; clauses 2 and 3 partly superseded by [0041](0041-attest-only-current-run-build-outputs.md) |
@@ -63,6 +63,7 @@ than silently changing its outcome.
 | [0055](0055-freeze-clrs-text-as-a-controller-shakedown.md) | Freeze CLRS-Text as a controller shakedown | accepted |
 | [0056](0056-keep-public-workflows-off-self-hosted-runners.md) | Keep public workflows off self-hosted runners | accepted |
 | [0057](0057-project-pull-request-metadata-from-managed-issues.md) | Project pull-request metadata from managed issues | accepted |
+| [0058](0058-expose-only-route-available-reviewed-translations.md) | Expose only route-available reviewed translations | accepted |
 | [0059](0059-run-one-enforcing-dependency-audit-per-full-gate.md) | Run one enforcing dependency audit per full gate | accepted |
 | [0061](0061-reconcile-managed-status-with-item-lifecycle.md) | Reconcile managed status with item lifecycle | accepted |
 | [0062](0062-impact-scope-comparable-main-pushes.md) | Impact-scope comparable main pushes | accepted |

--- a/docs/how-to-help.md
+++ b/docs/how-to-help.md
@@ -72,7 +72,7 @@ and [engineering and research contract](principles.md).
 | Contribution | Minimum review evidence | Focused checks before a pull request |
 | --- | --- | --- |
 | Readability or documentation | Exact path or URL, intended reader, shortest affected passage and the interpretation that failed | `npm run check:prose`; `npm run validate:docs` |
-| Translation | Language, exact canonical and translated paths, exact source digest, exact reviewed target digest, named language/domain reviewer, and disclosed drafting tools | `npm run validate:translations`; `npm run check:prose` for any changed English source |
+| Translation | Language, exact canonical and translated paths, exact source commit and digest, exact reviewed target digest, canonical UTC review instant, named language/domain reviewer, and disclosed drafting tools | `npm run validate:translations`; `npm run check:prose` for any changed English source |
 | Container report | Per-experiment image digest, tag, source revision, `linux/amd64`, exact command, output mount and `NO_RESULT` receipt | Run the image's smoke, analysis and validation actions with networking disabled |
 | Experiment change | Fixture/track and claim IDs, frozen inputs, bounds, controls, failure state, output identity and authority impact | `npm run validate:workstation`; the affected fixture tests |
 | Evidence or mechanism change | Primary locators, proposition actually supported, scope, uncertainty, nearest claim and principle IDs, strongest null | Documentation, coverage and taxonomy validators relevant to the changed authority |

--- a/public/downloads/book-manifest.json
+++ b/public/downloads/book-manifest.json
@@ -4,7 +4,7 @@
   "version": "0.3.0",
   "source_ref": "main",
   "pdf": "public/downloads/20-watts-was-enough-full-concept-book.pdf",
-  "source_digest": "1c4754287f56d6971758f33c7788cd48c05eb9c8453ee4364edb2cb19090b9b6",
+  "source_digest": "0f71572d58fa531deb2266faf333456ab45df53d1b41b2023a5c4afcd2a878a3",
   "source_files": [
     "app/book-content.ts",
     "app/components/book-edition.tsx",

--- a/scripts/book-pdf-semantic-baseline.json
+++ b/scripts/book-pdf-semantic-baseline.json
@@ -7,7 +7,7 @@
     "pdf": "public/downloads/20-watts-was-enough-full-concept-book.pdf",
     "manifest": "public/downloads/book-manifest.json",
     "pdf_sha256": "06a06d8f5cf2df794ed6ebea037baa3e1a6a7ed7045659296aa165486be74244",
-    "manifest_sha256": "c29bb8fccfb6f386f8e3395effd301b6462a620711c0be0ef905eac113af16ec",
+    "manifest_sha256": "286d64b22ea4e968ffecb3008746c0444d4ee846eeb91870adb9c2d06cb95715",
     "size_bytes": 12780949,
     "pages": 412,
     "page_size_name": "A4",
@@ -18,7 +18,7 @@
     "pdf_version": "1.4",
     "tagged": true,
     "source_ref": "main",
-    "source_digest": "1c4754287f56d6971758f33c7788cd48c05eb9c8453ee4364edb2cb19090b9b6",
+    "source_digest": "0f71572d58fa531deb2266faf333456ab45df53d1b41b2023a5c4afcd2a878a3",
     "version": "0.3.0"
   },
   "tools": {

--- a/scripts/language-access.test.mjs
+++ b/scripts/language-access.test.mjs
@@ -2,6 +2,10 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
 import {
+  languageAvailability,
+  languageAvailabilityForRoute,
+  languageAlternateLinksForRoute,
+  languageDestinationUrl,
   officialEuLanguages,
   reviewedTranslationUrl,
   translationContributionUrl,
@@ -12,6 +16,12 @@ import {
 } from "../app/lib/eu-languages.mjs";
 import languageRegistry from "../translations/eu-languages.json" with { type: "json" };
 import { parseStrictJson } from "./lib/strict-json.mjs";
+
+const reviewedGermanThesis = Object.freeze({
+  language: "de",
+  sourceRoute: "/concept/00-thesis-and-principles/",
+  route: "/de/concept/00-thesis-and-principles/",
+});
 
 test("language access enumerates the 24 official EU languages once", () => {
   const codes = officialEuLanguages.map(([code]) => code);
@@ -65,19 +75,165 @@ test("the shared EU language registry fails closed on identity, order, bounds, a
   assert.throws(() => validateEuLanguageRegistry(oversizedLabel), /exact ordered 24-code records/u);
 });
 
-test("unreviewed languages route to a contribution issue, never machine output", () => {
+test("reading destinations contain only English and route-matched reviewed translations", () => {
   const location = {
     pathname: "/concept/00-thesis-and-principles/",
     search: "?view=reader",
     hash: "#efficiency",
   };
+  const availability = languageAvailability(location, {
+    documents: [reviewedGermanThesis],
+  });
+  assert.deepEqual(
+    availability.available.map(({ code }) => code),
+    ["en", "de"],
+  );
+  assert.equal(availability.unavailable.length, 22);
+  assert.equal(availability.unavailable.some(({ code }) => code === "de"), false);
+  assert.equal(availability.available.find(({ code }) => code === "en")?.current, true);
+  assert.equal(
+    reviewedTranslationUrl("de", location, { documents: [reviewedGermanThesis] }),
+    "/de/concept/00-thesis-and-principles/#efficiency",
+  );
+  assert.equal(
+    reviewedTranslationUrl("fr", location, { documents: [reviewedGermanThesis] }),
+    null,
+  );
+});
+
+test("availability follows the current source route and strips the configured Pages base", () => {
+  const otherRoute = languageAvailabilityForRoute(
+    "/concept/10-learning-memory-and-plasticity/",
+    [reviewedGermanThesis],
+  );
+  assert.deepEqual(otherRoute.available.map(({ code }) => code), ["en"]);
+  assert.equal(otherRoute.unavailable.some(({ code }) => code === "de"), true);
+
+  const translated = {
+    pathname: "/research/de/concept/00-thesis-and-principles/",
+    hash: "#scope",
+  };
+  const translatedAvailability = languageAvailability(translated, {
+    basePath: "/research/",
+    documents: [reviewedGermanThesis],
+  });
+  assert.equal(translatedAvailability.currentLanguage, "de");
+  assert.equal(
+    languageDestinationUrl("en", translated, {
+      basePath: "/research/",
+      documents: [reviewedGermanThesis],
+    }),
+    "/research/concept/00-thesis-and-principles/#scope",
+  );
+});
+
+test("hydrated language destinations preserve root and explicit Pages bases", () => {
+  const canonical = {
+    pathname: "/concept/00-thesis-and-principles/",
+    hash: "#scope",
+  };
+  assert.equal(
+    languageDestinationUrl("de", canonical, {
+      basePath: "/",
+      documents: [reviewedGermanThesis],
+    }),
+    "/de/concept/00-thesis-and-principles/#scope",
+  );
+
+  const preview = {
+    pathname: "/preview/concept/00-thesis-and-principles/",
+    hash: "#scope",
+  };
+  assert.equal(
+    languageDestinationUrl("de", preview, {
+      basePath: "/preview/",
+      documents: [reviewedGermanThesis],
+    }),
+    "/preview/de/concept/00-thesis-and-principles/#scope",
+  );
+});
+
+test("language alternates are reciprocal self-and-peer links from one route projection", () => {
+  const expected = [
+    {
+      language: "en",
+      href: "https://www.cordana.dev/concept/00-thesis-and-principles/",
+    },
+    {
+      language: "de",
+      href: "https://www.cordana.dev/de/concept/00-thesis-and-principles/",
+    },
+  ];
+  assert.deepEqual(
+    languageAlternateLinksForRoute(
+      "/concept/00-thesis-and-principles/",
+      [reviewedGermanThesis],
+    ),
+    expected,
+  );
+  assert.deepEqual(
+    languageAlternateLinksForRoute(
+      "/de/concept/00-thesis-and-principles/",
+      [reviewedGermanThesis],
+    ),
+    expected,
+  );
+  assert.deepEqual(
+    languageAlternateLinksForRoute("/concept/untranslated/", [reviewedGermanThesis]),
+    [],
+  );
+});
+
+test("unavailable languages use a separate source-bound contribution route", () => {
+  const location = {
+    pathname: "/concept/00-thesis-and-principles/",
+    hash: "#efficiency",
+  };
   assert.equal(reviewedTranslationUrl("de", location), null);
-  const contribution = new URL(translationContributionUrl("de", location));
+  const contribution = new URL(translationContributionUrl(location));
   assert.equal(contribution.origin, "https://github.com");
   assert.equal(contribution.searchParams.get("template"), "translation-problem.yml");
-  assert.match(contribution.searchParams.get("title"), /de: \/concept\/00-thesis-and-principles\//);
-  assert.equal(translationContributionUrl("en", location), null);
-  assert.equal(translationContributionUrl("invalid", location), null);
+  assert.equal(
+    contribution.searchParams.get("title"),
+    "[Translation] /concept/00-thesis-and-principles/",
+  );
+  assert.match(
+    contribution.searchParams.get("source"),
+    /^https:\/\/www\.cordana\.dev\/concept\/00-thesis-and-principles\/ at commit or release:/u,
+  );
+});
+
+test("availability rejects malformed and duplicate route projections", () => {
+  assert.throws(
+    () => languageAvailabilityForRoute("/concept/source/", [{
+      language: "de",
+      sourceRoute: "/concept/source/",
+      route: "/fr/concept/source/",
+    }]),
+    /unsafe routes/u,
+  );
+  assert.throws(
+    () => languageAvailabilityForRoute(
+      "/concept/00-thesis-and-principles/",
+      [reviewedGermanThesis, reviewedGermanThesis],
+    ),
+    /repeats de:/u,
+  );
+  assert.throws(
+    () => languageAlternateLinksForRoute("/concept/source/", [{
+      language: "de",
+      sourceRoute: "/concept/source/",
+      route: "/fr/concept/source/",
+    }]),
+    /unsafe routes/u,
+  );
+  assert.throws(
+    () => languageAlternateLinksForRoute(
+      "/concept/00-thesis-and-principles/",
+      [reviewedGermanThesis, reviewedGermanThesis],
+    ),
+    /repeats de:/u,
+  );
 });
 
 test("portal and web book share one labelled language control", async () => {
@@ -86,11 +242,13 @@ test("portal and web book share one labelled language control", async () => {
     readFile("app/components/public-research-portal.tsx", "utf8"),
     readFile("app/components/book-edition.tsx", "utf8"),
   ]);
-  assert.match(portal, /<LanguageAccess\s*\/>/);
-  assert.match(book, /!isPublicPdf && <LanguageAccess\s*\/>/);
+  assert.match(portal, /<LanguageAccess basePath=\{assetBasePath\}\s*\/>/);
+  assert.match(book, /!isPublicPdf && <LanguageAccess basePath=\{assetBasePath\}\s*\/>/);
+  assert.match(control, /availability\.available\.map/);
+  assert.doesNotMatch(control, /officialEuLanguages\.map/);
   assert.match(control, /Open reviewed translation/);
-  assert.match(control, /Help translate or review this page/);
-  assert.match(control, /No automatic translation is presented as project text/);
+  assert.match(control, /Help add or review a language/);
+  assert.match(control, /translations tied to this source version/);
   assert.doesNotMatch(control, /Google|translate\.google/);
   assert.doesNotMatch(control, /<script|dangerouslySetInnerHTML|window\.location\.(?:assign|replace)/);
 });

--- a/scripts/lib/git-test-fixture.mjs
+++ b/scripts/lib/git-test-fixture.mjs
@@ -1,0 +1,49 @@
+import { spawnSync } from "node:child_process";
+import { devNull } from "node:os";
+
+const gitEnvironment = Object.freeze({
+  GIT_AUTHOR_DATE: "2026-09-05T00:00:00Z",
+  GIT_AUTHOR_EMAIL: "fixture@example.invalid",
+  GIT_AUTHOR_NAME: "Translation fixture",
+  GIT_COMMITTER_DATE: "2026-09-05T00:00:00Z",
+  GIT_COMMITTER_EMAIL: "fixture@example.invalid",
+  GIT_COMMITTER_NAME: "Translation fixture",
+  GIT_CONFIG_GLOBAL: devNull,
+  GIT_CONFIG_NOSYSTEM: "1",
+  GIT_OPTIONAL_LOCKS: "0",
+  LANG: "C",
+  LC_ALL: "C",
+  PATH: process.env.PATH ?? "",
+});
+
+export function runFixtureGit(root, arguments_, input = undefined) {
+  const result = spawnSync("git", ["-C", root, ...arguments_], {
+    encoding: "utf8",
+    env: gitEnvironment,
+    input,
+    killSignal: "SIGKILL",
+    maxBuffer: 1024 * 1024,
+    timeout: 10_000,
+    windowsHide: true,
+  });
+  if (result.error || result.signal !== null || result.status !== 0) {
+    throw new Error(`Fixture Git command failed: git ${arguments_.join(" ")}`);
+  }
+  return result.stdout.trim();
+}
+
+export function initialiseFixtureGitRepository(root, paths) {
+  runFixtureGit(root, ["init", "--quiet"]);
+  return commitFixturePaths(root, paths, "reviewed source fixture");
+}
+
+export function commitFixturePaths(root, paths, message = "publication fixture") {
+  runFixtureGit(root, ["add", "--", ...paths]);
+  runFixtureGit(root, ["commit", "--quiet", "-m", message]);
+  return runFixtureGit(root, ["rev-parse", "HEAD"]);
+}
+
+export function createUnrelatedFixtureCommit(root) {
+  const tree = runFixtureGit(root, ["write-tree"]);
+  return runFixtureGit(root, ["commit-tree", tree, "-m", "unrelated source fixture"]);
+}

--- a/scripts/lib/pages-seo.mjs
+++ b/scripts/lib/pages-seo.mjs
@@ -9,6 +9,7 @@ import {
   bookDocumentHeadingId,
   bookDocumentId,
 } from "../../app/lib/book-document-id.mjs";
+import { repositoryDocumentHref } from "../../app/lib/book-release-identity.mjs";
 import { openGraphLocaleForEuLanguage } from "../../app/lib/eu-languages.mjs";
 import {
   languageAlternateLinksForRoute,
@@ -19,6 +20,7 @@ import {
   publication,
   repositoryIssueUrl,
 } from "../../app/lib/publication.mjs";
+import { validateTranslationReviewMetadata } from "./translation-manifest.mjs";
 
 export const canonicalSite = publication.canonicalSite;
 const siteName = publication.siteName;
@@ -337,6 +339,20 @@ function renderPrimaryNavigation(basePath, label) {
   return `<nav aria-label="${label}"><a href="${withBase(basePath)}">Overview</a><a href="${withBase(basePath, "#research-system")}">Research system</a><a href="${withBase(basePath, "#library")}">Library</a><a href="${withBase(basePath, "book/")}">Book</a><a href="${repository}">GitHub <span aria-hidden="true">↗</span></a></nav>`;
 }
 
+export function renderTranslationReviewContext(document) {
+  const review = validateTranslationReviewMetadata(
+    document,
+    document.path ?? document.route ?? "translated document",
+  );
+  const source = repositoryDocumentHref(
+    review.sourceRevision,
+    document.canonicalSourcePath,
+  );
+  const revision = review.sourceRevision.match(/.{1,8}/gu)?.join("<wbr>")
+    ?? review.sourceRevision;
+  return `<section class="translation-review-context" lang="en" aria-labelledby="translation-review-context-heading"><h2 id="translation-review-context-heading">Translation review</h2><dl><div><dt>Canonical source</dt><dd><a href="${escapeAttribute(source)}">Open the bound source</a></dd></div><div><dt>Source revision</dt><dd><code>${revision}</code></dd></div><div><dt>Reviewed at</dt><dd><time datetime="${escapeAttribute(review.reviewedAt)}">${escapeAttribute(review.reviewedAt)}</time></dd></div></dl></section>`;
+}
+
 export function renderLanguageAvailability(route, translationDocuments, basePath) {
   const availability = languageAvailabilityForRoute(route, translationDocuments);
   const destinations = availability.available.map((destination) => {
@@ -403,8 +419,8 @@ export function renderDocumentFallback(
         `[Translation] ${document.language}: ${document.canonicalSourcePath}`,
         {
           language: document.language,
-          source: `${document.canonicalSourcePath} at source SHA-256 ${document.sourceSha256}`,
-          detail: `Published route: ${canonicalSite}${document.route}\nReviewed target SHA-256: ${document.targetSha256}`,
+          source: `${document.canonicalSourcePath} at commit ${document.sourceRevision} (source SHA-256 ${document.sourceSha256})`,
+          detail: `Published route: ${canonicalSite}${document.route}\nReviewed at: ${document.reviewedAt}\nReviewed target SHA-256: ${document.targetSha256}`,
           competence: `Recorded reviewer(s): ${document.reviewers.join(", ")}`,
         },
       )
@@ -420,7 +436,8 @@ export function renderDocumentFallback(
     translationDocuments,
     basePath,
   );
-  return `<main class="seo-static-page"><p${shellLanguage}><a href="${withBase(basePath)}">Research portal</a></p><header><p${shellLanguage}>${document.group} · ${document.words.toLocaleString(publication.locale)} words</p><h1>${escapeAttribute(document.title)}</h1><p>${escapeAttribute(document.description)}</p></header>${languages}${support}<article class="prose markdown-body">${renderMarkdown(document, documents, basePath)}</article><nav${shellLanguage} aria-label="Document sequence">${sequence}</nav></main>`;
+  const reviewContext = translated ? renderTranslationReviewContext(document) : "";
+  return `<main class="seo-static-page"><p${shellLanguage}><a href="${withBase(basePath)}">Research portal</a></p><header><p${shellLanguage}>${document.group} · ${document.words.toLocaleString(publication.locale)} words</p><h1>${escapeAttribute(document.title)}</h1><p>${escapeAttribute(document.description)}</p></header>${reviewContext}${languages}${support}<article class="prose markdown-body">${renderMarkdown(document, documents, basePath)}</article><nav${shellLanguage} aria-label="Document sequence">${sequence}</nav></main>`;
 }
 
 export function renderHelpFallback(document, documents, basePath) {

--- a/scripts/lib/pages-seo.mjs
+++ b/scripts/lib/pages-seo.mjs
@@ -11,6 +11,11 @@ import {
 } from "../../app/lib/book-document-id.mjs";
 import { openGraphLocaleForEuLanguage } from "../../app/lib/eu-languages.mjs";
 import {
+  languageAlternateLinksForRoute,
+  languageAvailabilityForRoute,
+  translationContributionUrl,
+} from "../../app/lib/language-access.mjs";
+import {
   publication,
   repositoryIssueUrl,
 } from "../../app/lib/publication.mjs";
@@ -139,7 +144,7 @@ function structuredData(kind, document) {
   };
 }
 
-export function renderSeoHead(kind, document, basePath) {
+export function renderSeoHead(kind, document, basePath, translationDocuments = []) {
   const canonical = canonicalFor(kind, document);
   const language = pageLanguage(kind, document);
   const openGraphLocale = openGraphLocaleForEuLanguage(language);
@@ -148,6 +153,13 @@ export function renderSeoHead(kind, document, basePath) {
   }
   const metadata = pageMetadata(kind, document);
   const jsonLd = JSON.stringify(structuredData(kind, document)).replaceAll("<", "\\u003c");
+  const languageAlternates = kind === "document"
+    ? languageAlternateLinksForRoute(document.route, translationDocuments).map(
+        (alternative) => (
+          `<link rel="alternate" hreflang="${escapeAttribute(alternative.language)}" href="${escapeAttribute(alternative.href)}" data-language-alternate="" />`
+        ),
+      )
+    : [];
   return [
     `<meta name="description" content="${escapeAttribute(metadata.description)}" />`,
     '<meta name="robots" content="index,follow,max-image-preview:large" />',
@@ -169,6 +181,7 @@ export function renderSeoHead(kind, document, basePath) {
     `<meta name="citation_public_url" content="${canonical}" />`,
     `<meta name="citation_language" content="${escapeAttribute(language)}" />`,
     `<link rel="canonical" href="${canonical}" />`,
+    ...languageAlternates,
     `<link rel="icon" href="${withBase(basePath, "favicon.svg")}" />`,
     `<script type="application/ld+json">${jsonLd}</script>`,
     `<title>${escapeAttribute(metadata.title)}</title>`,
@@ -324,17 +337,35 @@ function renderPrimaryNavigation(basePath, label) {
   return `<nav aria-label="${label}"><a href="${withBase(basePath)}">Overview</a><a href="${withBase(basePath, "#research-system")}">Research system</a><a href="${withBase(basePath, "#library")}">Library</a><a href="${withBase(basePath, "book/")}">Book</a><a href="${repository}">GitHub <span aria-hidden="true">↗</span></a></nav>`;
 }
 
-export function renderPortalFallback(documents, basePath) {
+export function renderLanguageAvailability(route, translationDocuments, basePath) {
+  const availability = languageAvailabilityForRoute(route, translationDocuments);
+  const destinations = availability.available.map((destination) => {
+    const language = escapeAttribute(destination.code);
+    const label = escapeAttribute(destination.label);
+    if (destination.current) {
+      return `<li><span aria-current="page"><span lang="${language}">${label}</span> · current</span></li>`;
+    }
+    return `<li><a lang="${language}" hreflang="${language}" href="${withBase(basePath, destination.route)}">${label}</a></li>`;
+  }).join("");
+  const contribution = translationContributionUrl(
+    { pathname: route, hash: "" },
+    { documents: translationDocuments },
+  );
+  return `<nav class="seo-language-access" lang="en" aria-label="Language availability"><strong>Read this page</strong><ul>${destinations}</ul><a href="${escapeAttribute(contribution)}">Help add or review a language</a></nav>`;
+}
+
+export function renderPortalFallback(documents, basePath, translationDocuments = []) {
   const groups = ["Concept", "Mathematics"].map((group) => {
     const links = documents.filter((document) => document.group === group)
       .map((document) => `<li>${documentLink(document, basePath)}</li>`)
       .join("");
     return `<section><h2>${group}</h2><ol>${links}</ol></section>`;
   }).join("");
-  return `<main class="seo-static-page"><p class="portal-eyebrow">Open research programme</p><h1>20 Watts Was Enough</h1><p>Can an artificial system learn and adapt while activating less computation and moving less data? This programme turns mechanisms from living and engineered systems into scoped claims, explicit principles and equal-budget tests.</p>${renderReaderSupport(basePath, "research portal", "Report a portal problem")}<nav aria-label="Research library">${groups}</nav><p><a href="${withBase(basePath, "book/")}">Read the full concept book</a></p></main>`;
+  const languages = renderLanguageAvailability("/", translationDocuments, basePath);
+  return `<main class="seo-static-page"><p class="portal-eyebrow">Open research programme</p><h1>20 Watts Was Enough</h1><p>Can an artificial system learn and adapt while activating less computation and moving less data? This programme turns mechanisms from living and engineered systems into scoped claims, explicit principles and equal-budget tests.</p>${languages}${renderReaderSupport(basePath, "research portal", "Report a portal problem")}<nav aria-label="Research library">${groups}</nav><p><a href="${withBase(basePath, "book/")}">Read the full concept book</a></p></main>`;
 }
 
-export function renderBookFallback(documents, basePath) {
+export function renderBookFallback(documents, basePath, translationDocuments = []) {
   if (!Array.isArray(documents) || documents.length === 0) {
     throw new Error("The static book fallback requires at least one canonical document.");
   }
@@ -344,10 +375,16 @@ export function renderBookFallback(documents, basePath) {
   const manuscript = documents.map((document) => (
     `<section id="${bookDocumentId(document.path)}"><header><p>${escapeAttribute(document.group)} · ${document.words.toLocaleString(publication.locale)} words</p><h2>${escapeAttribute(document.title)}</h2></header><article class="prose markdown-body">${renderMarkdown(document, documents, basePath, { bookFragments: true, headingOffset: 1, mathOutput: "mathml" })}</article></section>`
   )).join("");
-  return `<main class="seo-static-page"><a class="portal-skip-link" href="#${bookDocumentId(documents[0].path)}">Skip to first chapter</a><p><a href="${withBase(basePath)}">Research portal</a></p><h1>20 Watts Was Enough — Full Concept Book</h1><p>The complete public reading edition generated from canonical Git source.</p>${renderReaderSupport(basePath, "book/", "Report a book problem")}<nav aria-label="Book contents"><ol>${links}</ol></nav>${manuscript}</main>`;
+  const languages = renderLanguageAvailability("/book/", translationDocuments, basePath);
+  return `<main class="seo-static-page"><a class="portal-skip-link" href="#${bookDocumentId(documents[0].path)}">Skip to first chapter</a><p><a href="${withBase(basePath)}">Research portal</a></p><h1>20 Watts Was Enough — Full Concept Book</h1><p>The complete public reading edition generated from canonical Git source.</p>${languages}${renderReaderSupport(basePath, "book/", "Report a book problem")}<nav aria-label="Book contents"><ol>${links}</ol></nav>${manuscript}</main>`;
 }
 
-export function renderDocumentFallback(document, documents, basePath) {
+export function renderDocumentFallback(
+  document,
+  documents,
+  basePath,
+  translationDocuments = [],
+) {
   const index = documents.findIndex((candidate) => candidate.path === document.path);
   const previous = index > 0 ? documents[index - 1] : null;
   const next = index < documents.length - 1 ? documents[index + 1] : null;
@@ -378,7 +415,12 @@ export function renderDocumentFallback(document, documents, basePath) {
     translated ? "Report this translation" : "Report this document",
     translated ? { issueUrl: report, language: publication.htmlLanguage } : {},
   );
-  return `<main class="seo-static-page"><p${shellLanguage}><a href="${withBase(basePath)}">Research portal</a></p><header><p${shellLanguage}>${document.group} · ${document.words.toLocaleString(publication.locale)} words</p><h1>${escapeAttribute(document.title)}</h1><p>${escapeAttribute(document.description)}</p></header>${support}<article class="prose markdown-body">${renderMarkdown(document, documents, basePath)}</article><nav${shellLanguage} aria-label="Document sequence">${sequence}</nav></main>`;
+  const languages = renderLanguageAvailability(
+    document.route.startsWith("/") ? document.route : `/${document.route}`,
+    translationDocuments,
+    basePath,
+  );
+  return `<main class="seo-static-page"><p${shellLanguage}><a href="${withBase(basePath)}">Research portal</a></p><header><p${shellLanguage}>${document.group} · ${document.words.toLocaleString(publication.locale)} words</p><h1>${escapeAttribute(document.title)}</h1><p>${escapeAttribute(document.description)}</p></header>${languages}${support}<article class="prose markdown-body">${renderMarkdown(document, documents, basePath)}</article><nav${shellLanguage} aria-label="Document sequence">${sequence}</nav></main>`;
 }
 
 export function renderHelpFallback(document, documents, basePath) {

--- a/scripts/lib/translation-manifest.mjs
+++ b/scripts/lib/translation-manifest.mjs
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import path from "node:path";
 
@@ -32,6 +33,11 @@ export const translationManifestLimits = Object.freeze({
   reviewerCharacters: 160,
 });
 
+const gitValidationLimits = Object.freeze({
+  outputBytes: 2 * translationManifestLimits.manifestBytes,
+  timeoutMilliseconds: 10_000,
+});
+
 function inside(root, candidate) {
   const relative = path.relative(root, candidate);
   return relative !== "" && !relative.startsWith("..") && !path.isAbsolute(relative);
@@ -61,6 +67,110 @@ function readTranslationFile(root, file, label, maximumBytes) {
     containedBy: path.dirname(absolute),
     maximumBytes,
   });
+}
+
+function gitCommand(root, arguments_, input, label) {
+  const result = spawnSync("git", ["-C", root, ...arguments_], {
+    encoding: null,
+    env: {
+      GIT_NO_REPLACE_OBJECTS: "1",
+      GIT_OPTIONAL_LOCKS: "0",
+      LANG: "C",
+      LC_ALL: "C",
+      PATH: process.env.PATH ?? "",
+    },
+    input,
+    killSignal: "SIGKILL",
+    maxBuffer: gitValidationLimits.outputBytes,
+    timeout: gitValidationLimits.timeoutMilliseconds,
+    windowsHide: true,
+  });
+  if (result.error || result.signal !== null || result.status !== 0) {
+    throw new Error(`${label} could not be verified in the local Git history.`);
+  }
+  return Buffer.from(result.stdout ?? []);
+}
+
+function gitObjectRecords(root, specifications) {
+  const output = gitCommand(
+    root,
+    ["cat-file", "--batch-check=%(objectname)|%(objecttype)|%(objectsize)|%(objectmode)"],
+    Buffer.from(`${specifications.join("\n")}\n`),
+    "Translation source revisions",
+  ).toString("utf8");
+  const lines = output.endsWith("\n") ? output.slice(0, -1).split("\n") : [];
+  if (lines.length !== specifications.length) {
+    throw new Error("Translation source revision object inventory is incomplete.");
+  }
+  return lines.map((line) => {
+    const match = /^([a-f0-9]{40})\|([a-z]+)\|([0-9]+)\|([0-9]{6})?$/u.exec(line);
+    return match === null ? null : Object.freeze({
+      mode: match[4] ?? null,
+      oid: match[1],
+      type: match[2],
+    });
+  });
+}
+
+function validateSourceRevisionBindings(root, bindings) {
+  if (bindings.length === 0) return;
+  const sourceObjectOutput = gitCommand(
+    root,
+    ["hash-object", "--no-filters", "--stdin-paths"],
+    Buffer.from(`${bindings.map(({ source }) => source).join("\n")}\n`),
+    "Current translation sources",
+  ).toString("utf8");
+  const sourceObjectIds = sourceObjectOutput.endsWith("\n")
+    ? sourceObjectOutput.slice(0, -1).split("\n")
+    : [];
+  if (
+    sourceObjectIds.length !== bindings.length
+    || sourceObjectIds.some((oid) => !/^[a-f0-9]{40}$/u.test(oid))
+  ) {
+    throw new Error("Current translation source object inventory is incomplete.");
+  }
+  const specifications = bindings.flatMap(({ source, sourceRevision }) => [
+    sourceRevision,
+    `${sourceRevision}:${source}`,
+  ]);
+  const objects = gitObjectRecords(root, specifications);
+  for (const [index, binding] of bindings.entries()) {
+    const commit = objects[index * 2];
+    const source = objects[(index * 2) + 1];
+    if (
+      commit?.oid !== binding.sourceRevision
+      || commit.type !== "commit"
+    ) {
+      throw new Error(
+        `Translation source revision is not an available exact commit: ${binding.target}`,
+      );
+    }
+    if (source?.type !== "blob") {
+      throw new Error(
+        `Translation source does not exist at its reviewed commit: ${binding.source}`,
+      );
+    }
+    if (source.mode !== "100644" && source.mode !== "100755") {
+      throw new Error(
+        `Translation source at its reviewed commit is not a regular file: ${binding.source}`,
+      );
+    }
+    if (source.oid !== sourceObjectIds[index]) {
+      throw new Error(
+        `Translation source revision does not bind its recorded source: ${binding.source}`,
+      );
+    }
+  }
+  const revisions = [...new Set(bindings.map(({ sourceRevision }) => sourceRevision))];
+  const unreachable = gitCommand(
+    root,
+    ["rev-list", "--max-count=1", "--stdin"],
+    Buffer.from(`${revisions.join("\n")}\n^HEAD\n`),
+    "Translation source revision ancestry",
+  );
+  if (unreachable.length !== 0) {
+    throw new Error("Translation source revision is not an ancestor of the publication checkout.");
+  }
 }
 
 function validatedReviewers(reviewers, target) {
@@ -185,7 +295,8 @@ function validatedDocuments(root, documents) {
   }
   const identities = new Set();
   const routes = new Set();
-  return Object.freeze(documents.map((entry, index) => {
+  const bindings = [];
+  const validated = documents.map((entry, index) => {
     const review = validateEntryShape(entry, index);
     const identity = `${entry.language}:${entry.source}`;
     if (identities.has(identity) || routes.has(entry.route)) {
@@ -194,6 +305,11 @@ function validatedDocuments(root, documents) {
     identities.add(identity);
     routes.add(entry.route);
     validateEntryFiles(root, entry);
+    bindings.push({
+      source: entry.source,
+      sourceRevision: review.sourceRevision,
+      target: entry.target,
+    });
     return Object.freeze({
       language: entry.language,
       source: entry.source,
@@ -206,7 +322,9 @@ function validatedDocuments(root, documents) {
       reviewedAt: review.reviewedAt,
       reviewers: review.reviewers,
     });
-  }));
+  });
+  validateSourceRevisionBindings(root, bindings);
+  return Object.freeze(validated);
 }
 
 export function validateTranslationManifest(repositoryRoot) {

--- a/scripts/lib/translation-manifest.mjs
+++ b/scripts/lib/translation-manifest.mjs
@@ -8,12 +8,16 @@ import { parseStrictJson } from "./strict-json.mjs";
 
 const SOURCE = /^(?:concept|math)\/(?:[a-z0-9][a-z0-9-]*\/)*[a-z0-9][a-z0-9-]*\.md$/u;
 const SHA256 = /^[a-f0-9]{64}$/u;
+const SOURCE_REVISION = /^(?!0{40}$)[a-f0-9]{40}$/u;
+const REVIEWED_AT = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/u;
 const topLevelFields = Object.freeze(["documents", "schema", "sourceLanguage"]);
 const documentFields = Object.freeze([
   "language",
+  "reviewedAt",
   "reviewers",
   "route",
   "source",
+  "sourceRevision",
   "sourceRoute",
   "sourceSha256",
   "target",
@@ -87,6 +91,30 @@ function validatedReviewers(reviewers, target) {
   return Object.freeze([...reviewers]);
 }
 
+export function validateTranslationReviewMetadata(entry, target) {
+  if (
+    typeof entry.sourceRevision !== "string"
+    || !SOURCE_REVISION.test(entry.sourceRevision)
+  ) {
+    throw new Error(`Translation source revision is not an exact Git commit: ${target}`);
+  }
+  const reviewInstant = typeof entry.reviewedAt === "string"
+    ? Date.parse(entry.reviewedAt)
+    : Number.NaN;
+  if (
+    typeof entry.reviewedAt !== "string"
+    || !REVIEWED_AT.test(entry.reviewedAt)
+    || !Number.isFinite(reviewInstant)
+    || new Date(reviewInstant).toISOString() !== `${entry.reviewedAt.slice(0, -1)}.000Z`
+  ) {
+    throw new Error(`Translation review time is not canonical UTC: ${target}`);
+  }
+  return Object.freeze({
+    sourceRevision: entry.sourceRevision,
+    reviewedAt: entry.reviewedAt,
+  });
+}
+
 function validateEntryShape(entry, index) {
   exactObject(entry, documentFields, `Translation manifest document ${index}`);
   if (
@@ -118,7 +146,10 @@ function validateEntryShape(entry, index) {
   if (typeof entry.targetSha256 !== "string" || !SHA256.test(entry.targetSha256)) {
     throw new Error(`Translation target digest is not SHA-256: ${entry.target}`);
   }
-  return validatedReviewers(entry.reviewers, entry.target);
+  return Object.freeze({
+    ...validateTranslationReviewMetadata(entry, entry.target),
+    reviewers: validatedReviewers(entry.reviewers, entry.target),
+  });
 }
 
 function validateEntryFiles(root, entry) {
@@ -155,7 +186,7 @@ function validatedDocuments(root, documents) {
   const identities = new Set();
   const routes = new Set();
   return Object.freeze(documents.map((entry, index) => {
-    const reviewers = validateEntryShape(entry, index);
+    const review = validateEntryShape(entry, index);
     const identity = `${entry.language}:${entry.source}`;
     if (identities.has(identity) || routes.has(entry.route)) {
       throw new Error(`Duplicate translation identity or route: ${identity}`);
@@ -171,7 +202,9 @@ function validatedDocuments(root, documents) {
       route: entry.route,
       sourceSha256: entry.sourceSha256,
       targetSha256: entry.targetSha256,
-      reviewers,
+      sourceRevision: review.sourceRevision,
+      reviewedAt: review.reviewedAt,
+      reviewers: review.reviewers,
     });
   }));
 }

--- a/scripts/lib/translation-pages.mjs
+++ b/scripts/lib/translation-pages.mjs
@@ -71,6 +71,14 @@ export function translatedSourceDocuments(repositoryRoot, { afterTargetRead } = 
   ));
 }
 
+export function translationAvailabilityRecords(documents) {
+  return Object.freeze(documents.map((document) => Object.freeze({
+    language: document.language,
+    sourceRoute: `/${withoutLeadingSlash(document.canonicalSourceRoute)}`,
+    route: `/${withoutLeadingSlash(document.route)}`,
+  })));
+}
+
 function withHtmlLanguage(template, language) {
   const matches = [...template.matchAll(englishHtmlLanguagePattern)];
   if (matches.length !== 1) {
@@ -79,11 +87,23 @@ function withHtmlLanguage(template, language) {
   return template.replace(englishHtmlLanguagePattern, `<html lang="${language}">`);
 }
 
-export function renderTranslationPage({ template, document, documents, basePath }) {
+export function renderTranslationPage({
+  template,
+  document,
+  documents,
+  availabilityDocuments = documents,
+  basePath,
+}) {
+  const availability = translationAvailabilityRecords(availabilityDocuments);
   return populateSeoTemplate(
     withHtmlLanguage(template, document.language),
-    renderSeoHead("document", document, basePath),
-    renderDocumentFallback(document, documents, basePath),
+    renderSeoHead("document", document, basePath, availability),
+    renderDocumentFallback(
+      document,
+      documents,
+      basePath,
+      availability,
+    ),
   );
 }
 
@@ -115,6 +135,7 @@ export function writeTranslationPages({
       template,
       document,
       documents: cohort,
+      availabilityDocuments: documents,
       basePath,
     }), "utf8");
     written.push(relative.replaceAll("\\", "/"));

--- a/scripts/lib/translation-pages.mjs
+++ b/scripts/lib/translation-pages.mjs
@@ -62,6 +62,8 @@ export function translatedSourceDocuments(repositoryRoot, { afterTargetRead } = 
     canonicalSourceRoute: withoutLeadingSlash(entry.sourceRoute),
     sourceSha256: entry.sourceSha256,
     targetSha256: entry.targetSha256,
+    sourceRevision: entry.sourceRevision,
+    reviewedAt: entry.reviewedAt,
     reviewers: entry.reviewers,
   })).sort((left, right) => (
     left.language.localeCompare(right.language)

--- a/scripts/mermaid-browser.test.mjs
+++ b/scripts/mermaid-browser.test.mjs
@@ -539,11 +539,12 @@ async function assertMobilePortalSurface(cdp, address) {
     await new Promise((resolve) => setTimeout(resolve, 100));
   }
   assert.equal(ready, true, "Portal language control did not render");
+  await openLanguageControlWithKeyboard(cdp);
   const snapshot = (await cdp.send("Runtime.evaluate", {
     expression: `(() => {
-      document.querySelector(".language-access > summary").click();
       const panel = document.querySelector(".language-access-panel");
       const select = panel?.querySelector("select");
+      const help = panel?.querySelector(".language-access-help");
       const panelRect = panel?.getBoundingClientRect();
       const selectRect = select?.getBoundingClientRect();
       const parseColour = (value) => {
@@ -588,6 +589,12 @@ async function assertMobilePortalSurface(cdp, address) {
           statusLabel: contrastFor(".portal-overview-metrics dt"),
         },
         scrollWidth: document.documentElement.scrollWidth,
+        expandedByKeyboard: document.querySelector(".language-access")?.open === true,
+        focusedOutline: getComputedStyle(document.activeElement).outlineStyle,
+        focusedOutlineWidth: getComputedStyle(document.activeElement).outlineWidth,
+        label: panel?.querySelector('label[for="site-language"]')?.textContent,
+        optionCodes: [...(select?.options ?? [])].map((option) => option.value),
+        help: help && { href: help.href, text: help.textContent.trim() },
         panel: panelRect && { left: panelRect.left, right: panelRect.right, width: panelRect.width },
         select: selectRect && { left: selectRect.left, right: selectRect.right, width: selectRect.width },
       };
@@ -596,6 +603,13 @@ async function assertMobilePortalSurface(cdp, address) {
   })).result?.value;
   assert.ok(snapshot.panel, JSON.stringify(snapshot));
   assert.ok(snapshot.select, JSON.stringify(snapshot));
+  assert.equal(snapshot.expandedByKeyboard, true, JSON.stringify(snapshot));
+  assert.equal(snapshot.focusedOutline, "solid", JSON.stringify(snapshot));
+  assert.equal(snapshot.focusedOutlineWidth, "3px", JSON.stringify(snapshot));
+  assert.equal(snapshot.label, "Read this page", JSON.stringify(snapshot));
+  assert.deepEqual(snapshot.optionCodes, ["en"], JSON.stringify(snapshot));
+  assert.equal(snapshot.help?.text, "Help add or review a language", JSON.stringify(snapshot));
+  assert.match(snapshot.help?.href ?? "", /template=translation-problem\.yml/u);
   assert.ok(snapshot.panel.left >= 0, JSON.stringify(snapshot));
   assert.ok(snapshot.panel.right <= snapshot.clientWidth, JSON.stringify(snapshot));
   assert.ok(snapshot.select.left >= 0, JSON.stringify(snapshot));
@@ -657,6 +671,34 @@ async function assertConstrainedMobileMenu(cdp) {
   assert.ok(snapshot.lastLink.top >= snapshot.panel.top - 1, JSON.stringify(snapshot));
   assert.ok(snapshot.lastLink.bottom <= snapshot.panel.bottom + 1, JSON.stringify(snapshot));
   assert.ok(snapshot.scrollWidth <= snapshot.clientWidth, JSON.stringify(snapshot));
+}
+
+async function openLanguageControlWithKeyboard(cdp) {
+  await cdp.send("Runtime.evaluate", {
+    expression: `document.querySelector(".language-access > summary").focus()`,
+  });
+  await cdp.send("Input.dispatchKeyEvent", {
+    type: "rawKeyDown",
+    key: " ",
+    code: "Space",
+    windowsVirtualKeyCode: 32,
+    nativeVirtualKeyCode: 32,
+  });
+  await cdp.send("Input.dispatchKeyEvent", {
+    type: "char",
+    text: " ",
+    key: " ",
+    code: "Space",
+    windowsVirtualKeyCode: 32,
+    nativeVirtualKeyCode: 32,
+  });
+  await cdp.send("Input.dispatchKeyEvent", {
+    type: "keyUp",
+    key: " ",
+    code: "Space",
+    windowsVirtualKeyCode: 32,
+    nativeVirtualKeyCode: 32,
+  });
 }
 
 test("browser rendering keeps Mermaid stable and wide publication content keyboard operable", {

--- a/scripts/pages-seo.test.mjs
+++ b/scripts/pages-seo.test.mjs
@@ -17,11 +17,13 @@ import {
   renderBookFallback,
   renderDocumentFallback,
   renderHelpFallback,
+  renderLanguageAvailability,
   renderPortalFallback,
   renderRobots,
   renderSeoHead,
   renderSitemap,
 } from "./lib/pages-seo.mjs";
+import { resolvePagesBase } from "./lib/pages-base.mjs";
 
 const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const portalStylesheet = await readFile(path.join(repositoryRoot, "app/portal.css"), "utf8");
@@ -104,7 +106,7 @@ test("the local Pages server renders the canonical no-JavaScript help page", asy
   const handler = typeof transform === "function" ? transform : transform?.handler;
   assert.ok(handler);
   const rendered = await handler.call({}, template, {
-    path: "/help/",
+    path: `${resolvePagesBase(process.env.PAGES_BASE_PATH)}help/`,
     filename: path.join(repositoryRoot, "github-pages", "help", "index.html"),
     server: {},
   });
@@ -149,6 +151,25 @@ test("no-JS reading fallbacks expose help and source-bound issue routes", () => 
     assert.ok(fallback.includes('href="/research/help/">How to help</a>'));
     assert.ok(fallback.includes(`href="${issueHref}">${reportLabel}</a>`));
   }
+});
+
+test("no-JS language navigation separates published editions from contribution", () => {
+  const route = "/concept/00-thesis-and-principles/";
+  const translationDocuments = [{
+    language: "de",
+    sourceRoute: route,
+    route: `/de${route}`,
+  }];
+  const canonical = renderLanguageAvailability(route, translationDocuments, "/research/");
+  assert.match(canonical, /<strong>Read this page<\/strong>/u);
+  assert.match(canonical, /<span aria-current="page"><span lang="en">English<\/span> · current<\/span>/u);
+  assert.match(canonical, /lang="de" hreflang="de" href="\/research\/de\/concept\/00-thesis-and-principles\/">Deutsch<\/a>/u);
+  assert.match(canonical, />Help add or review a language<\/a>/u);
+  assert.doesNotMatch(canonical, />Français<\/a>/u);
+
+  const translated = renderLanguageAvailability(`/de${route}`, translationDocuments, "/research/");
+  assert.match(translated, /href="\/research\/concept\/00-thesis-and-principles\/">English<\/a>/u);
+  assert.match(translated, /<span aria-current="page"><span lang="de">Deutsch<\/span> · current<\/span>/u);
 });
 
 test("the no-JS book fallback carries the canonical manuscript and nested headings", () => {
@@ -249,6 +270,45 @@ test("document metadata carries a reviewed translation language", () => {
   );
 });
 
+test("canonical and translated document heads expose reciprocal language alternates", () => {
+  const source = documents[0];
+  const sourceRoute = `/${source.route}`;
+  const translatedRoute = `/de/${source.route}`;
+  const translationDocuments = [{
+    language: "de",
+    sourceRoute,
+    route: translatedRoute,
+  }];
+  const translated = {
+    ...source,
+    language: "de",
+    route: translatedRoute.slice(1),
+  };
+  const expected = [
+    `<link rel="alternate" hreflang="en" href="${canonicalSite}${source.route}" data-language-alternate="" />`,
+    `<link rel="alternate" hreflang="de" href="${canonicalSite}${translated.route}" data-language-alternate="" />`,
+  ];
+
+  for (const page of [source, translated]) {
+    const head = renderSeoHead("document", page, "/research/", translationDocuments);
+    for (const alternate of expected) assert.ok(head.includes(alternate));
+    assert.equal((head.match(/rel="alternate" hreflang=/gu) ?? []).length, 2);
+  }
+
+  assert.doesNotMatch(
+    renderSeoHead("document", source, "/research/"),
+    /rel="alternate" hreflang=/u,
+  );
+  assert.throws(
+    () => renderSeoHead("document", source, "/research/", [{
+      language: "de",
+      sourceRoute,
+      route: `/fr/${source.route}`,
+    }]),
+    /unsafe routes/u,
+  );
+});
+
 test("translated Markdown resolves media and links from its canonical source", () => {
   const source = documents[0];
   const peer = documents[1];
@@ -282,6 +342,11 @@ test("translated Markdown resolves media and links from its canonical source", (
     translated,
     [translated, translatedPeer],
     "/research/",
+    [{
+      language: "de",
+      sourceRoute: `/${source.route}`,
+      route: `/${translated.route}`,
+    }],
   );
 
   assert.ok(fallback.includes('href="#scope"'));
@@ -293,6 +358,8 @@ test("translated Markdown resolves media and links from its canonical source", (
   assert.match(fallback, /<p lang="en"><a href="\/research\/">Research portal<\/a><\/p>/);
   assert.match(fallback, /<nav lang="en" aria-label="Reader support">/);
   assert.match(fallback, /<nav lang="en" aria-label="Document sequence">/);
+  assert.match(fallback, /<nav class="seo-language-access" lang="en" aria-label="Language availability">/);
+  assert.match(fallback, /<span aria-current="page"><span lang="de">Deutsch<\/span> · current<\/span>/u);
   assert.match(fallback, /<span lang="de">/);
   const issue = new URL(
     fallback.match(/href="([^"]+)">Report this translation<\/a>/u)?.[1].replaceAll("&amp;", "&") ?? "",

--- a/scripts/pages-seo.test.mjs
+++ b/scripts/pages-seo.test.mjs
@@ -329,6 +329,8 @@ test("translated Markdown resolves media and links from its canonical source", (
     route: `de/${source.route}`,
     sourceSha256: "a".repeat(64),
     targetSha256: "b".repeat(64),
+    sourceRevision: "facac8c699a5c6e2ac258f30209a96ba06dca741",
+    reviewedAt: "2026-09-05T00:00:00Z",
     reviewers: ["reviewer-handle"],
   };
   const translatedPeer = {
@@ -360,14 +362,24 @@ test("translated Markdown resolves media and links from its canonical source", (
   assert.match(fallback, /<nav lang="en" aria-label="Document sequence">/);
   assert.match(fallback, /<nav class="seo-language-access" lang="en" aria-label="Language availability">/);
   assert.match(fallback, /<span aria-current="page"><span lang="de">Deutsch<\/span> · current<\/span>/u);
+  assert.match(fallback, /aria-labelledby="translation-review-context-heading"/u);
+  assert.match(
+    fallback,
+    /blob\/facac8c699a5c6e2ac258f30209a96ba06dca741\/concept\//u,
+  );
+  assert.match(fallback, /datetime="2026-09-05T00:00:00Z"/u);
   assert.match(fallback, /<span lang="de">/);
   const issue = new URL(
     fallback.match(/href="([^"]+)">Report this translation<\/a>/u)?.[1].replaceAll("&amp;", "&") ?? "",
   );
   assert.equal(issue.searchParams.get("template"), "translation-problem.yml");
   assert.equal(issue.searchParams.get("language"), "de");
-  assert.match(issue.searchParams.get("source"), new RegExp(`^${source.path} at source SHA-256 `));
+  assert.equal(
+    issue.searchParams.get("source"),
+    `${source.path} at commit facac8c699a5c6e2ac258f30209a96ba06dca741 (source SHA-256 ${"a".repeat(64)})`,
+  );
   assert.match(issue.searchParams.get("detail"), new RegExp(`${translated.route}`));
+  assert.match(issue.searchParams.get("detail"), /Reviewed at: 2026-09-05T00:00:00Z/u);
   assert.match(issue.searchParams.get("competence"), /^Recorded reviewer\(s\): /u);
   assert.doesNotMatch(fallback, /template=site-documentation-problem\.yml/u);
 });

--- a/scripts/publication-unification.test.mjs
+++ b/scripts/publication-unification.test.mjs
@@ -17,11 +17,14 @@ import { portalSourceMetrics } from "./lib/portal-metrics.mjs";
 
 const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
-function staticDescriptor(kind, document) {
-  const head = renderSeoHead(kind, document, "/");
+function staticDescriptor(kind, document, translationDocuments = []) {
+  const head = renderSeoHead(kind, document, "/", translationDocuments);
   const value = (pattern) => decodeBasicHtmlEntitiesOnce(head.match(pattern)?.[1] ?? "");
   return {
     canonical: value(/<link rel="canonical" href="([^"]+)" \/>/u),
+    languageAlternates: [...head.matchAll(
+      /<link rel="alternate" hreflang="([^"]+)" href="([^"]+)" data-language-alternate="" \/>/gu,
+    )].map((match) => ({ language: match[1], href: decodeBasicHtmlEntitiesOnce(match[2]) })),
     title: value(/<title>([^<]+)<\/title>/u),
     description: value(/<meta name="description" content="([^"]+)" \/>/u),
     ogType: value(/<meta property="og:type" content="([^"]+)" \/>/u),
@@ -44,6 +47,19 @@ test("dynamic portal SEO stays equal to the generated static descriptor", () => 
   const document = portalSourceDocuments(repositoryRoot)[0];
   assert.deepEqual(portalSeoDescriptor(null), staticDescriptor("portal", null));
   assert.deepEqual(portalSeoDescriptor(document), staticDescriptor("document", document));
+});
+
+test("dynamic and static document SEO share reciprocal reviewed-language alternates", () => {
+  const document = portalSourceDocuments(repositoryRoot)[0];
+  const translationDocuments = [{
+    language: "de",
+    sourceRoute: `/${document.route}`,
+    route: `/de/${document.route}`,
+  }];
+  assert.deepEqual(
+    portalSeoDescriptor(document, translationDocuments),
+    staticDescriptor("document", document, translationDocuments),
+  );
 });
 
 test("source HTML identity placeholders stay equal to the shared publication authority", async () => {

--- a/scripts/translation-manifest.test.mjs
+++ b/scripts/translation-manifest.test.mjs
@@ -16,6 +16,12 @@ import {
   translationManifestLimits,
   validateTranslationManifest,
 } from "./lib/translation-manifest.mjs";
+import {
+  commitFixturePaths,
+  createUnrelatedFixtureCommit,
+  initialiseFixtureGitRepository,
+  runFixtureGit,
+} from "./lib/git-test-fixture.mjs";
 
 async function writeManifest(root, manifest) {
   await writeFile(
@@ -31,6 +37,7 @@ async function fixture(t) {
   await mkdir(path.join(root, "concept"), { recursive: true });
   await mkdir(path.join(root, "translations", "de", "concept"), { recursive: true });
   await writeFile(path.join(root, "concept", "00-source.md"), source);
+  const sourceRevision = initialiseFixtureGitRepository(root, ["concept/00-source.md"]);
   const target = Buffer.from("# Quelle\n");
   await writeFile(path.join(root, "translations", "de", "concept", "00-source.md"), target);
   const entry = {
@@ -41,13 +48,13 @@ async function fixture(t) {
     route: "/de/concept/00-source/",
     sourceSha256: createHash("sha256").update(source).digest("hex"),
     targetSha256: createHash("sha256").update(target).digest("hex"),
-    sourceRevision: "facac8c699a5c6e2ac258f30209a96ba06dca741",
+    sourceRevision,
     reviewedAt: "2026-09-05T00:00:00Z",
     reviewers: ["reviewer-handle"],
   };
   const manifest = { schema: 2, sourceLanguage: "en-GB", documents: [entry] };
   await writeManifest(root, manifest);
-  return { root, entry, manifest };
+  return { root, entry, manifest, sourceRevision };
 }
 
 async function replaceWithSymlink(file) {
@@ -57,17 +64,85 @@ async function replaceWithSymlink(file) {
 }
 
 test("reviewed translations are tied to an exact mirrored source", async (t) => {
-  const { root } = await fixture(t);
+  const { root, sourceRevision } = await fixture(t);
+  commitFixturePaths(root, ["translations"]);
   const result = validateTranslationManifest(root);
   assert.equal(result.documents.length, 1);
   assert.equal(
     result.documents[0].sourceRevision,
-    "facac8c699a5c6e2ac258f30209a96ba06dca741",
+    sourceRevision,
   );
   assert.equal(result.documents[0].reviewedAt, "2026-09-05T00:00:00Z");
   assert.ok(Object.isFrozen(result));
   assert.ok(Object.isFrozen(result.documents[0]));
   assert.ok(Object.isFrozen(result.documents[0].reviewers));
+});
+
+test("source revision resolves to the reviewed source in publication history", async (t) => {
+  {
+    const { root, entry, manifest } = await fixture(t);
+    entry.sourceRevision = "1".repeat(40);
+    await writeManifest(root, manifest);
+    assert.throws(
+      () => validateTranslationManifest(root),
+      /source revision is not an available exact commit/u,
+    );
+  }
+  {
+    const { root, entry, manifest } = await fixture(t);
+    const changed = Buffer.from("# Source\n\nDifferent canonical text.\n");
+    await writeFile(path.join(root, entry.source), changed);
+    entry.sourceSha256 = createHash("sha256").update(changed).digest("hex");
+    await writeManifest(root, manifest);
+    assert.throws(
+      () => validateTranslationManifest(root),
+      /source revision does not bind its recorded source/u,
+    );
+  }
+  {
+    const { root, entry, manifest } = await fixture(t);
+    entry.sourceRevision = createUnrelatedFixtureCommit(root);
+    await writeManifest(root, manifest);
+    assert.throws(
+      () => validateTranslationManifest(root),
+      /source revision is not an ancestor of the publication checkout/u,
+    );
+  }
+  {
+    const { root, entry, manifest } = await fixture(t);
+    entry.sourceRevision = runFixtureGit(root, ["rev-parse", `HEAD:${entry.source}`]);
+    await writeManifest(root, manifest);
+    assert.throws(
+      () => validateTranslationManifest(root),
+      /source revision is not an available exact commit/u,
+    );
+  }
+  {
+    const { root } = await fixture(t);
+    await rm(path.join(root, ".git"), { recursive: true, force: true });
+    assert.throws(
+      () => validateTranslationManifest(root),
+      /could not be verified in the local Git history/u,
+    );
+  }
+  {
+    const { root, entry, manifest } = await fixture(t);
+    const sourceBlob = runFixtureGit(root, ["rev-parse", `HEAD:${entry.source}`]);
+    runFixtureGit(root, [
+      "update-index",
+      "--cacheinfo",
+      `120000,${sourceBlob},${entry.source}`,
+    ]);
+    runFixtureGit(root, ["commit", "--quiet", "-m", "linked source fixture"]);
+    entry.sourceRevision = runFixtureGit(root, ["rev-parse", "HEAD"]);
+    runFixtureGit(root, ["add", "--", entry.source]);
+    runFixtureGit(root, ["commit", "--quiet", "-m", "regular source fixture"]);
+    await writeManifest(root, manifest);
+    assert.throws(
+      () => validateTranslationManifest(root),
+      /source at its reviewed commit is not a regular file/u,
+    );
+  }
 });
 
 test("review provenance requires an exact commit and canonical UTC instant", async (t) => {
@@ -103,6 +178,7 @@ test("review provenance requires an exact commit and canonical UTC instant", asy
     "2026-09-05T00:00:00+00:00",
     "2026-09-05T00:00:00.000Z",
     "2026-02-30T00:00:00Z",
+    "2026-09-05T24:00:00Z",
   ]) {
     const { root, entry, manifest } = await fixture(t);
     entry.reviewedAt = reviewedAt;

--- a/scripts/translation-manifest.test.mjs
+++ b/scripts/translation-manifest.test.mjs
@@ -41,6 +41,8 @@ async function fixture(t) {
     route: "/de/concept/00-source/",
     sourceSha256: createHash("sha256").update(source).digest("hex"),
     targetSha256: createHash("sha256").update(target).digest("hex"),
+    sourceRevision: "facac8c699a5c6e2ac258f30209a96ba06dca741",
+    reviewedAt: "2026-09-05T00:00:00Z",
     reviewers: ["reviewer-handle"],
   };
   const manifest = { schema: 2, sourceLanguage: "en-GB", documents: [entry] };
@@ -58,8 +60,59 @@ test("reviewed translations are tied to an exact mirrored source", async (t) => 
   const { root } = await fixture(t);
   const result = validateTranslationManifest(root);
   assert.equal(result.documents.length, 1);
+  assert.equal(
+    result.documents[0].sourceRevision,
+    "facac8c699a5c6e2ac258f30209a96ba06dca741",
+  );
+  assert.equal(result.documents[0].reviewedAt, "2026-09-05T00:00:00Z");
   assert.ok(Object.isFrozen(result));
+  assert.ok(Object.isFrozen(result.documents[0]));
   assert.ok(Object.isFrozen(result.documents[0].reviewers));
+});
+
+test("review provenance requires an exact commit and canonical UTC instant", async (t) => {
+  for (const field of ["sourceRevision", "reviewedAt"]) {
+    const { root, entry, manifest } = await fixture(t);
+    delete entry[field];
+    await writeManifest(root, manifest);
+    assert.throws(
+      () => validateTranslationManifest(root),
+      new RegExp(`fields are not closed: .*missing=\\[${field}\\]`, "u"),
+      `missing ${field}`,
+    );
+  }
+
+  for (const sourceRevision of [
+    "",
+    "FACAC8C699A5C6E2AC258F30209A96BA06DCA741",
+    "f".repeat(39),
+    "0".repeat(40),
+  ]) {
+    const { root, entry, manifest } = await fixture(t);
+    entry.sourceRevision = sourceRevision;
+    await writeManifest(root, manifest);
+    assert.throws(
+      () => validateTranslationManifest(root),
+      /source revision is not an exact Git commit/u,
+      sourceRevision,
+    );
+  }
+
+  for (const reviewedAt of [
+    "2026-09-05",
+    "2026-09-05T00:00:00+00:00",
+    "2026-09-05T00:00:00.000Z",
+    "2026-02-30T00:00:00Z",
+  ]) {
+    const { root, entry, manifest } = await fixture(t);
+    entry.reviewedAt = reviewedAt;
+    await writeManifest(root, manifest);
+    assert.throws(
+      () => validateTranslationManifest(root),
+      /review time is not canonical UTC/u,
+      reviewedAt,
+    );
+  }
 });
 
 test("the pre-target-digest manifest schema is rejected", async (t) => {

--- a/scripts/translation-pages.test.mjs
+++ b/scripts/translation-pages.test.mjs
@@ -90,8 +90,15 @@ test("a reviewed non-English manifest entry produces a static locale route", asy
   const html = await readFile(path.join(outputRoot, "de", "concept", "00-source", "index.html"), "utf8");
   assert.match(html, /<html lang="de">/u);
   assert.match(html, /rel="canonical" href="https:\/\/www\.cordana\.dev\/de\/concept\/00-source\/"/u);
+  assert.match(html, /rel="alternate" hreflang="en" href="https:\/\/www\.cordana\.dev\/concept\/00-source\/"/u);
+  assert.match(html, /rel="alternate" hreflang="de" href="https:\/\/www\.cordana\.dev\/de\/concept\/00-source\/"/u);
   assert.match(html, /<h1>Deutscher Titel<\/h1>/u);
   assert.match(html, /Geprüfter deutscher Text\./u);
+  assert.match(html, /<strong>Read this page<\/strong>/u);
+  assert.match(html, /href="\/concept\/00-source\/">English<\/a>/u);
+  assert.match(html, /<span aria-current="page"><span lang="de">Deutsch<\/span> · current<\/span>/u);
+  assert.match(html, />Help add or review a language<\/a>/u);
+  assert.doesNotMatch(html, />Français<\/a>/u);
   assert.match(html, /href="#abschnitt"/u);
   assert.match(
     html,

--- a/scripts/translation-pages.test.mjs
+++ b/scripts/translation-pages.test.mjs
@@ -13,6 +13,8 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
+import { initialiseFixtureGitRepository } from "./lib/git-test-fixture.mjs";
+
 import {
   renderTranslationPage,
   translatedSourceDocuments,
@@ -48,6 +50,7 @@ async function translationFixture() {
   await mkdir(path.join(root, "concept"), { recursive: true });
   await mkdir(path.join(root, "translations", "de", "concept"), { recursive: true });
   await writeFile(path.join(root, "concept", "00-source.md"), source);
+  const sourceRevision = initialiseFixtureGitRepository(root, ["concept/00-source.md"]);
   await writeFile(path.join(root, "translations", "de", "concept", "00-source.md"), target);
   await writeFile(
     path.join(root, "translations", "manifest.json"),
@@ -62,17 +65,17 @@ async function translationFixture() {
         route: "/de/concept/00-source/",
         sourceSha256: createHash("sha256").update(source).digest("hex"),
         targetSha256: createHash("sha256").update(target).digest("hex"),
-        sourceRevision: "facac8c699a5c6e2ac258f30209a96ba06dca741",
+        sourceRevision,
         reviewedAt: "2026-09-05T00:00:00Z",
         reviewers: ["reviewer-handle"],
       }],
     }, null, 2)}\n`,
   );
-  return root;
+  return { root, sourceRevision };
 }
 
 test("a reviewed non-English manifest entry produces a static locale route", async (t) => {
-  const root = await translationFixture();
+  const { root, sourceRevision } = await translationFixture();
   t.after(() => rm(root, { recursive: true, force: true }));
   const outputRoot = path.join(root, "dist");
   const template = `<!doctype html>
@@ -85,7 +88,7 @@ test("a reviewed non-English manifest entry produces a static locale route", asy
   assert.equal(documents[0].route, "de/concept/00-source/");
   assert.equal(documents[0].language, "de");
   assert.equal(documents[0].canonicalSourcePath, "concept/00-source.md");
-  assert.equal(documents[0].sourceRevision, "facac8c699a5c6e2ac258f30209a96ba06dca741");
+  assert.equal(documents[0].sourceRevision, sourceRevision);
   assert.equal(documents[0].reviewedAt, "2026-09-05T00:00:00Z");
   assert.deepEqual(
     writeTranslationPages({ outputRoot, template, documents, basePath: "/" }),
@@ -100,14 +103,10 @@ test("a reviewed non-English manifest entry produces a static locale route", asy
   assert.match(html, /<h1>Deutscher Titel<\/h1>/u);
   assert.match(html, /Geprüfter deutscher Text\./u);
   assert.match(html, /<section class="translation-review-context" lang="en"/u);
-  assert.match(
-    html,
-    /blob\/facac8c699a5c6e2ac258f30209a96ba06dca741\/concept\/00-source\.md/u,
-  );
-  assert.match(
-    html,
-    /<code>facac8c6<wbr>99a5c6e2<wbr>ac258f30<wbr>209a96ba<wbr>06dca741<\/code>/u,
-  );
+  assert.ok(html.includes(`/blob/${sourceRevision}/concept/00-source.md`));
+  assert.ok(html.includes(
+    `<code>${sourceRevision.match(/.{1,8}/gu).join("<wbr>")}</code>`,
+  ));
   assert.match(
     html,
     /<time datetime="2026-09-05T00:00:00Z">2026-09-05T00:00:00Z<\/time>/u,
@@ -127,7 +126,7 @@ test("a reviewed non-English manifest entry produces a static locale route", asy
 });
 
 test("translated route generation rejects path aliases before writing", async (t) => {
-  const root = await translationFixture();
+  const { root } = await translationFixture();
   t.after(() => rm(root, { recursive: true, force: true }));
   const [document] = translatedSourceDocuments(root);
   const outputRoot = path.join(root, "dist");
@@ -144,7 +143,7 @@ test("translated route generation rejects path aliases before writing", async (t
 });
 
 test("translation rendering rejects omitted maintained review provenance", async (t) => {
-  const root = await translationFixture();
+  const { root } = await translationFixture();
   t.after(() => rm(root, { recursive: true, force: true }));
   const [document] = translatedSourceDocuments(root);
   const template = '<html lang="en"><head><!-- pages-seo:head --><!-- /pages-seo:head --></head><body><!-- pages-seo:fallback --><!-- /pages-seo:fallback --></body></html>';
@@ -169,7 +168,7 @@ test("translation rendering rejects omitted maintained review provenance", async
 });
 
 test("translation rendering rejects a pathname replacement during its reviewed read", async (t) => {
-  const root = await translationFixture();
+  const { root } = await translationFixture();
   t.after(() => rm(root, { recursive: true, force: true }));
   const movedPath = path.join(root, "translations", "de", "concept", "opened-original.md");
 
@@ -190,7 +189,7 @@ test("translation rendering rejects a pathname replacement during its reviewed r
 });
 
 test("translation rendering rejects same-inode mutation during its reviewed read", async (t) => {
-  const root = await translationFixture();
+  const { root } = await translationFixture();
   t.after(() => rm(root, { recursive: true, force: true }));
 
   assert.throws(

--- a/scripts/translation-pages.test.mjs
+++ b/scripts/translation-pages.test.mjs
@@ -14,6 +14,7 @@ import path from "node:path";
 import test from "node:test";
 
 import {
+  renderTranslationPage,
   translatedSourceDocuments,
   writeTranslationPages,
 } from "./lib/translation-pages.mjs";
@@ -61,6 +62,8 @@ async function translationFixture() {
         route: "/de/concept/00-source/",
         sourceSha256: createHash("sha256").update(source).digest("hex"),
         targetSha256: createHash("sha256").update(target).digest("hex"),
+        sourceRevision: "facac8c699a5c6e2ac258f30209a96ba06dca741",
+        reviewedAt: "2026-09-05T00:00:00Z",
         reviewers: ["reviewer-handle"],
       }],
     }, null, 2)}\n`,
@@ -82,6 +85,8 @@ test("a reviewed non-English manifest entry produces a static locale route", asy
   assert.equal(documents[0].route, "de/concept/00-source/");
   assert.equal(documents[0].language, "de");
   assert.equal(documents[0].canonicalSourcePath, "concept/00-source.md");
+  assert.equal(documents[0].sourceRevision, "facac8c699a5c6e2ac258f30209a96ba06dca741");
+  assert.equal(documents[0].reviewedAt, "2026-09-05T00:00:00Z");
   assert.deepEqual(
     writeTranslationPages({ outputRoot, template, documents, basePath: "/" }),
     ["de/concept/00-source/index.html"],
@@ -94,6 +99,19 @@ test("a reviewed non-English manifest entry produces a static locale route", asy
   assert.match(html, /rel="alternate" hreflang="de" href="https:\/\/www\.cordana\.dev\/de\/concept\/00-source\/"/u);
   assert.match(html, /<h1>Deutscher Titel<\/h1>/u);
   assert.match(html, /Geprüfter deutscher Text\./u);
+  assert.match(html, /<section class="translation-review-context" lang="en"/u);
+  assert.match(
+    html,
+    /blob\/facac8c699a5c6e2ac258f30209a96ba06dca741\/concept\/00-source\.md/u,
+  );
+  assert.match(
+    html,
+    /<code>facac8c6<wbr>99a5c6e2<wbr>ac258f30<wbr>209a96ba<wbr>06dca741<\/code>/u,
+  );
+  assert.match(
+    html,
+    /<time datetime="2026-09-05T00:00:00Z">2026-09-05T00:00:00Z<\/time>/u,
+  );
   assert.match(html, /<strong>Read this page<\/strong>/u);
   assert.match(html, /href="\/concept\/00-source\/">English<\/a>/u);
   assert.match(html, /<span aria-current="page"><span lang="de">Deutsch<\/span> · current<\/span>/u);
@@ -123,6 +141,31 @@ test("translated route generation rejects path aliases before writing", async (t
     }),
     /Unsafe translated publication route/,
   );
+});
+
+test("translation rendering rejects omitted maintained review provenance", async (t) => {
+  const root = await translationFixture();
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const [document] = translatedSourceDocuments(root);
+  const template = '<html lang="en"><head><!-- pages-seo:head --><!-- /pages-seo:head --></head><body><!-- pages-seo:fallback --><!-- /pages-seo:fallback --></body></html>';
+
+  for (const [field, pattern] of [
+    ["sourceRevision", /source revision is not an exact Git commit/u],
+    ["reviewedAt", /review time is not canonical UTC/u],
+  ]) {
+    const malformed = { ...document };
+    delete malformed[field];
+    assert.throws(
+      () => renderTranslationPage({
+        template,
+        document: malformed,
+        documents: [malformed],
+        basePath: "/",
+      }),
+      pattern,
+      field,
+    );
+  }
 });
 
 test("translation rendering rejects a pathname replacement during its reviewed read", async (t) => {

--- a/scripts/translation-vite-build.test.mjs
+++ b/scripts/translation-vite-build.test.mjs
@@ -7,6 +7,7 @@ import test from "node:test";
 import { build } from "vite";
 
 import pagesConfig, { createSeoStaticPages } from "../vite.pages.config.ts";
+import { initialiseFixtureGitRepository } from "./lib/git-test-fixture.mjs";
 import { resolvePagesBase } from "./lib/pages-base.mjs";
 import { translatedSourceDocuments } from "./lib/translation-pages.mjs";
 
@@ -18,6 +19,7 @@ async function nonemptyManifestFixture(root) {
   await mkdir(path.join(root, "concept"), { recursive: true });
   await mkdir(path.join(root, "translations", "de", "concept"), { recursive: true });
   await writeFile(path.join(root, sourcePath), source);
+  const sourceRevision = initialiseFixtureGitRepository(root, [sourcePath]);
   await writeFile(path.join(root, targetPath), target);
   await writeFile(path.join(root, "translations", "manifest.json"), `${JSON.stringify({
     schema: 2,
@@ -30,11 +32,12 @@ async function nonemptyManifestFixture(root) {
       route: "/de/concept/build-fixture/",
       sourceSha256: createHash("sha256").update(source).digest("hex"),
       targetSha256: createHash("sha256").update(target).digest("hex"),
-      sourceRevision: "facac8c699a5c6e2ac258f30209a96ba06dca741",
+      sourceRevision,
       reviewedAt: "2026-09-05T00:00:00Z",
       reviewers: ["build-fixture-reviewer"],
     }],
   }, null, 2)}\n`);
+  return sourceRevision;
 }
 
 test("a Vite Pages build publishes routes from a nonempty reviewed manifest", async (t) => {
@@ -44,7 +47,7 @@ test("a Vite Pages build publishes routes from a nonempty reviewed manifest", as
     rm(fixtureRoot, { recursive: true, force: true }),
     rm(outputRoot, { recursive: true, force: true }),
   ]));
-  await nonemptyManifestFixture(fixtureRoot);
+  const sourceRevision = await nonemptyManifestFixture(fixtureRoot);
   const translations = translatedSourceDocuments(fixtureRoot);
   assert.equal(translations.length, 1);
 
@@ -76,10 +79,7 @@ test("a Vite Pages build publishes routes from a nonempty reviewed manifest", as
   assert.match(html, /property="og:locale" content="de_DE"/u);
   assert.match(html, /<h1>Geprüfte Übersetzung<\/h1>/u);
   assert.match(html, /<h2 id="translation-review-context-heading">Translation review<\/h2>/u);
-  assert.match(
-    html,
-    /blob\/facac8c699a5c6e2ac258f30209a96ba06dca741\/concept\/build-fixture\.md/u,
-  );
+  assert.ok(html.includes(`/blob/${sourceRevision}/concept/build-fixture.md`));
   assert.match(html, /datetime="2026-09-05T00:00:00Z"/u);
   assert.match(html, /<span aria-current="page"><span lang="de">Deutsch<\/span> · current<\/span>/u);
   assert.ok(html.includes(`href="${pagesBase}concept/build-fixture/">English</a>`));

--- a/scripts/translation-vite-build.test.mjs
+++ b/scripts/translation-vite-build.test.mjs
@@ -7,6 +7,7 @@ import test from "node:test";
 import { build } from "vite";
 
 import pagesConfig, { createSeoStaticPages } from "../vite.pages.config.ts";
+import { resolvePagesBase } from "./lib/pages-base.mjs";
 import { translatedSourceDocuments } from "./lib/translation-pages.mjs";
 
 async function nonemptyManifestFixture(root) {
@@ -68,9 +69,15 @@ test("a Vite Pages build publishes routes from a nonempty reviewed manifest", as
     readFile(path.join(outputRoot, "de", "concept", "build-fixture", "index.html"), "utf8"),
     readFile(path.join(outputRoot, "sitemap.xml"), "utf8"),
   ]);
+  const pagesBase = resolvePagesBase(process.env.PAGES_BASE_PATH);
   assert.match(html, /<html lang="de">/u);
   assert.match(html, /property="og:locale" content="de_DE"/u);
   assert.match(html, /<h1>Geprüfte Übersetzung<\/h1>/u);
+  assert.match(html, /<span aria-current="page"><span lang="de">Deutsch<\/span> · current<\/span>/u);
+  assert.ok(html.includes(`href="${pagesBase}concept/build-fixture/">English</a>`));
+  assert.match(html, /rel="alternate" hreflang="en" href="https:\/\/www\.cordana\.dev\/concept\/build-fixture\/"/u);
+  assert.match(html, /rel="alternate" hreflang="de" href="https:\/\/www\.cordana\.dev\/de\/concept\/build-fixture\/"/u);
+  assert.doesNotMatch(html, />Français<\/a>/u);
   assert.match(html, /template=translation-problem\.yml/u);
   assert.doesNotMatch(html, /<script\b[^>]*\bsrc=/u);
   assert.match(

--- a/scripts/translation-vite-build.test.mjs
+++ b/scripts/translation-vite-build.test.mjs
@@ -30,6 +30,8 @@ async function nonemptyManifestFixture(root) {
       route: "/de/concept/build-fixture/",
       sourceSha256: createHash("sha256").update(source).digest("hex"),
       targetSha256: createHash("sha256").update(target).digest("hex"),
+      sourceRevision: "facac8c699a5c6e2ac258f30209a96ba06dca741",
+      reviewedAt: "2026-09-05T00:00:00Z",
       reviewers: ["build-fixture-reviewer"],
     }],
   }, null, 2)}\n`);
@@ -73,6 +75,12 @@ test("a Vite Pages build publishes routes from a nonempty reviewed manifest", as
   assert.match(html, /<html lang="de">/u);
   assert.match(html, /property="og:locale" content="de_DE"/u);
   assert.match(html, /<h1>Geprüfte Übersetzung<\/h1>/u);
+  assert.match(html, /<h2 id="translation-review-context-heading">Translation review<\/h2>/u);
+  assert.match(
+    html,
+    /blob\/facac8c699a5c6e2ac258f30209a96ba06dca741\/concept\/build-fixture\.md/u,
+  );
+  assert.match(html, /datetime="2026-09-05T00:00:00Z"/u);
   assert.match(html, /<span aria-current="page"><span lang="de">Deutsch<\/span> · current<\/span>/u);
   assert.ok(html.includes(`href="${pagesBase}concept/build-fixture/">English</a>`));
   assert.match(html, /rel="alternate" hreflang="en" href="https:\/\/www\.cordana\.dev\/concept\/build-fixture\/"/u);

--- a/scripts/validate-github-pages-build.mjs
+++ b/scripts/validate-github-pages-build.mjs
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 import { bookDocumentId } from "../app/lib/book-document-id.mjs";
 import { assertBookPdfIntegrity } from "./lib/book-pdf-integrity.mjs";
 import { assertBookManifestContract } from "./lib/book-manifest-contract.mjs";
+import { languageAlternateLinksForRoute } from "../app/lib/language-access.mjs";
 import {
   bookRendererLockPath,
   bookRendererLockSHA256,
@@ -21,7 +22,10 @@ import {
   renderRobots,
   renderSitemap,
 } from "./lib/pages-seo.mjs";
-import { translatedSourceDocuments } from "./lib/translation-pages.mjs";
+import {
+  translatedSourceDocuments,
+  translationAvailabilityRecords,
+} from "./lib/translation-pages.mjs";
 
 const repositoryRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -119,7 +123,7 @@ function oneMatch(source, pattern, label) {
   return matches[0][1];
 }
 
-function validateSeoDocument(html, document) {
+function validateSeoDocument(html, document, translationAvailability = []) {
   const canonical = `${canonicalSite}${document.route}`;
   const language = document.language ?? "en";
   const title = oneMatch(html, /<title>([^<]+)<\/title>/g, `${document.route} title`);
@@ -153,6 +157,16 @@ function validateSeoDocument(html, document) {
     /<html\s+lang="([^"]+)">/g,
     `${document.route} HTML language`,
   );
+  const declaredLanguageAlternates = [...html.matchAll(
+    /<link\b(?=[^>]*\brel=["']alternate["'])(?=[^>]*\bhreflang=["'][^"']+["'])[^>]*>/gu,
+  )].map((match) => ({
+    language: oneMatch(match[0], /\bhreflang=["']([^"']+)["']/gu, `${document.route} alternate language`),
+    href: oneMatch(match[0], /\bhref=["']([^"']+)["']/gu, `${document.route} alternate URL`),
+  }));
+  const expectedLanguageAlternates = languageAlternateLinksForRoute(
+    document.route,
+    translationAvailability,
+  );
   invariant(declaredCanonical === canonical, `${document.route} canonical is not self-referential`);
   invariant(title === `${document.title} — 20 Watts Was Enough`, `${document.route} title is stale`);
   invariant(description === document.description.replaceAll("&", "&amp;").replaceAll('"', "&quot;"), `${document.route} description is stale`);
@@ -164,6 +178,10 @@ function validateSeoDocument(html, document) {
   invariant(jsonLd.inLanguage === language, `${document.route} JSON-LD language is stale`);
   invariant(citationLanguage === language, `${document.route} citation language is stale`);
   invariant(htmlLanguage === language, `${document.route} HTML language is stale`);
+  invariant(
+    JSON.stringify(declaredLanguageAlternates) === JSON.stringify(expectedLanguageAlternates),
+    `${document.route} language alternates are stale, incomplete, or not reciprocal`,
+  );
   invariant(html.includes('<main class="seo-static-page">'), `${document.route} lacks static fallback content`);
   invariant(html.includes(`<h1>${document.title.replaceAll("&", "&amp;")}</h1>`), `${document.route} static H1 is stale`);
   invariant(!html.includes("?doc="), `${document.route} contains a query-parameter document link`);
@@ -258,6 +276,7 @@ const sourceDocuments = [
 ].sort();
 const portalDocuments = portalSourceDocuments(repositoryRoot);
 const translatedDocuments = translatedSourceDocuments(repositoryRoot);
+const translationAvailability = translationAvailabilityRecords(translatedDocuments);
 invariant(portalDocuments.length === sourceDocuments.length, "SEO route registry does not cover the canonical portal corpus");
 const builtDocuments = (await recursiveInventory("documents"))
   .filter((relative) => relative.endsWith(".md"))
@@ -280,7 +299,7 @@ const seoDescriptions = new Set();
 for (const document of portalDocuments) {
   const relativeHtml = `${document.route}index.html`;
   const page = await validatePage(relativeHtml, "portal");
-  const metadata = validateSeoDocument(page.html, document);
+  const metadata = validateSeoDocument(page.html, document, translationAvailability);
   invariant(!seoTitles.has(metadata.title), `duplicate SEO title: ${metadata.title}`);
   invariant(!seoDescriptions.has(metadata.description), `duplicate SEO description: ${metadata.description}`);
   seoTitles.add(metadata.title);
@@ -294,7 +313,7 @@ for (const document of portalDocuments) {
 for (const document of translatedDocuments) {
   const relativeHtml = `${document.route}index.html`;
   const page = await validatePage(relativeHtml, null);
-  validateSeoDocument(page.html, document);
+  validateSeoDocument(page.html, document, translationAvailability);
 }
 
 const sitemap = await readFile(path.join(outputRoot, "sitemap.xml"), "utf8");

--- a/scripts/validate-github-pages-build.mjs
+++ b/scripts/validate-github-pages-build.mjs
@@ -21,6 +21,7 @@ import {
   renderBookFallback,
   renderRobots,
   renderSitemap,
+  renderTranslationReviewContext,
 } from "./lib/pages-seo.mjs";
 import {
   translatedSourceDocuments,
@@ -178,6 +179,17 @@ function validateSeoDocument(html, document, translationAvailability = []) {
   invariant(jsonLd.inLanguage === language, `${document.route} JSON-LD language is stale`);
   invariant(citationLanguage === language, `${document.route} citation language is stale`);
   invariant(htmlLanguage === language, `${document.route} HTML language is stale`);
+  if (language !== "en") {
+    invariant(
+      html.includes(renderTranslationReviewContext(document)),
+      `${document.route} translation review context is stale or incomplete`,
+    );
+  } else {
+    invariant(
+      !html.includes('class="translation-review-context"'),
+      `${document.route} canonical page claims translation review context`,
+    );
+  }
   invariant(
     JSON.stringify(declaredLanguageAlternates) === JSON.stringify(expectedLanguageAlternates),
     `${document.route} language alternates are stale, incomplete, or not reciprocal`,

--- a/translations/README.md
+++ b/translations/README.md
@@ -26,12 +26,14 @@ example `translations/de/concept/00-thesis-and-principles.md`. An entry in
 
 `npm run validate:translations` uses bounded, stable regular-file reads and
 rejects ambiguous or open-ended manifest JSON, links, stale source or reviewed
-target digests, malformed source revisions or review times, path aliases and
-escapes, duplicate routes, missing reviewers and missing files. The published
-page links the maintained commit and shows the maintained review instant. The
-validator does not infer either value from the build checkout: the named human
-reviewer and pull-request review remain accountable for that binding. A
-translation is not published merely because a machine produced a draft.
+target digests, unavailable or non-ancestor source commits, a source digest
+that does not match the file at the named commit, malformed review times, path
+aliases and escapes, duplicate routes, missing reviewers and missing files.
+The published page links the verified commit and shows the maintained review
+instant. The validator cannot establish reviewer competence or that the named
+review happened at that instant: the named human reviewer and pull-request
+review remain accountable for those claims. A translation is not published
+merely because a machine produced a draft.
 Drafting tools must be disclosed in the pull request, and a reviewer remains
 accountable for meaning, terminology, equations, qualifications and links.
 

--- a/translations/README.md
+++ b/translations/README.md
@@ -15,16 +15,23 @@ example `translations/de/concept/00-thesis-and-principles.md`. An entry in
 - one of the official EU language codes exposed by the reader;
 - the canonical and translated repository paths;
 - the canonical public route and translated public route;
+- `sourceRevision`, the exact lowercase 40-character Git commit whose
+  canonical file was reviewed;
 - the SHA-256 digest of the exact canonical file translated;
-- the SHA-256 digest of the exact translated file the reviewer accepted; and
+- the SHA-256 digest of the exact translated file the reviewer accepted;
+- `reviewedAt`, the review instant in canonical UTC-second form, such as
+  `2026-09-05T00:00:00Z`; and
 - at least one human reviewer who is competent in the target language and the
   affected research domain.
 
 `npm run validate:translations` uses bounded, stable regular-file reads and
 rejects ambiguous or open-ended manifest JSON, links, stale source or reviewed
-target digests, path aliases and escapes, duplicate routes, missing reviewers
-and missing files. A translation is not published merely because a machine
-produced a draft.
+target digests, malformed source revisions or review times, path aliases and
+escapes, duplicate routes, missing reviewers and missing files. The published
+page links the maintained commit and shows the maintained review instant. The
+validator does not infer either value from the build checkout: the named human
+reviewer and pull-request review remain accountable for that binding. A
+translation is not published merely because a machine produced a draft.
 Drafting tools must be disclosed in the pull request, and a reviewer remains
 accountable for meaning, terminology, equations, qualifications and links.
 
@@ -97,9 +104,8 @@ SHA-256 rather than requiring a `.git` directory. This permits work from a
 tagged source archive or release checkout. Validation and import both require
 the operator to repeat the expected source path and language, then compare the
 bundle with the current local source. The later pull request and reviewed
-manifest supply the Git revision and publication authority; the digest alone
-does not claim that a
-candidate came from `main`.
+manifest supply the exact Git revision, review instant and publication
+authority; the digest alone does not claim that a candidate came from `main`.
 
 After a competent human has checked meaning, terminology, negation,
 qualifications, equations, units, links and evidence status, copy the accepted

--- a/vite.pages.config.ts
+++ b/vite.pages.config.ts
@@ -22,6 +22,7 @@ import { resolvePagesBase } from "./scripts/lib/pages-base.mjs";
 import { renderThirdPartyNotices } from "./scripts/lib/third-party-notices.mjs";
 import { resolveViteCacheDirectory } from "./scripts/lib/vite-cache-directory.mjs";
 import {
+  translationAvailabilityRecords,
   translatedSourceDocuments,
   writeTranslationPages,
 } from "./scripts/lib/translation-pages.mjs";
@@ -191,6 +192,7 @@ export function createSeoStaticPages({
       const bookDocuments = bookSourceDocuments(repositoryRoot) as PortalSourceDocument[];
       const translations = translationDocuments
         ?? translatedSourceDocuments(repositoryRoot) as TranslationSourceDocument[];
+      const translationAvailability = translationAvailabilityRecords(translations);
       const portalPath = path.join(outputRoot, "index.html");
       const bookPath = path.join(outputRoot, "book", "index.html");
       const helpPath = path.join(outputRoot, "help", "index.html");
@@ -199,12 +201,12 @@ export function createSeoStaticPages({
       writeFileSync(portalPath, populateSeoTemplate(
         portalTemplate,
         renderSeoHead("portal", null, pagesBase),
-        renderPortalFallback(documents, pagesBase),
+        renderPortalFallback(documents, pagesBase, translationAvailability),
       ), "utf8");
       writeFileSync(bookPath, populateSeoTemplate(
         readFileSync(bookPath, "utf8"),
         renderSeoHead("book", null, pagesBase),
-        renderBookFallback(bookDocuments, pagesBase),
+        renderBookFallback(bookDocuments, pagesBase, translationAvailability),
       ), "utf8");
       writeFileSync(helpPath, renderCurrentHelpPage(readFileSync(helpPath, "utf8")), "utf8");
       for (const document of documents) {
@@ -212,8 +214,13 @@ export function createSeoStaticPages({
         mkdirSync(path.dirname(output), { recursive: true });
         writeFileSync(output, populateSeoTemplate(
           portalTemplate,
-          renderSeoHead("document", document, pagesBase),
-          renderDocumentFallback(document, documents, pagesBase),
+          renderSeoHead("document", document, pagesBase, translationAvailability),
+          renderDocumentFallback(
+            document,
+            documents,
+            pagesBase,
+            translationAvailability,
+          ),
         ), "utf8");
       }
       writeTranslationPages({

--- a/vite.pages.config.ts
+++ b/vite.pages.config.ts
@@ -60,6 +60,8 @@ type TranslationSourceDocument = PortalSourceDocument & {
   canonicalSourceRoute: string;
   sourceSha256: string;
   targetSha256: string;
+  sourceRevision: string;
+  reviewedAt: string;
   reviewers: readonly string[];
 };
 


### PR DESCRIPTION
# Pull request

## Summary

- Make the hydrated reader, static Pages routes and no-JavaScript fallback use
  the same route-specific language availability. English and reviewed
  translations are reading destinations; unavailable languages lead to a
  separate contribution and review path.
- Extend the reviewed-translation manifest contract with maintained source
  revision and review-time provenance, then fail closed when the recorded
  source cannot be recovered exactly from publication history.
- Keep translation presentation in the public-reader CSS owner and fetch the
  complete Git history in the CI and Pages jobs that enforce provenance.

Tracks #51

`translations/manifest.json` still contains 0 reviewed translations. This
change publishes no German text, admits no machine-generated translation and
makes no claim about translation quality, readability, accessibility or
general model adequacy. The implementation and its checks remain `NO_RESULT`.

### Provenance admission

For every future reviewed manifest entry, the validator now requires all of
the following:

1. `sourceRevision` is one exact 40-hex Git commit object available locally and
   is an ancestor of the publishing `HEAD`.
2. The exact normalized source path resolves at that commit to a blob with
   regular-file mode `100644` or `100755`; symlink mode `120000` and other tree
   entry modes are rejected.
3. That historical blob OID equals the Git blob OID of the currently
   SHA-256-checked canonical source. A changed historical source, a blob passed
   as a commit, an unrelated commit, a nonexistent ID and missing Git history
   all fail closed.
4. The target remains a regular, mirrored translation path whose reviewed
   SHA-256 digest still matches its bytes.
5. `reviewedAt` is an exact canonical UTC instant in
   `YYYY-MM-DDTHH:mm:ssZ` form and survives an exact date round trip.

The rendered review context links to the verified commit and source path. These
checks prove the recorded path, mode and bytes are recoverable from the named
publication history; they cannot prove that a review occurred at the stated
time or that the reviewer was competent.

The tracked issue therefore remains blocked. It still needs a named human
reviewer competent in German and the affected domain, followed by a complete
in-context review of the German pilot and truthful approval metadata. Codex's
adversarial code review does not satisfy that language or domain-review
boundary.

## Research traceability

- **Claim IDs:** none; no empirical or translation-quality claim changes.
- **Principle bundles:** none; this is a publication-admission and route-parity
  repair, not a proposed scientific mechanism.
- **Experiment or fixture IDs:** none.
- **Evidence and result authority:** `NO_RESULT`; focused engineering tests and
  a static build only. No translation, accessibility, usability or scientific
  result is promoted.
- **Contributors and accountable approver:** OpenAI Codex implemented the
  branch and performed adversarial code review. `@lusoris` remains the
  accountable maintainer and prospective pull-request approver. This is not a
  claim-eligible output, and no independent scientific reviewer is claimed.
- **Funding, material support, and competing interests:** no project funding or
  donated compute was disclosed for this change; no competing interest is
  known. Material Codex use is disclosed below.
- **Material AI, automation, or external services:** OpenAI Codex, used on
  2026-09-05 for implementation, adversarial review, hostile-test design,
  rebase verification and this pull-request draft. The red-team pass found the
  historical symlink-mode bypass before publication. Repository tests and Git
  object checks supplied the verification evidence; no AI-produced German text
  entered the repository.
- **Ethics, rights, safety, misuse, and data-plan triggers:** no trigger. This
  change handles public repository paths and publication metadata; it collects
  no personal data, recruits no participant and performs no physical or
  environmental intervention.
- **Intended reader:** multilingual readers deciding which reviewed edition is
  actually available, plus contributors and reviewers preparing a translation.
- **Domain-accuracy review:** no scientific prose or German text changes. A
  named human German/domain reviewer is still required before the pilot can be
  admitted.
- **Curious-reader review:** no independent reader review is claimed. Route
  labels, source relationships and static/hydrated parity are test-covered,
  but this change makes no comprehension or usability claim.

## Checklist

- [x] I separated source observation, proposed translation, and project hypothesis where applicable.
- [x] New or changed empirical claims have stable `C-` IDs, scoped evidence status, primary sources, and explicit boundary conditions.
- [x] New mechanisms were checked against existing `P-` bundles and the strongest ordinary engineering null.
- [x] Imported, quoted, adapted, or generated material has provenance and a recorded reuse basis; public availability or citation alone was not treated as permission to copy.
- [x] Smoke, construction, development, and specification-only work remains `NO_RESULT`; no result or authority was promoted without an eligible run.
- [x] Quantitative statements define symbols, units, assumptions, uncertainty, and the measured system boundary.
- [x] Contributor credit, support, conflicts, and material tool use are disclosed at the authority this change claims.
- [x] Triggered ethics, misuse, collaboration, and research-object stewardship requirements were satisfied before the affected work began.
- [x] Editable sources and affected generated artifacts, indexes, plots, book files, or manifests were updated together.
- [x] A changed `Scope` gives its intended reader an entry ramp; acronyms and project terms are explained before they carry the argument.
- [x] I ran the relevant validation commands and list them below.

## Validation

```text
PASS  npm run validate:css-authority
      372 unique portal selectors; no same-scope duplicates
PASS  npm run validate:translations
      0 reviewed translations
PASS  npm run test:translations
      20/20 tests
PASS  npm run validate:policy
PASS  npm run test:policy
      69/69 tests
PASS  npm run typecheck
PASS  npm run lint
PASS  npm run check:prose
PASS  npm run validate:docs
      366 Markdown files, 19 chapters, 59 Mermaid sources
PASS  npm run check:code-shape
PASS  node --test --experimental-test-isolation=none scripts/github-pages.test.mjs
      17/17 tests; 4 unchanged replays passed after one transient DOM-loss timeout
PASS  npm run prepare:reader-artifacts
PASS  PAGES_BASE_PATH=/ ./node_modules/.bin/vite build --config vite.pages.config.ts
PASS  PAGES_BASE_PATH=/ npm run validate:github-pages
      384 files, 49 portal documents, 0 reviewed translations
PASS  npm run generate:book-pdf
      PDF remained byte-identical: 06a06d8f5cf2df794ed6ebea037baa3e1a6a7ed7045659296aa165486be74244
      12,780,949 bytes, 412 pages; source digest refreshed to 0f71572d58fa531deb2266faf333456ab45df53d1b41b2023a5c4afcd2a878a3
PASS  npm run validate:book-pdf
      173 source files
PASS  semantic replay against the refreshed manifest and baseline
      exact Poppler stream hashes; expected nonzero outcome for exactly 5 known-debt sentinels
PASS  every constituent gate in npm run check on the unchanged final tree
      83/83 site tests; 20/20 workstation jobs; 45/45 release tests
PASS  git range-diff e146a5e7f79daead40a5770aaf424e340029b028..ea894dfae518a745bf0308684eef215f40e9de82 79ae54af2cabb053961ae55bbf8b46c2b4a112b0..673c229bab1e441f951aa817dfe7a5c1e4d71433
      all four translation/publication commits are exact patch matches after #82
PASS  post-rebase publication identity verification
      PDF 06a06d8f5cf2df794ed6ebea037baa3e1a6a7ed7045659296aa165486be74244;
      manifest 286d64b22ea4e968ffecb3008746c0444d4ee846eeb91870adb9c2d06cb95715;
      baseline 8ad714cf18f984e828b020011612daa833019c7e467775e4c54fd333362df706;
      source digest 0f71572d58fa531deb2266faf333456ab45df53d1b41b2023a5c4afcd2a878a3
PASS  post-rebase npm run validate:book-pdf and translation gates
      173 PDF sources; 20/20 translation tests
PASS  post-rebase node --test --test-concurrency=1 --experimental-test-isolation=none scripts/mermaid-browser.test.mjs
      3/3 combined browser tests; bounded ArrowRight observation retained
```

The first browser invocation above reached the expected document URL but lost
the complete reader DOM during a viewport transition and timed out. No source
changed; four immediate isolated replays passed 17/17. The successful replays
and direct build are the acceptance evidence, while the transient event remains
reported rather than being recast as a translation result.

The aggregate was not one uninterrupted process: the first exact-runtime run
received external `SIGTERM` while the site browser suite was still passing. Its
already-green prefix was retained, and the exact remaining command sequence was
rerun on the unchanged tree. An accidental `/usr/bin/node` suffix correctly
failed the numeric-runtime sentinel even though it reported version 26.8.1; the
workstation and build suffix was rerun with the locked official Node binary and
passed all 20 jobs. No failed shard was treated as acceptance evidence.

Regenerating the publication changed no PDF byte. It refreshed only the source
digest in `book-manifest.json` and the corresponding manifest/source bindings in
the semantic baseline. The semantic audit retains its expected nonzero
`known-debt` outcome; it is not a conformance pass.
