### PR TITLE
test(site): wait for observed keyboard scroll

### DIFF
--- a/scripts/mermaid-browser.test.mjs
+++ b/scripts/mermaid-browser.test.mjs
@@ -261,12 +261,29 @@ async function assertArrowKeyScrollsRegion(cdp, kind) {
     windowsVirtualKeyCode: 39,
     nativeVirtualKeyCode: 39,
   });
-  await new Promise((resolve) => setTimeout(resolve, 150));
-  const scrollLeft = (await cdp.send("Runtime.evaluate", {
-    expression: `document.querySelector(${JSON.stringify(selector)})?.scrollLeft ?? 0`,
-    returnByValue: true,
-  })).result?.value;
-  assert.ok(scrollLeft > 0, `${kind} overflow region did not respond to ArrowRight`);
+  const scrollDeadline = Date.now() + 5_000;
+  let scrollState;
+  do {
+    scrollState = (await cdp.send("Runtime.evaluate", {
+      expression: `(() => {
+        const region = document.querySelector(${JSON.stringify(selector)});
+        return region ? {
+          active: document.activeElement === region,
+          clientWidth: region.clientWidth,
+          scrollLeft: region.scrollLeft,
+          scrollWidth: region.scrollWidth,
+        } : null;
+      })()`,
+      returnByValue: true,
+    })).result?.value;
+    if (scrollState?.scrollLeft > 0) break;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  } while (Date.now() < scrollDeadline);
+  assert.equal(scrollState?.active, true, JSON.stringify(scrollState));
+  assert.ok(
+    scrollState?.scrollLeft > 0,
+    `${kind} overflow region did not respond to ArrowRight: ${JSON.stringify(scrollState)}`,
+  );
 }
 
 async function assertPrintRetiresOverflowSemantics(cdp, expectedRegionCount) {


### PR DESCRIPTION
# Pull request

## Summary

- Replace the Mermaid browser test's single 150 ms keyboard-scroll sample with
  a bounded poll of the actual focused overflow region.
- Retain the same behavioral assertion: an overflowing code, equation, table or
  diagram region must receive focus and move horizontally after `ArrowRight`.
- Include focus and scroll geometry in a failure so a real regression is
  diagnosable instead of reported as one context-free boolean.

Tracks #7

The full-quality job for pull request #81 reached the diagram assertion with a
valid overflowing and focused region, but the default browser scroll had not
advanced at the one fixed 150 ms sample on a saturated runner. The earlier
regions and the same local browser gate passed. Default keyboard scrolling is
asynchronous, so the test now observes the effect for at most 5 seconds, matching
the existing bounded phase waits in this file. It still fails if focus moves,
the region is absent, or `scrollLeft` never becomes positive.

This is test-harness maintenance. It changes no reader behavior, claim,
experiment, accessibility statement, or scientific result and remains
`NO_RESULT`.

## Research traceability

- **Claim IDs:** none.
- **Principle bundles:** none; no mechanism changes.
- **Experiment or fixture IDs:** none.
- **Evidence and result authority:** `NO_RESULT`; browser regression evidence
  only, with no accessibility or usability conformance claim.
- **Contributors and accountable approver:** OpenAI Codex diagnosed and
  implemented the bounded wait. `@lusoris` remains the accountable maintainer
  and prospective approver. This is not a claim-eligible output.
- **Funding, material support, and competing interests:** no project funding or
  donated compute was disclosed; no competing interest is known.
- **Material AI, automation, or external services:** OpenAI Codex on 2026-09-05
  for log diagnosis, implementation and review; GitHub Actions run 33941487978
  supplied the failing runner evidence.
- **Ethics, rights, safety, misuse, and data-plan triggers:** no trigger; this is
  a local-browser test over public repository content.
- **Intended reader:** maintainers diagnosing publication-browser CI failures.
- **Domain-accuracy review:** no scientific meaning changes.
- **Curious-reader review:** no public prose or interface changes.

## Checklist

- [x] I separated source observation, proposed translation, and project hypothesis where applicable.
- [x] New or changed empirical claims have stable `C-` IDs, scoped evidence status, primary sources, and explicit boundary conditions.
- [x] New mechanisms were checked against existing `P-` bundles and the strongest ordinary engineering null.
- [x] Imported, quoted, adapted, or generated material has provenance and a recorded reuse basis; public availability or citation alone was not treated as permission to copy.
- [x] Smoke, construction, development, and specification-only work remains `NO_RESULT`; no result or authority was promoted without an eligible run.
- [x] Quantitative statements define symbols, units, assumptions, uncertainty, and the measured system boundary.
- [x] Contributor credit, support, conflicts, and material tool use are disclosed at the authority this change claims.
- [x] Triggered ethics, misuse, collaboration, and research-object stewardship requirements were satisfied before the affected work began.
- [x] Editable sources and affected generated artifacts, indexes, plots, book files, or manifests were updated together.
- [x] A changed `Scope` gives its intended reader an entry ramp; acronyms and project terms are explained before they carry the argument.
- [x] I ran the relevant validation commands and list them below.

## Validation

```text
PASS  node --check scripts/mermaid-browser.test.mjs
PASS  eslint scripts/mermaid-browser.test.mjs
PASS  node --test --test-concurrency=1 --experimental-test-isolation=none scripts/mermaid-browser.test.mjs (3/3)
PASS  20w ci plan (impact; site lane only; one changed path)
PASS  npm run check through the changed site/browser boundary
      site source 75/75; browser 3/3; translation 17/17; docs/source/math/workstation inventories
OBSERVED  npm run check aggregate workstation stage: 18/20 jobs passed
      fixture-026 shards 3 and 6 failed under the eight-way local aggregate;
      neither shard consumes the changed file
PASS  npm run test:workstation:fixture-026:shard-3 (77/77, exact serial rerun)
PASS  npm run test:workstation:fixture-026:shard-6 (70/70, exact serial rerun)
```

The exact locked Node 26.8.1 runtime is used for every Node command.
