### PR TITLE
fix(workstation): bound local policy load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ the exact diff; this file records why the project changed.
 
 ### Fixed
 
+- Decision 0070 makes Fixture 026 check a missing arm commitment against
+  existing evaluator state before invoking the isolated policy bank, so a
+  bounded policy timeout cannot mask deterministic resume corruption. The
+  policy regexes and frozen VM deadlines do not change. The complete local Go
+  workstation aggregate now defaults to four active process trees inside its
+  hard ceiling of eight; the separate GitHub matrix keeps its eight-job bound.
+  All paths remain development validation with `NO_RESULT`.
 - The deterministic PDF finaliser now gives Chromium's `Strong` and `Em`
   structure types an explicit PDF 1.x compatibility mapping. Poppler's 627
   unknown-type diagnostics are removed without changing the page content or

--- a/decisions/0070-default-the-local-workstation-aggregate-to-four-commands.md
+++ b/decisions/0070-default-the-local-workstation-aggregate-to-four-commands.md
@@ -1,0 +1,56 @@
+# 0070 — Default the local workstation aggregate to four commands
+
+- **Status:** accepted
+- **Date:** 2026-09-05
+- **Partly supersedes:** [0068](0068-run-workstation-tests-through-the-bounded-go-catalogue.md),
+  clause 2's eight-command local default only
+- **Related:** [issue #7](https://github.com/lusoris/20-watts-was-enough/issues/7)
+
+## Context
+
+Decision 0068 made eight commands both the production default and the hard
+validation ceiling for the local Go workstation aggregate. Its first scheduling
+wave can place several process-heavy Fixture 026 shards beside one another. An
+eight-way aggregate failed two exact shards at policy boundaries; both shards
+passed unchanged when run alone. The failures exposed one deterministic
+preflight-order defect as well as local resource contention. Increasing the
+frozen policy VM deadlines or loosening the expected error would hide those
+boundaries rather than repair the scheduler.
+
+GitHub does not use the local Go scheduler for its workstation jobs. It runs the
+same catalogue as separate matrix jobs, where the existing eight-job cap bounds
+remote scheduling.
+
+## Decision
+
+1. Run `20w ci run-workstation` with four active commands by default. Retain
+   eight as the hard validation ceiling; the public command exposes no
+   concurrency override.
+2. Keep the GitHub workstation matrix at eight concurrent jobs. This decision
+   changes no workflow, catalogue entry, package script, test partition, seed,
+   horizon or assertion.
+3. Keep every isolated-policy regex and frozen VM deadline unchanged. The
+   Fixture 026 runner instead rejects a missing arm commitment beside any
+   evaluator-bearing raw, checkpoint, run or analysis state before invoking the
+   policy bank.
+4. Treat every aggregate and shard outcome as development validation with
+   `NO_RESULT`. Issue 7 remains open until a complete live workflow meets its
+   wall-time acceptance.
+
+## Consequences
+
+- Local validation leaves capacity for each bounded child process while still
+  executing the complete core-plus-artifact catalogue.
+- The local aggregate may take longer than an ideal eight-way schedule. A full
+  four-way run remains required at the integration boundary; this decision does
+  not claim its eventual duration.
+- A one-millisecond hostile timeout now proves that evaluator state wins the
+  failure order before policy execution can abstain. It creates neither a
+  replacement commitment nor an abstention artifact.
+- Remote CI retains its current eight-job scheduling behaviour.
+
+## Supersession
+
+Supersede this record if measured local runs justify a different default, the
+hard ceiling changes, or a containerised runner replaces direct local execution
+while preserving the closed test authority and `NO_RESULT` boundary.

--- a/decisions/README.md
+++ b/decisions/README.md
@@ -71,5 +71,6 @@ than silently changing its outcome.
 | [0064](0064-map-chromium-emphasis-tags-for-pdf-1x.md) | Map Chromium emphasis tags for PDF 1.x | accepted |
 | [0065](0065-isolate-fixture-026-ledger-semantics.md) | Isolate Fixture 026 ledger semantics from shard 5 | accepted |
 | [0066](0066-create-longer-workstation-matrix-jobs-first.md) | Create longer workstation matrix jobs first | accepted |
-| [0068](0068-run-workstation-tests-through-the-bounded-go-catalogue.md) | Run workstation tests through the bounded Go catalogue | accepted |
+| [0068](0068-run-workstation-tests-through-the-bounded-go-catalogue.md) | Run workstation tests through the bounded Go catalogue | accepted; clause 2's eight-command local default partly superseded by [0070](0070-default-the-local-workstation-aggregate-to-four-commands.md) |
 | [0069](0069-map-ci-deletions-through-their-owning-lanes.md) | Map CI deletions through their owning lanes | accepted |
+| [0070](0070-default-the-local-workstation-aggregate-to-four-commands.md) | Default the local workstation aggregate to four commands | accepted |

--- a/experiments/workstation/README.md
+++ b/experiments/workstation/README.md
@@ -55,14 +55,16 @@ energy comparison, or claim-promotion evidence.
 ## CI scheduling
 
 `npm run check` remains the complete local merge floor and runs the workstation
-inventory as one serial suite. GitHub full CI separates the non-workstation
-quality gate from workstation core and a closed test matrix. Under
-[decision 0051](../../decisions/0051-add-a-seventh-fixture-026-shard-after-live-timing.md),
-Fixture 026 uses seven fixed file-level jobs and Fixture 029 uses two; the other
+inventory through one bounded Go aggregate with four active commands by
+default and a hard ceiling of eight. GitHub full CI separately runs the
+non-workstation quality gate, workstation core, and a closed test matrix. Under
+[decision 0065](../../decisions/0065-isolate-fixture-026-ledger-semantics.md),
+Fixture 026 uses eight fixed file-level jobs and Fixture 029 uses two; the other
 nine artifacts retain one job each. Impact plans expand only the selected
 artifact, while a
-full plan requires all 18 matrix entries. The eight-job concurrency cap is a
-scheduling bound, not experiment parallelism or scientific evidence.
+full plan requires all 19 matrix entries. The GitHub matrix retains its
+eight-job concurrency cap; that remote scheduling bound is not experiment
+parallelism or scientific evidence.
 
 With eight GitHub runners available, the workstation matrix is initially
 expected to finish in roughly five to seven minutes because its two longest

--- a/experiments/workstation/fixture-026/rsd-t02-runner-boundaries.test.mjs
+++ b/experiments/workstation/fixture-026/rsd-t02-runner-boundaries.test.mjs
@@ -190,7 +190,11 @@ test("whole-system arm responses are committed before any evaluator-bearing raw 
     await rm(armPath);
     await assert.rejects(
       () => executeFixture026RsdT02({
-        profile: "smoke", output: fixture.output, resume: true, maxWorkUnits: 1,
+        profile: "smoke",
+        output: fixture.output,
+        resume: true,
+        maxWorkUnits: 1,
+        policyTimeoutMs: 1,
       }),
       /refuses to create an arm commitment after evaluator-bearing run state exists/u,
     );
@@ -215,6 +219,34 @@ test("whole-system arm responses are committed before any evaluator-bearing raw 
     );
   } finally {
     await cleanup(fixture);
+  }
+});
+
+test("every evaluator-bearing artifact blocks a missing arm commitment before policy execution", async () => {
+  for (const stateFile of [RAW_FILE, CHECKPOINT_FILE, RUN_FILE, SUMMARY_FILE]) {
+    const fixture = await temporaryOutput("fixture-026-rsd-t02-missing-arm-preflight-");
+    try {
+      const statePath = path.join(fixture.output, stateFile);
+      await mkdir(path.dirname(statePath), { recursive: true });
+      await writeFile(statePath, "occupied\n", "utf8");
+      await assert.rejects(
+        () => executeFixture026RsdT02({
+          profile: "smoke",
+          output: fixture.output,
+          resume: true,
+          policyTimeoutMs: 1,
+        }),
+        /refuses to create an arm commitment after evaluator-bearing run state exists/u,
+      );
+      for (const absentFile of [ARM_COMMITMENT_FILE, ARM_ABSTENTION_FILE]) {
+        await assert.rejects(
+          () => readFile(path.join(fixture.output, absentFile)),
+          (error) => error.code === "ENOENT",
+        );
+      }
+    } finally {
+      await cleanup(fixture);
+    }
   }
 });
 

--- a/experiments/workstation/fixture-026/rsd-t02-runner.mjs
+++ b/experiments/workstation/fixture-026/rsd-t02-runner.mjs
@@ -1277,29 +1277,33 @@ async function readValidatedRecords(directory, identity = null, profile = null) 
 }
 
 async function ensurePreEvaluatorArmCommitment({ directory, inputs, units, policyTimeoutMs }) {
-  const isolated = await expectedArmCommitment(inputs, units, policyTimeoutMs);
-  const expected = isolated.commitment;
   const commitmentPath = path.join(directory, ARM_COMMITMENT_FILE);
   await assertSafeRepositoryPath(commitmentPath, {
     allowMissing: true,
     finalType: "file",
     label: "Fixture 026 RSD-T02 pre-evaluator arm commitment",
   });
-  if (await exists(commitmentPath)) {
-    const stored = assertFixture026RsdT02ArmCommitment(await loadJson(commitmentPath));
-    if (canonicalize(stored) !== canonicalize(expected)) {
-      throw new Error("Fixture 026 RSD-T02 stored arm commitment differs from the frozen policies and packet grid.");
-    }
-  } else {
+  const hasCommitment = await exists(commitmentPath);
+  if (!hasCommitment) {
     const rawPath = path.join(directory, RAW_FILE);
     const rawHasEvaluatorRecords = await exists(rawPath) && (await stat(rawPath)).size > 0;
     if (
       rawHasEvaluatorRecords
       || await exists(path.join(directory, CHECKPOINT_FILE))
       || await exists(path.join(directory, RUN_FILE))
+      || await exists(path.join(directory, SUMMARY_FILE))
     ) {
       throw new Error("Fixture 026 RSD-T02 refuses to create an arm commitment after evaluator-bearing run state exists.");
     }
+  }
+  const isolated = await expectedArmCommitment(inputs, units, policyTimeoutMs);
+  const expected = isolated.commitment;
+  if (hasCommitment) {
+    const stored = assertFixture026RsdT02ArmCommitment(await loadJson(commitmentPath));
+    if (canonicalize(stored) !== canonicalize(expected)) {
+      throw new Error("Fixture 026 RSD-T02 stored arm commitment differs from the frozen policies and packet grid.");
+    }
+  } else {
     await writeJsonStable(commitmentPath, expected, { durable: true });
   }
   await assertSafeRepositoryPath(commitmentPath, {

--- a/tooling/internal/workstationrunner/runner.go
+++ b/tooling/internal/workstationrunner/runner.go
@@ -21,6 +21,7 @@ import (
 const (
 	expectedArtifactJobs         = 19
 	maximumSuiteJobs             = 32
+	defaultConcurrency           = 4
 	maximumConcurrency           = 8
 	maximumJobDuration           = 30 * time.Minute
 	maximumJobOutputBytes        = 2 << 20
@@ -141,7 +142,7 @@ func Run(ctx context.Context, repositoryRoot string, summary io.Writer) error {
 		return fmt.Errorf("resolve Node executable: %w", err)
 	}
 	return runSuite(ctx, root, jobs, runOptions{
-		concurrency: maximumConcurrency,
+		concurrency: defaultConcurrency,
 		jobDuration: maximumJobDuration,
 		outputBytes: maximumJobOutputBytes,
 		waitDelay:   maximumCommandWaitDelay,

--- a/tooling/internal/workstationrunner/runner_test.go
+++ b/tooling/internal/workstationrunner/runner_test.go
@@ -246,6 +246,23 @@ func TestRunSuiteRejectsConcurrencyAboveEight(t *testing.T) {
 	}
 }
 
+func TestLocalAggregateDefaultsToFourWithinEightHardLimit(t *testing.T) {
+	t.Parallel()
+	if defaultConcurrency != 4 {
+		t.Fatalf("defaultConcurrency = %d, want 4", defaultConcurrency)
+	}
+	if maximumConcurrency != 8 {
+		t.Fatalf("maximumConcurrency = %d, want 8", maximumConcurrency)
+	}
+	if defaultConcurrency >= maximumConcurrency {
+		t.Fatalf(
+			"default concurrency %d must stay below hard limit %d",
+			defaultConcurrency,
+			maximumConcurrency,
+		)
+	}
+}
+
 func TestRunSuiteRejectsInvalidBoundsAndDuplicateJobs(t *testing.T) {
 	t.Parallel()
 	valid := helperOptions(t, 1)


### PR DESCRIPTION
## Summary

- reject a missing Fixture 026 arm commitment beside non-empty raw, checkpoint,
  run, or analysis-summary state before invoking the isolated policy bank;
- run the complete local Go workstation catalogue with four active commands by
  default while retaining the hard maximum of eight;
- keep the separate GitHub workstation matrix at eight jobs, and record the
  local scheduling correction in append-only decision 0070.

## Failure repaired

The old failure order invoked `expectedArmCommitment` before checking whether
evaluator-bearing state made a missing commitment deterministic corruption.
Under load, a policy timeout could therefore report boundary abstention before
the runner reached the corruption check. The regression uses the same 1 ms
hostile timeout and proves all four evaluator-state forms fail first without
creating either a replacement commitment or an abstention artifact.

The local runner also used its hard safety maximum of eight as its production
default. Four is now the public default; validation still rejects values above
eight. No workflow changed, so remote matrix scheduling remains unchanged.

## Verification

- PASS — exact `npm run test:workstation:fixture-026:shard-6`: 71/71;
- PASS — post-rebase boundary file: 6/6;
- PASS — `go test -race -shuffle=on -count=1 ./internal/workstationrunner`;
- PASS — `go vet ./internal/workstationrunner`;
- PASS — JavaScript syntax and focused ESLint;
- PASS — workstation, engineering-policy, code-shape, prose, prose-test, and
  documentation validators;
- PASS — complete `npm run test:workstation` through the four-command
  production default: 20/20 jobs, zero failures, zero cancellations.
- PASS — exact `npm run check:full-without-workstation`, including every Go
  package, policy, release, source, translation, site/browser, readiness, build,
  and generated-site validation gate.

## Evidence boundary

The retained local diagnostic transcribes the earlier eight-way and standalone
durations, but the raw aggregate log was not retained. Those timings are
diagnostic context, not durable measurement authority. This change does not
alter policy regexes, frozen VM deadlines, package scripts, test partitions,
seeds, horizons, result authority, or scientific claims. Every execution path
remains development validation with `NO_RESULT`.

Tracks #7
