### PR TITLE
build(experiment): lock CLRS wheel selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,18 @@ the exact diff; this file records why the project changed.
 
 ### Added
 
+- Decision 0071 locks one 61-file, 823,932,066-byte Linux `amd64` wheel
+  selection for the pinned CLRS generator graph. Sixty files map directly to
+  `uv.lock`; the sole `promise==2.3` source build binds its sdist, three build
+  tools, candidate step arguments, twice-observed local byte identity and MIT
+  licence provenance while the complete build procedure and reproduction
+  receipt remain explicitly missing. Go now renders a candidate manifest to a
+  new path and verifies a materialised directory without Python, resolution or
+  network access. Compatibility is bound to CPython 3.13, Linux `amd64` and
+  glibc 2.36 from the pinned Bookworm base; verification bounds enumeration and
+  bytes before hashing and rejects concurrent directory drift. No wheel payload
+  enters Git, the generator image remains blocked, and all construction state
+  remains `NO_RESULT`.
 - Decision 0068 makes the Go workstation catalogue own each artifact's exact
   package script as well as its creation rank in one embedded machine-readable
   authority. CI consumes the projected, validated `{artifact, script}` objects

--- a/LICENSES/promise-MIT.txt
+++ b/LICENSES/promise-MIT.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Syrus Akbary
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -63,6 +63,11 @@ inventory. The reviewed Goldmark MIT text is retained verbatim in
 fails if that text or the compiled module graph differs from the reviewed
 identity.
 
+The CLRS generator wheelhouse foundation retains the reviewed Promise 2.3 MIT
+text verbatim in [`LICENSES/promise-MIT.txt`](LICENSES/promise-MIT.txt). Its
+source distribution and candidate wheel keep their own MIT terms; the
+foundation fails if the retained text differs from the recorded identity.
+
 ## Material not relicensed by this repository
 
 The licences above apply only to rights that the project contributors are

--- a/decisions/0071-lock-the-clrs-generator-wheel-selection.md
+++ b/decisions/0071-lock-the-clrs-generator-wheel-selection.md
@@ -1,0 +1,64 @@
+# 0071 — Lock the CLRS generator wheel selection
+
+- **Status:** accepted
+- **Date:** 2026-09-05
+- **Extends:** [0055](0055-freeze-clrs-text-as-a-controller-shakedown.md)
+- **Related:** [issue #12](https://github.com/lusoris/20-watts-was-enough/issues/12)
+
+## Context
+
+The CLRS generator dependency lock records 62 packages and 135 source or wheel
+artifacts across its one Linux `amd64` environment. A reproducible offline
+image needs one exact install artifact for each of the 61 runtime packages; the
+local project is the remaining lock entry. Selecting files during each image
+build would leave platform compatibility and source-versus-wheel choices to a
+mutable package index.
+
+Sixty runtime packages have compatible Python 3.13 wheels in the frozen lock.
+Compatibility here means CPython 3.13 on Linux `amd64`, against glibc 2.36 in
+the pinned Bookworm image. It excludes exact lock entries built for musl,
+WebAssembly, free-threaded CPython, another architecture, or a newer glibc.
+`promise==2.3` has only a 19,534-byte source distribution. Local reconnaissance
+with the pinned Python image, three locked build tools, a fixed epoch and a
+fixed environment produced the same 21,582-byte wheel twice. This slice does
+not retain a complete executable build procedure or reproduction receipt, so
+that identity is only a construction candidate. It is not generator-image
+admission or a scientific result.
+
+## Decision
+
+1. Track one canonical manifest selecting exactly 61 Linux `amd64`, Python
+   3.13 wheel files against the pinned base image and its glibc 2.36 boundary.
+   Each of the 60 downloaded wheels must match one exact URL, hash and size in
+   `uv.lock` and carry compatible Python, ABI and platform tags.
+2. Bind the sole missing `promise==2.3` wheel candidate to its locked source
+   distribution, pinned Python image, three locked build-tool wheels, candidate
+   step arguments and locally observed output identity. Record the complete
+   procedure and reproduction receipt as missing. Admission still requires two
+   clean byte-identical reproductions under one independently executable,
+   bounded container contract.
+3. Keep the 823,932,066 selected artifact bytes outside Git. A Go command must
+   verify the complete materialised directory without Python, a resolver or
+   network access. Candidate-manifest generation may only write a new file;
+   review and commit remain separate actions.
+4. Keep the generator image `blocked` and every construction artifact
+   `NO_RESULT` until the Dockerfile, complete offline context, licence, two
+   image builds, SBOM, hardened runtime smoke and two fixture generations pass
+   their existing gates.
+
+## Consequences
+
+- Package-index choice no longer occurs inside the future image build.
+- The exceptional source-build inputs and candidate output are visible instead
+  of being hidden inside an installer cache; the complete reproducible build
+  procedure remains an admission gate.
+- Materialising the wheelhouse still requires network access to fetch the
+  locked bytes, but verification and installation do not.
+- The manifest does not publish an image, fixture, model output, energy result
+  or claim-eligible comparison.
+
+## Supersession
+
+Supersede this record if the pinned dependency graph changes, upstream ships a
+reviewed compatible `promise` wheel, the target Python/platform changes, or a
+different source-build method is independently locked and reproduced.

--- a/decisions/README.md
+++ b/decisions/README.md
@@ -74,3 +74,4 @@ than silently changing its outcome.
 | [0068](0068-run-workstation-tests-through-the-bounded-go-catalogue.md) | Run workstation tests through the bounded Go catalogue | accepted; clause 2's eight-command local default partly superseded by [0070](0070-default-the-local-workstation-aggregate-to-four-commands.md) |
 | [0069](0069-map-ci-deletions-through-their-owning-lanes.md) | Map CI deletions through their owning lanes | accepted |
 | [0070](0070-default-the-local-workstation-aggregate-to-four-commands.md) | Default the local workstation aggregate to four commands | accepted |
+| [0071](0071-lock-the-clrs-generator-wheel-selection.md) | Lock the CLRS generator wheel selection | accepted |

--- a/public/downloads/book-manifest.json
+++ b/public/downloads/book-manifest.json
@@ -4,7 +4,7 @@
   "version": "0.3.0",
   "source_ref": "main",
   "pdf": "public/downloads/20-watts-was-enough-full-concept-book.pdf",
-  "source_digest": "0f71572d58fa531deb2266faf333456ab45df53d1b41b2023a5c4afcd2a878a3",
+  "source_digest": "de90efda30157cc183f4adaed2913e53646cca5761c10a6044be3dd66f988904",
   "source_files": [
     "app/book-content.ts",
     "app/components/book-edition.tsx",

--- a/scripts/book-pdf-semantic-baseline.json
+++ b/scripts/book-pdf-semantic-baseline.json
@@ -7,7 +7,7 @@
     "pdf": "public/downloads/20-watts-was-enough-full-concept-book.pdf",
     "manifest": "public/downloads/book-manifest.json",
     "pdf_sha256": "06a06d8f5cf2df794ed6ebea037baa3e1a6a7ed7045659296aa165486be74244",
-    "manifest_sha256": "286d64b22ea4e968ffecb3008746c0444d4ee846eeb91870adb9c2d06cb95715",
+    "manifest_sha256": "c4ccdac0ec5c89cbc7274b51a35c0378c3c21fcfdc25658259e5bf10f6989335",
     "size_bytes": 12780949,
     "pages": 412,
     "page_size_name": "A4",
@@ -18,7 +18,7 @@
     "pdf_version": "1.4",
     "tagged": true,
     "source_ref": "main",
-    "source_digest": "0f71572d58fa531deb2266faf333456ab45df53d1b41b2023a5c4afcd2a878a3",
+    "source_digest": "de90efda30157cc183f4adaed2913e53646cca5761c10a6044be3dd66f988904",
     "version": "0.3.0"
   },
   "tools": {

--- a/tooling/clrs-generator/README.md
+++ b/tooling/clrs-generator/README.md
@@ -1,7 +1,8 @@
 # CLRS generator image foundation
 
-No generator image is admitted yet. This directory now records the exact
-Linux `amd64` dependency graph, but the build context and retained acceptance
+No generator image is admitted yet. This directory records the exact Linux
+`amd64` dependency graph and the selected 61-file wheelhouse manifest. The
+wheel bytes, Dockerfile, complete build context and retained acceptance
 receipts are still absent. Registry absence has not been checked; the state
 remains `blocked` and `NO_RESULT`.
 
@@ -24,11 +25,26 @@ the controller, validator and fixture-import boundary.
   artifacts. Two isolated runs of the pinned resolver produced identical lock
   bytes. This closes dependency resolution only; it does not prove that the
   source imports or runs.
+- [`wheelhouse.json`](wheelhouse.json) selects one exact Python 3.13 Linux
+  `amd64` wheel for each of the 61 runtime packages and binds the pinned
+  Bookworm image's glibc 2.36 boundary. Sixty wheels map directly to compatible
+  artifacts in `uv.lock`; the Go validator rejects musl, WebAssembly,
+  free-threaded CPython, other architectures and glibc versions newer than the
+  base. `promise==2.3` has no upstream wheel, so the manifest fixes its
+  19,534-byte sdist, the three locked build-tool wheels, candidate step
+  arguments and the output identity seen in two local reconnaissance builds.
+  The complete executable container procedure and reproduction receipt remain
+  explicitly missing. The Promise MIT text is retained at
+  [`LICENSES/promise-MIT.txt`](../../LICENSES/promise-MIT.txt); the manifest
+  binds its source and built-wheel paths, hash and size. The complete selected
+  set is 823,932,066 bytes; those bytes remain ignored build inputs rather than
+  Git content.
 - [`image-contract.json`](image-contract.json) reuses the repository's pinned
   Buildx, BuildKit and timestamp-rewrite authority; fixes resource and runtime
   containment; binds the upstream licence's final image path; caps retained
-  SBOM bytes and packages; binds the exact dependency files; and records each
-  remaining acceptance identity as `missing`.
+  SBOM bytes and packages; binds the exact dependency files and selected
+  wheelhouse manifest; and keeps the Dockerfile and every execution-derived
+  acceptance identity missing.
 
 Python 3.13 is the newest candidate interpreter because TensorFlow 2.21.0 has no
 CPython 3.14 wheel, while current JAX and JAXlib require Python 3.12 or newer.
@@ -48,23 +64,43 @@ go -C tooling vet ./internal/clrsfixture
 
 `CheckGeneratorImageFoundation` rejects ambiguous JSON, non-canonical authority
 files, symlinks and unstable reads. It derives the project requirements from
-the reviewed inputs, binds the complete lock digest, checks its resolver
-header, cutoff, selected high-impact wheels, package count, artifact count and
-total recorded bytes, and rejects artifacts uploaded after the cutoff. A
-Dockerfile or wheelhouse manifest still fails while the contract marks it
-missing.
+the reviewed inputs, binds the complete lock and wheelhouse-manifest digests,
+checks the resolver header and cutoff, and requires exactly one selected wheel
+per runtime package. Every downloaded wheel must be an exact, platform-
+compatible `uv.lock` artifact. The sole source-built wheel must match its
+frozen source, build tools, candidate arguments, environment subset and output
+identity. This does not turn those partial fields into a build procedure.
+Directory enumeration and expected sizes bound verification before hashing; a
+final name-and-file-identity pass rejects files added or replaced during the
+read.
+
+Once the ignored wheel bytes have been materialised, verify their exact names,
+sizes, hashes and complete set without Python, a resolver or network access:
+
+```bash
+go -C tooling run ./cmd/20w experiment verify-clrs-wheelhouse \
+  --root .. \
+  --wheelhouse /path/to/wheelhouse
+```
+
+To reproduce the reviewed manifest into a new file for comparison, use
+`experiment render-clrs-wheelhouse-manifest`; it refuses to overwrite an
+existing output. Rendering a candidate does not change repository authority.
 
 ## Admission sequence
 
 The image stays blocked until one later, bounded change provides all of the
 following:
 
-1. a hash-complete Linux `amd64` wheelhouse and manifest selected from the
-   exact uv lock;
+1. materialisation of the 60 locked upstream wheels plus one complete,
+   retained container procedure and receipt for two clean, byte-identical
+   builds of the locked `promise` wheel;
 2. a checksum-closed Dockerfile and complete build context whose dependency
    install runs without network access;
 3. the 11,358-byte Apache-2.0 `LICENSE`, with its pinned source digest, at
-   `/usr/share/licenses/clrs/LICENSE`, bound to the final image and receipt;
+   `/usr/share/licenses/clrs/LICENSE`, plus verification that Promise's pinned
+   1,079-byte MIT text survives installation in its wheel metadata; both must
+   be represented in final-image evidence;
 4. a successful import smoke for the pinned CLRS source;
 5. identical manifest, config and layer identities from two isolated,
    no-cache builds;
@@ -87,6 +123,7 @@ seconds of wall time. The external runner must stop and remove the complete
 container after a five-second grace period. These are construction limits, not
 performance results.
 
-There is deliberately no `Dockerfile`, wheelhouse, generated fixture, admitted
-image digest or publication step in this foundation. [Issue 12](https://github.com/lusoris/20-watts-was-enough/issues/12)
-tracks the remaining acceptance work.
+There is deliberately no `Dockerfile`, committed wheel payload, generated
+fixture, admitted image digest or publication step in this foundation.
+[Issue 12](https://github.com/lusoris/20-watts-was-enough/issues/12) tracks the
+remaining acceptance work.

--- a/tooling/clrs-generator/image-contract.json
+++ b/tooling/clrs-generator/image-contract.json
@@ -33,11 +33,11 @@
     "artifact_count": 135
   },
   "build_context": {
-    "state": "missing",
+    "state": "wheelhouse-manifest-locked",
     "dockerfile_path": "tooling/clrs-generator/Dockerfile",
     "dockerfile_sha256": "",
     "wheelhouse_manifest_path": "tooling/clrs-generator/wheelhouse.json",
-    "wheelhouse_manifest_sha256": "",
+    "wheelhouse_manifest_sha256": "06f86574c8457337919bc2380b1fca899215bacd3c040cb127ea2d27ff9dcd06",
     "context_sha256": "",
     "install_network": "none"
   },
@@ -149,6 +149,8 @@
     "blocked_on": [
       "checksum_closed_build_context",
       "pinned_upstream_license_material",
+      "promise_source_build_procedure",
+      "promise_source_build_reproduction_receipt",
       "image_bound_spdx_sbom",
       "no_network_runtime_smoke",
       "pinned_source_import_smoke",

--- a/tooling/clrs-generator/wheelhouse.json
+++ b/tooling/clrs-generator/wheelhouse.json
@@ -1,0 +1,654 @@
+{
+  "schema_version": 1,
+  "authority": "NO_RESULT",
+  "state": "locked-selection",
+  "platform": "linux/amd64",
+  "python_version": "3.13.15",
+  "base_image": "docker.io/library/python:3.13.15-slim-bookworm@sha256:c45a22ea000adfd9cda29364bbe7edd23001ce5cc2ad15857cfbf7766943b9ca",
+  "glibc_version": "2.36",
+  "dependency_lock_sha256": "1aff6ff0e589539e07b3ee75579803ebd66636ab35568661680a703ed38ab640",
+  "source_date_epoch": 1787658740,
+  "package_count": 61,
+  "artifact_count": 61,
+  "downloaded_wheel_count": 60,
+  "source_built_wheel_count": 1,
+  "total_size_bytes": 823932066,
+  "artifacts": [
+    {
+      "package": "absl-py",
+      "version": "2.5.0",
+      "kind": "downloaded-wheel",
+      "filename": "absl_py-2.5.0-py3-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/58/0a/a10b45aab35b175aded078a462dc8d0c698f5b13946e7cb0869097b78bb6/absl_py-2.5.0-py3-none-any.whl",
+      "sha256": "0f17b89f2a4eaaedc4f28c622998aa690564b3012a396a4ffad0821007fe03ba",
+      "size_bytes": 137410
+    },
+    {
+      "package": "array-record",
+      "version": "0.8.3",
+      "kind": "downloaded-wheel",
+      "filename": "array_record-0.8.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
+      "url": "https://files.pythonhosted.org/packages/d7/6d/5575a1d64cffecb72de5743b35a1532b1801a0350b9b45f277090d02b3c2/array_record-0.8.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
+      "sha256": "13df1aec9b38afe98973bf5fe3cf523f83ca904b0423d85319930877145b8f28",
+      "size_bytes": 4995837
+    },
+    {
+      "package": "astunparse",
+      "version": "1.6.3",
+      "kind": "downloaded-wheel",
+      "filename": "astunparse-1.6.3-py2.py3-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/2b/03/13dde6512ad7b4557eb792fbcf0c653af6076b81e5941d36ec61f7ce6028/astunparse-1.6.3-py2.py3-none-any.whl",
+      "sha256": "c2652417f2c8b5bb325c885ae329bdf3f86424075c4fd1a128674bc6fba4b8e8",
+      "size_bytes": 12732
+    },
+    {
+      "package": "attrs",
+      "version": "26.1.0",
+      "kind": "downloaded-wheel",
+      "filename": "attrs-26.1.0-py3-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl",
+      "sha256": "c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309",
+      "size_bytes": 67548
+    },
+    {
+      "package": "certifi",
+      "version": "2026.7.22",
+      "kind": "downloaded-wheel",
+      "filename": "certifi-2026.7.22-py3-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl",
+      "sha256": "62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775",
+      "size_bytes": 136983
+    },
+    {
+      "package": "charset-normalizer",
+      "version": "3.5.1",
+      "kind": "downloaded-wheel",
+      "filename": "charset_normalizer-3.5.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl",
+      "url": "https://files.pythonhosted.org/packages/fb/af/63240b0c0248c075c2535a1f1bd992821d8251b9f173abc13329661d09e4/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl",
+      "sha256": "62b55f6722735a6c472f88361cde6640608773d9443cebdbb51abf436a1fcdd3",
+      "size_bytes": 250638
+    },
+    {
+      "package": "chex",
+      "version": "0.1.92",
+      "kind": "downloaded-wheel",
+      "filename": "chex-0.1.92-py3-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/de/42/5d8282d6dc4cd9971f865eb5cc767d180d1564475826e43150d1ea1dba51/chex-0.1.92-py3-none-any.whl",
+      "sha256": "f34989d9bff7954edfab09fba7757e3d62404da34577bff0d253599ec5b4f93d",
+      "size_bytes": 102275
+    },
+    {
+      "package": "dm-haiku",
+      "version": "0.0.17",
+      "kind": "downloaded-wheel",
+      "filename": "dm_haiku-0.0.17-py3-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/54/82/7045ad957defb3bfc28b89c748a1874c73f37b9337963b52d6de48ca4648/dm_haiku-0.0.17-py3-none-any.whl",
+      "sha256": "aa1394276adf59d695c910810ad90febb741503a83c32b022ce1162483904bbb",
+      "size_bytes": 377007
+    },
+    {
+      "package": "dm-tree",
+      "version": "0.1.10",
+      "kind": "downloaded-wheel",
+      "filename": "dm_tree-0.1.10-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl",
+      "url": "https://files.pythonhosted.org/packages/2f/23/bd3e75cbff06a464339d32667d740acf49812b027142a013b54d2c4d830a/dm_tree-0.1.10-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl",
+      "sha256": "6d7134c0805294c640b94d85cc725084f0c5087bcda5a7fb38eeb7f479ecc37c",
+      "size_bytes": 186187
+    },
+    {
+      "package": "docstring-parser",
+      "version": "0.18.0",
+      "kind": "downloaded-wheel",
+      "filename": "docstring_parser-0.18.0-py3-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl",
+      "sha256": "b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b",
+      "size_bytes": 22484
+    },
+    {
+      "package": "einops",
+      "version": "0.8.2",
+      "kind": "downloaded-wheel",
+      "filename": "einops-0.8.2-py3-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/2a/09/f8d8f8f31e4483c10a906437b4ce31bdf3d6d417b73fe33f1a8b59e34228/einops-0.8.2-py3-none-any.whl",
+      "sha256": "54058201ac7087911181bfec4af6091bb59380360f069276601256a76af08193",
+      "size_bytes": 65638
+    },
+    {
+      "package": "etils",
+      "version": "1.14.0",
+      "kind": "downloaded-wheel",
+      "filename": "etils-1.14.0-py3-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/5a/3d/589663aeeacd59bb2f3e8596bfd3e81cf0fb18d70bb433199041f469771b/etils-1.14.0-py3-none-any.whl",
+      "sha256": "b5df7341f54dbe1405a4450b2741207b4a8c279780402b45f87202b94dfc52b4",
+      "size_bytes": 172934
+    },
+    {
+      "package": "flatbuffers",
+      "version": "25.12.19",
+      "kind": "downloaded-wheel",
+      "filename": "flatbuffers-25.12.19-py2.py3-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl",
+      "sha256": "7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4",
+      "size_bytes": 26661
+    },
+    {
+      "package": "fsspec",
+      "version": "2026.7.0",
+      "kind": "downloaded-wheel",
+      "filename": "fsspec-2026.7.0-py3-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/fd/3c/6a2bf344106328fd04963664a60b9bb6496fc25df8e962fcdc1367285fb9/fsspec-2026.7.0-py3-none-any.whl",
+      "sha256": "b57ddbafedfaef7018c1ecab32aa200a9d7ca26b77965f64e48b70061249d279",
+      "size_bytes": 206583
+    },
+    {
+      "package": "gast",
+      "version": "0.7.0",
+      "kind": "downloaded-wheel",
+      "filename": "gast-0.7.0-py3-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/1d/33/f1c6a276de27b7d7339a34749cc33fa87f077f921969c47185d34a887ae2/gast-0.7.0-py3-none-any.whl",
+      "sha256": "99cbf1365633a74099f69c59bd650476b96baa5ef196fec88032b00b31ba36f7",
+      "size_bytes": 22966
+    },
+    {
+      "package": "google-pasta",
+      "version": "0.2.0",
+      "kind": "downloaded-wheel",
+      "filename": "google_pasta-0.2.0-py3-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/a3/de/c648ef6835192e6e2cc03f40b19eeda4382c49b5bafb43d88b931c4c74ac/google_pasta-0.2.0-py3-none-any.whl",
+      "sha256": "b32482794a366b5366a32c92a9a9201b107821889935a02b3e51f6b432ea84ed",
+      "size_bytes": 57471
+    },
+    {
+      "package": "googleapis-common-protos",
+      "version": "1.75.2",
+      "kind": "downloaded-wheel",
+      "filename": "googleapis_common_protos-1.75.2-py3-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/47/5b/1c9e55363c3b1890a98cae813de5b4ea327845756cd8fb7ee690140c7eac/googleapis_common_protos-1.75.2-py3-none-any.whl",
+      "sha256": "6b83302f554ea93a0f48409c7fc2050f954bcbcddb7e3a9c76d4a823cb22920e",
+      "size_bytes": 307002
+    },
+    {
+      "package": "grpcio",
+      "version": "1.83.1",
+      "kind": "downloaded-wheel",
+      "filename": "grpcio-1.83.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
+      "url": "https://files.pythonhosted.org/packages/54/ec/bd798654b06fb42a92b57d1dc1b530084fa89ed442806fcd0a833a36f9b3/grpcio-1.83.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
+      "sha256": "55656318d5dd387077396dffb929171ca3966e24bfead9a6c5dba9f889062cb4",
+      "size_bytes": 7042942
+    },
+    {
+      "package": "h5py",
+      "version": "3.14.0",
+      "kind": "downloaded-wheel",
+      "filename": "h5py-3.14.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+      "url": "https://files.pythonhosted.org/packages/e7/ec/86f59025306dcc6deee5fda54d980d077075b8d9889aac80f158bd585f1b/h5py-3.14.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+      "sha256": "d90e6445ab7c146d7f7981b11895d70bc1dd91278a4f9f9028bc0c95e4a53f13",
+      "size_bytes": 4921632
+    },
+    {
+      "package": "idna",
+      "version": "3.19",
+      "kind": "downloaded-wheel",
+      "filename": "idna-3.19-py3-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl",
+      "sha256": "815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4",
+      "size_bytes": 68550
+    },
+    {
+      "package": "immutabledict",
+      "version": "4.3.1",
+      "kind": "downloaded-wheel",
+      "filename": "immutabledict-4.3.1-py3-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/a3/ce/f9018bf69ae91b273b6391a095e7c93fa5e1617f25b6ba81ad4b20c9df10/immutabledict-4.3.1-py3-none-any.whl",
+      "sha256": "c9facdc0ff30fdb8e35bd16532026cac472a549e182c94fa201b51b25e4bf7bf",
+      "size_bytes": 5000
+    },
+    {
+      "package": "jax",
+      "version": "0.11.1",
+      "kind": "downloaded-wheel",
+      "filename": "jax-0.11.1-py3-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/8f/f4/5f9a286e1eeca9faa8b83885edccf63ab2f1b22e17f6a5ea66ac86b1afe4/jax-0.11.1-py3-none-any.whl",
+      "sha256": "72ed60bf85a0b53d0f5b5cd61e37a8b25f369f6f88481feb98ab489894861a82",
+      "size_bytes": 3302513
+    },
+    {
+      "package": "jaxlib",
+      "version": "0.11.1",
+      "kind": "downloaded-wheel",
+      "filename": "jaxlib-0.11.1-cp313-cp313-manylinux_2_27_x86_64.whl",
+      "url": "https://files.pythonhosted.org/packages/f5/28/ef1371618e784880e68c2ab5277d5ccbaf518a2a5ec9ec05ef90a9ee7d1b/jaxlib-0.11.1-cp313-cp313-manylinux_2_27_x86_64.whl",
+      "sha256": "7ebe86a7b891fcda83e7f634a677d285681a7b80b3ec9ed435536078a8371acf",
+      "size_bytes": 87901562
+    },
+    {
+      "package": "jmp",
+      "version": "0.0.4",
+      "kind": "downloaded-wheel",
+      "filename": "jmp-0.0.4-py3-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/27/e5/cce82de2831e5aff9332d8d624bb57188f1b2af6ccf6979caf898a8a4348/jmp-0.0.4-py3-none-any.whl",
+      "sha256": "6aa7adbddf2bd574b28c7faf6e81a735eb11f53386447896909c6968dc36807d",
+      "size_bytes": 18274
+    },
+    {
+      "package": "keras",
+      "version": "3.15.1",
+      "kind": "downloaded-wheel",
+      "filename": "keras-3.15.1-py3-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/8d/b3/c9b848bbdba18e765a8051917c0cc82585b64278ce87895f2e521a27438f/keras-3.15.1-py3-none-any.whl",
+      "sha256": "836460e480930acbd19bb7a17e62f9ecad40e8a9af9a651fc8d0586a96d27e20",
+      "size_bytes": 2398595
+    },
+    {
+      "package": "libclang",
+      "version": "18.1.1",
+      "kind": "downloaded-wheel",
+      "filename": "libclang-18.1.1-py2.py3-none-manylinux2010_x86_64.whl",
+      "url": "https://files.pythonhosted.org/packages/1d/fc/716c1e62e512ef1c160e7984a73a5fc7df45166f2ff3f254e71c58076f7c/libclang-18.1.1-py2.py3-none-manylinux2010_x86_64.whl",
+      "sha256": "c533091d8a3bbf7460a00cb6c1a71da93bffe148f172c7d03b1c31fbf8aa2a0b",
+      "size_bytes": 24515943
+    },
+    {
+      "package": "markdown-it-py",
+      "version": "4.2.0",
+      "kind": "downloaded-wheel",
+      "filename": "markdown_it_py-4.2.0-py3-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl",
+      "sha256": "9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a",
+      "size_bytes": 91687
+    },
+    {
+      "package": "mdurl",
+      "version": "0.1.2",
+      "kind": "downloaded-wheel",
+      "filename": "mdurl-0.1.2-py3-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl",
+      "sha256": "84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8",
+      "size_bytes": 9979
+    },
+    {
+      "package": "ml-collections",
+      "version": "1.1.0",
+      "kind": "downloaded-wheel",
+      "filename": "ml_collections-1.1.0-py3-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/ab/8a/18d4ff2c7bd83f30d6924bd4ad97abf418488c3f908dea228d6f0961ad68/ml_collections-1.1.0-py3-none-any.whl",
+      "sha256": "23b6fa4772aac1ae745a96044b925a5746145a70734f087eaca6626e92c05cbc",
+      "size_bytes": 76707
+    },
+    {
+      "package": "ml-dtypes",
+      "version": "0.6.0",
+      "kind": "downloaded-wheel",
+      "filename": "ml_dtypes-0.6.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
+      "url": "https://files.pythonhosted.org/packages/89/a5/da8ae6c6f1babe4b68e3e55d43d39b529e29774f10e0910671a6b8c86eb8/ml_dtypes-0.6.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
+      "sha256": "26b1f1fa4f0435a2946859823f6e2bf06796f1e9f10f5a05b08a5e3c8f46ff69",
+      "size_bytes": 410169
+    },
+    {
+      "package": "namex",
+      "version": "0.1.0",
+      "kind": "downloaded-wheel",
+      "filename": "namex-0.1.0-py3-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/b2/bc/465daf1de06409cdd4532082806770ee0d8d7df434da79c76564d0f69741/namex-0.1.0-py3-none-any.whl",
+      "sha256": "e2012a474502f1e2251267062aae3114611f07df4224b6e06334c57b0f2ce87c",
+      "size_bytes": 5905
+    },
+    {
+      "package": "numpy",
+      "version": "2.5.2",
+      "kind": "downloaded-wheel",
+      "filename": "numpy-2.5.2-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
+      "url": "https://files.pythonhosted.org/packages/7b/44/59a1eb68e773c4098d107ef34a0dbdeca501d72ffcfbff9a7707343921ce/numpy-2.5.2-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
+      "sha256": "29b86ff8a6cc556b47ec6b64b194815cc80e6bf5eedcc6cddfd65318cb0b4eee",
+      "size_bytes": 16709995
+    },
+    {
+      "package": "opt-einsum",
+      "version": "3.4.0",
+      "kind": "downloaded-wheel",
+      "filename": "opt_einsum-3.4.0-py3-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/23/cd/066e86230ae37ed0be70aae89aabf03ca8d9f39c8aea0dec8029455b5540/opt_einsum-3.4.0-py3-none-any.whl",
+      "sha256": "69bb92469f86a1565195ece4ac0323943e83477171b91d24c35afe028a90d7cd",
+      "size_bytes": 71932
+    },
+    {
+      "package": "optax",
+      "version": "0.2.8",
+      "kind": "downloaded-wheel",
+      "filename": "optax-0.2.8-py3-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/8a/69/6a93d8600c339d7687a05857c7907bd4dd8cf88691a5ea106d7a50af90a1/optax-0.2.8-py3-none-any.whl",
+      "sha256": "e3ca2d36c99daab1800ae9dbc0545034382d6bc780b24d969e1b0df65fa31cb4",
+      "size_bytes": 402960
+    },
+    {
+      "package": "optree",
+      "version": "0.20.0",
+      "kind": "downloaded-wheel",
+      "filename": "optree-0.20.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
+      "url": "https://files.pythonhosted.org/packages/93/b2/696029cd979f5429ec25c12767734bf0e13175d3341a2aeac59127d00ca0/optree-0.20.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
+      "sha256": "d1034c2cc02ec12ed413727664f015a681e2eea551e05640951b05b06c07f084",
+      "size_bytes": 490769
+    },
+    {
+      "package": "packaging",
+      "version": "26.3",
+      "kind": "downloaded-wheel",
+      "filename": "packaging-26.3-py3-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl",
+      "sha256": "d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c",
+      "size_bytes": 129956
+    },
+    {
+      "package": "promise",
+      "version": "2.3",
+      "kind": "source-built-wheel",
+      "filename": "promise-2.3-py3-none-any.whl",
+      "url": "",
+      "sha256": "bef8aedf1f65bca04bed59a7dd784f94075ceeb61c13ea9aaf86c91f569f861b",
+      "size_bytes": 21582
+    },
+    {
+      "package": "protobuf",
+      "version": "7.36.0",
+      "kind": "downloaded-wheel",
+      "filename": "protobuf-7.36.0-cp310-abi3-manylinux2014_x86_64.whl",
+      "url": "https://files.pythonhosted.org/packages/c7/f8/bd5804695ba400e423c33fd4d9f58c28d86633d5ba1945c36ff3967d98cb/protobuf-7.36.0-cp310-abi3-manylinux2014_x86_64.whl",
+      "sha256": "70f5ec8eb0da81a44360c0dc0beac99a0d78071d21956a7076bae8bd2051841b",
+      "size_bytes": 340439
+    },
+    {
+      "package": "psutil",
+      "version": "7.2.2",
+      "kind": "downloaded-wheel",
+      "filename": "psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl",
+      "url": "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl",
+      "sha256": "076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9",
+      "size_bytes": 155560
+    },
+    {
+      "package": "pyarrow",
+      "version": "25.0.1",
+      "kind": "downloaded-wheel",
+      "filename": "pyarrow-25.0.1-cp313-cp313-manylinux_2_28_x86_64.whl",
+      "url": "https://files.pythonhosted.org/packages/98/d6/33a411115b61dbfc16ad6ad73e71730f6fea654ee3667673bc53ab0e2fe7/pyarrow-25.0.1-cp313-cp313-manylinux_2_28_x86_64.whl",
+      "sha256": "0befcf816e45a1af33ac775a9970b749e4868a230c7372f0ae5e932bee27039f",
+      "size_bytes": 50104452
+    },
+    {
+      "package": "pygments",
+      "version": "2.21.0",
+      "kind": "downloaded-wheel",
+      "filename": "pygments-2.21.0-py3-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl",
+      "sha256": "2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9",
+      "size_bytes": 1250147
+    },
+    {
+      "package": "pyyaml",
+      "version": "6.0.3",
+      "kind": "downloaded-wheel",
+      "filename": "pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl",
+      "url": "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl",
+      "sha256": "0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6",
+      "size_bytes": 801626
+    },
+    {
+      "package": "requests",
+      "version": "2.34.2",
+      "kind": "downloaded-wheel",
+      "filename": "requests-2.34.2-py3-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl",
+      "sha256": "2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0",
+      "size_bytes": 73075
+    },
+    {
+      "package": "rich",
+      "version": "15.0.0",
+      "kind": "downloaded-wheel",
+      "filename": "rich-15.0.0-py3-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl",
+      "sha256": "33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb",
+      "size_bytes": 310654
+    },
+    {
+      "package": "scipy",
+      "version": "1.18.1",
+      "kind": "downloaded-wheel",
+      "filename": "scipy-1.18.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
+      "url": "https://files.pythonhosted.org/packages/41/48/6450ed9243315322bbc19ac57b9b70d66a20bf1d38d124c96bc4bf6af9ea/scipy-1.18.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
+      "sha256": "fdaf5ea890a6183d0565f51a61799d67081bd5b1cf03c5f4b3fd3732108625c9",
+      "size_bytes": 35312578
+    },
+    {
+      "package": "setuptools",
+      "version": "84.0.0",
+      "kind": "downloaded-wheel",
+      "filename": "setuptools-84.0.0-py3-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/95/9c/c510029fc6ef33a6275cd2c5d3cecd6613dfd6aa401d57c54f1c18852ccf/setuptools-84.0.0-py3-none-any.whl",
+      "sha256": "51a52592b3b99e102b609654876bd65f19f999935166d1352678931132b0c670",
+      "size_bytes": 818216
+    },
+    {
+      "package": "simple-parsing",
+      "version": "0.1.9",
+      "kind": "downloaded-wheel",
+      "filename": "simple_parsing-0.1.9-py3-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/dc/de/95277ceb670f0076d0d9ee06ade551d236e4989e2853e15a369bd7c67e5f/simple_parsing-0.1.9-py3-none-any.whl",
+      "sha256": "398c6b2c3d6ee3b865a6b8d7413999ee7b373de3c5a047f0b12b03b705d52e16",
+      "size_bytes": 113702
+    },
+    {
+      "package": "six",
+      "version": "1.17.0",
+      "kind": "downloaded-wheel",
+      "filename": "six-1.17.0-py2.py3-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl",
+      "sha256": "4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274",
+      "size_bytes": 11050
+    },
+    {
+      "package": "tabulate",
+      "version": "0.10.0",
+      "kind": "downloaded-wheel",
+      "filename": "tabulate-0.10.0-py3-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl",
+      "sha256": "f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3",
+      "size_bytes": 39814
+    },
+    {
+      "package": "tensorflow",
+      "version": "2.21.0",
+      "kind": "downloaded-wheel",
+      "filename": "tensorflow-2.21.0-cp313-cp313-manylinux_2_27_x86_64.whl",
+      "url": "https://files.pythonhosted.org/packages/86/6c/10d075ffc09754c7f10e749ba3c9d46dd809fb007990c7f788128044180c/tensorflow-2.21.0-cp313-cp313-manylinux_2_27_x86_64.whl",
+      "sha256": "e9d8da8dcab9650efb45f032ba70af2f016f907e6e0c6bda29dd101bba945406",
+      "size_bytes": 572881074
+    },
+    {
+      "package": "tensorflow-metadata",
+      "version": "1.21.0",
+      "kind": "downloaded-wheel",
+      "filename": "tensorflow_metadata-1.21.0-py3-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/d4/d1/6542ead3ba68ba54a6dbd9a3952514fac9c082b6f8ee860110fdf4c8f366/tensorflow_metadata-1.21.0-py3-none-any.whl",
+      "sha256": "0520806bf3bdd9157333203a3aa0e8afde2a97cc619f15ba622603dc6c898d1f",
+      "size_bytes": 30212
+    },
+    {
+      "package": "termcolor",
+      "version": "3.3.0",
+      "kind": "downloaded-wheel",
+      "filename": "termcolor-3.3.0-py3-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/33/d1/8bb87d21e9aeb323cc03034f5eaf2c8f69841e40e4853c2627edf8111ed3/termcolor-3.3.0-py3-none-any.whl",
+      "sha256": "cf642efadaf0a8ebbbf4bc7a31cec2f9b5f21a9f726f4ccbb08192c9c26f43a5",
+      "size_bytes": 7734
+    },
+    {
+      "package": "tfds-nightly",
+      "version": "4.9.9.dev202510250044",
+      "kind": "downloaded-wheel",
+      "filename": "tfds_nightly-4.9.9.dev202510250044-py3-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/6e/e2/8b6a66a15777ca2a730bc38881e1d7dbc70807ee09e91094f42335676dbf/tfds_nightly-4.9.9.dev202510250044-py3-none-any.whl",
+      "sha256": "aa1b56746733af6cebc614bd5f01179e9f46151320cc823973a7eed20b41b32c",
+      "size_bytes": 5335857
+    },
+    {
+      "package": "toml",
+      "version": "0.10.2",
+      "kind": "downloaded-wheel",
+      "filename": "toml-0.10.2-py2.py3-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl",
+      "sha256": "806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
+      "size_bytes": 16588
+    },
+    {
+      "package": "toolz",
+      "version": "1.1.0",
+      "kind": "downloaded-wheel",
+      "filename": "toolz-1.1.0-py3-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl",
+      "sha256": "15ccc861ac51c53696de0a5d6d4607f99c210739caf987b5d2054f3efed429d8",
+      "size_bytes": 58093
+    },
+    {
+      "package": "tqdm",
+      "version": "4.70.0",
+      "kind": "downloaded-wheel",
+      "filename": "tqdm-4.70.0-py3-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/f9/1c/01bfd571a64e7f270e6bab5e33777debe0edc56759233ce84f27dec92d14/tqdm-4.70.0-py3-none-any.whl",
+      "sha256": "7f585706bfddbdebf89daac705b2dfcc16890130727d3197ca62c732b4310953",
+      "size_bytes": 80184
+    },
+    {
+      "package": "typing-extensions",
+      "version": "4.16.0",
+      "kind": "downloaded-wheel",
+      "filename": "typing_extensions-4.16.0-py3-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl",
+      "sha256": "481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8",
+      "size_bytes": 45571
+    },
+    {
+      "package": "urllib3",
+      "version": "2.7.0",
+      "kind": "downloaded-wheel",
+      "filename": "urllib3-2.7.0-py3-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl",
+      "sha256": "9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897",
+      "size_bytes": 131087
+    },
+    {
+      "package": "wheel",
+      "version": "0.48.0",
+      "kind": "downloaded-wheel",
+      "filename": "wheel-0.48.0-py3-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/2e/29/69cfbb602cd91690c55d38ba9fe53e6a7e76a6fa647bf38f19c138d25449/wheel-0.48.0-py3-none-any.whl",
+      "sha256": "3217dcc807155e45db462d7ef2431f5ddda0d7273b700d05a67b271ceb1287ab",
+      "size_bytes": 33320
+    },
+    {
+      "package": "wrapt",
+      "version": "2.4.0",
+      "kind": "downloaded-wheel",
+      "filename": "wrapt-2.4.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl",
+      "url": "https://files.pythonhosted.org/packages/cb/a3/a3b5cde1cd06e04b6e95134eb3187a0a7da607a530e7795b221d4e4fa819/wrapt-2.4.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl",
+      "sha256": "6436e2bda993a3eb69a1b317fc831c8ebcafb5704c390859ebd49f81218c4bbb",
+      "size_bytes": 225787
+    },
+    {
+      "package": "zipp",
+      "version": "4.1.0",
+      "kind": "downloaded-wheel",
+      "filename": "zipp-4.1.0-py3-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl",
+      "sha256": "25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f",
+      "size_bytes": 10238
+    }
+  ],
+  "source_build": {
+    "procedure_state": "missing",
+    "reproduction_receipt_state": "missing",
+    "package": "promise",
+    "version": "2.3",
+    "provenance": {
+      "acquired_on": "2026-09-05",
+      "access_route": "https-download-from-uv-lock-url",
+      "upload_time": "2019-12-18T07:31:43.07Z",
+      "spdx": "MIT",
+      "repository_license_path": "LICENSES/promise-MIT.txt",
+      "source_license_path": "LICENSE",
+      "built_wheel_license_path": "promise-2.3.dist-info/licenses/LICENSE",
+      "license_sha256": "5d328768394abffaa84512c90783941dd899a62bcc8009a4181e28b2743228ec",
+      "license_size_bytes": 1079
+    },
+    "source_url": "https://files.pythonhosted.org/packages/cf/9c/fb5d48abfe5d791cd496e4242ebcf87a4bb2e0c3dcd6e0ae68c11426a528/promise-2.3.tar.gz",
+    "source_sha256": "dfd18337c523ba4b6a58801c164c1904a9d4d1b1747c7d5dbf45b693a49d93d0",
+    "source_size_bytes": 19534,
+    "builder_image": "docker.io/library/python:3.13.15-slim-bookworm@sha256:c45a22ea000adfd9cda29364bbe7edd23001ce5cc2ad15857cfbf7766943b9ca",
+    "build_requirements": [
+      {
+        "package": "packaging",
+        "version": "26.3",
+        "kind": "downloaded-wheel",
+        "filename": "packaging-26.3-py3-none-any.whl",
+        "url": "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl",
+        "sha256": "d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c",
+        "size_bytes": 129956
+      },
+      {
+        "package": "setuptools",
+        "version": "84.0.0",
+        "kind": "downloaded-wheel",
+        "filename": "setuptools-84.0.0-py3-none-any.whl",
+        "url": "https://files.pythonhosted.org/packages/95/9c/c510029fc6ef33a6275cd2c5d3cecd6613dfd6aa401d57c54f1c18852ccf/setuptools-84.0.0-py3-none-any.whl",
+        "sha256": "51a52592b3b99e102b609654876bd65f19f999935166d1352678931132b0c670",
+        "size_bytes": 818216
+      },
+      {
+        "package": "wheel",
+        "version": "0.48.0",
+        "kind": "downloaded-wheel",
+        "filename": "wheel-0.48.0-py3-none-any.whl",
+        "url": "https://files.pythonhosted.org/packages/2e/29/69cfbb602cd91690c55d38ba9fe53e6a7e76a6fa647bf38f19c138d25449/wheel-0.48.0-py3-none-any.whl",
+        "sha256": "3217dcc807155e45db462d7ef2431f5ddda0d7273b700d05a67b271ceb1287ab",
+        "size_bytes": 33320
+      }
+    ],
+    "candidate_working_directory": "/work/promise-2.3",
+    "candidate_bootstrap_argv": [
+      "python",
+      "-m",
+      "venv",
+      "/opt/build"
+    ],
+    "candidate_install_argv": [
+      "/opt/build/bin/python",
+      "-m",
+      "pip",
+      "install",
+      "--isolated",
+      "--disable-pip-version-check",
+      "--no-input",
+      "--no-cache-dir",
+      "--no-index",
+      "--no-deps",
+      "/inputs/wheelhouse/packaging-26.3-py3-none-any.whl",
+      "/inputs/wheelhouse/setuptools-84.0.0-py3-none-any.whl",
+      "/inputs/wheelhouse/wheel-0.48.0-py3-none-any.whl"
+    ],
+    "candidate_build_argv": [
+      "/opt/build/bin/python",
+      "setup.py",
+      "bdist_wheel",
+      "--dist-dir",
+      "/output"
+    ],
+    "candidate_environment": [
+      "LANG=C.UTF-8",
+      "LC_ALL=C.UTF-8",
+      "PYTHONHASHSEED=0",
+      "SOURCE_DATE_EPOCH=1787658740",
+      "TZ=UTC"
+    ],
+    "required_reproductions": 2
+  }
+}

--- a/tooling/cmd/20w/main.go
+++ b/tooling/cmd/20w/main.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/lusoris/20-watts-was-enough/tooling/internal/buildinfo"
 	"github.com/lusoris/20-watts-was-enough/tooling/internal/ciplan"
+	"github.com/lusoris/20-watts-was-enough/tooling/internal/clrsfixture"
 	"github.com/lusoris/20-watts-was-enough/tooling/internal/docscheck"
 	"github.com/lusoris/20-watts-was-enough/tooling/internal/experiment"
 	"github.com/lusoris/20-watts-was-enough/tooling/internal/githubapi"
@@ -55,6 +56,8 @@ func usage(writer io.Writer) {
 	fmt.Fprintln(writer, "  20w experiment validate [--root <repository>]")
 	fmt.Fprintln(writer, "  20w experiment release-plan [--root <repository>] [--json]")
 	fmt.Fprintln(writer, "  20w experiment package-node-image --artifact <id> --output <directory> [--root <repository>]")
+	fmt.Fprintln(writer, "  20w experiment render-clrs-wheelhouse-manifest --wheelhouse <directory> --output <new.json> [--root <repository>]")
+	fmt.Fprintln(writer, "  20w experiment verify-clrs-wheelhouse --wheelhouse <directory> [--root <repository>]")
 	fmt.Fprintln(writer, "  20w publication render-pdf [--root <repository>] [--ref main|vMAJOR.MINOR.PATCH] [--revision <commit>] [--check]")
 	fmt.Fprintln(writer, "  20w publication verify-pdf-tools [--root <repository>]")
 	fmt.Fprintln(writer, "  20w publication reproduce-pdf-tools-image --receipt <new.json> [--root <repository>]")
@@ -110,6 +113,12 @@ func run(arguments []string, stdout, stderr io.Writer) int {
 		}
 		if len(arguments) >= 2 && arguments[1] == "release-plan" {
 			return runExperimentReleasePlan(arguments[2:], stdout, stderr)
+		}
+		if len(arguments) >= 2 && arguments[1] == "render-clrs-wheelhouse-manifest" {
+			return runExperimentRenderCLRSWheelhouseManifest(arguments[2:], stdout, stderr)
+		}
+		if len(arguments) >= 2 && arguments[1] == "verify-clrs-wheelhouse" {
+			return runExperimentVerifyCLRSWheelhouse(arguments[2:], stdout, stderr)
 		}
 	case "release":
 		if len(arguments) >= 2 && arguments[1] == "inspect-image" {
@@ -994,6 +1003,67 @@ func runExperimentReleasePlan(arguments []string, stdout, stderr io.Writer) int 
 	for _, entry := range plan {
 		fmt.Fprintf(stdout, "%s\t%s\t%s\n", entry.Artifact, entry.Distribution.Image, strings.Join(entry.Distribution.Platforms, ","))
 	}
+	return 0
+}
+
+func runExperimentRenderCLRSWheelhouseManifest(arguments []string, stdout, stderr io.Writer) int {
+	flags := flag.NewFlagSet("experiment render-clrs-wheelhouse-manifest", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	root := flags.String("root", ".", "repository root")
+	wheelhouse := flags.String("wheelhouse", "", "materialised wheel directory")
+	output := flags.String("output", "", "new candidate manifest path")
+	if err := flags.Parse(arguments); err != nil {
+		return 2
+	}
+	if flags.NArg() != 0 {
+		fmt.Fprintln(stderr, "experiment render-clrs-wheelhouse-manifest accepts no positional arguments")
+		return 2
+	}
+	if *wheelhouse == "" || *output == "" {
+		fmt.Fprintln(stderr, "experiment render-clrs-wheelhouse-manifest requires --wheelhouse and --output")
+		return 2
+	}
+	digest, size, err := clrsfixture.WriteGeneratorWheelhouseManifest(*root, *wheelhouse, *output)
+	if err != nil {
+		fmt.Fprintf(stderr, "Render CLRS generator wheelhouse manifest: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(
+		stdout,
+		"CLRS generator wheelhouse manifest rendered: sha256:%s, %d bytes, NO_RESULT.\n",
+		digest,
+		size,
+	)
+	return 0
+}
+
+func runExperimentVerifyCLRSWheelhouse(arguments []string, stdout, stderr io.Writer) int {
+	flags := flag.NewFlagSet("experiment verify-clrs-wheelhouse", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	root := flags.String("root", ".", "repository root")
+	wheelhouse := flags.String("wheelhouse", "", "materialised wheel directory")
+	if err := flags.Parse(arguments); err != nil {
+		return 2
+	}
+	if flags.NArg() != 0 {
+		fmt.Fprintln(stderr, "experiment verify-clrs-wheelhouse accepts no positional arguments")
+		return 2
+	}
+	if *wheelhouse == "" {
+		fmt.Fprintln(stderr, "experiment verify-clrs-wheelhouse requires --wheelhouse")
+		return 2
+	}
+	manifest, err := clrsfixture.VerifyGeneratorWheelhouse(*root, *wheelhouse)
+	if err != nil {
+		fmt.Fprintf(stderr, "Verify CLRS generator wheelhouse: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(
+		stdout,
+		"CLRS generator wheelhouse verified: %d artifacts, %d bytes, NO_RESULT.\n",
+		manifest.ArtifactCount,
+		manifest.TotalSizeBytes,
+	)
 	return 0
 }
 

--- a/tooling/cmd/20w/main_test.go
+++ b/tooling/cmd/20w/main_test.go
@@ -123,6 +123,39 @@ func TestRunPackageNodeImageRequiresClosedArguments(t *testing.T) {
 	}
 }
 
+func TestRunCLRSWheelhouseCommandsAreVisibleAndRequireClosedArguments(t *testing.T) {
+	t.Parallel()
+	var help bytes.Buffer
+	var helpErrors bytes.Buffer
+	if exitCode := run([]string{"--help"}, &help, &helpErrors); exitCode != 0 || helpErrors.Len() != 0 {
+		t.Fatalf("help exit/stderr = %d/%q", exitCode, helpErrors.String())
+	}
+	for _, command := range []string{
+		"experiment render-clrs-wheelhouse-manifest",
+		"experiment verify-clrs-wheelhouse",
+	} {
+		if !strings.Contains(help.String(), command) {
+			t.Fatalf("help omits %q", command)
+		}
+	}
+
+	for name, arguments := range map[string][]string{
+		"render without wheelhouse": {"experiment", "render-clrs-wheelhouse-manifest", "--output", "candidate.json"},
+		"render without output":     {"experiment", "render-clrs-wheelhouse-manifest", "--wheelhouse", "wheels"},
+		"verify without wheelhouse": {"experiment", "verify-clrs-wheelhouse"},
+	} {
+		name, arguments := name, arguments
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			if exitCode := run(arguments, &stdout, &stderr); exitCode != 2 || !strings.Contains(stderr.String(), "requires") {
+				t.Fatalf("run() exit/stdout/stderr = %d/%q/%q, want usage failure", exitCode, stdout.String(), stderr.String())
+			}
+		})
+	}
+}
+
 func TestRunPublicationRenderPDFCheckIsOfflineAndReportsThePin(t *testing.T) {
 	t.Parallel()
 	var stdout bytes.Buffer

--- a/tooling/internal/clrsfixture/image_contract.go
+++ b/tooling/internal/clrsfixture/image_contract.go
@@ -23,6 +23,8 @@ var (
 	lockedGeneratorBlockers = []string{
 		"checksum_closed_build_context",
 		"pinned_upstream_license_material",
+		"promise_source_build_procedure",
+		"promise_source_build_reproduction_receipt",
 		"image_bound_spdx_sbom",
 		"no_network_runtime_smoke",
 		"pinned_source_import_smoke",
@@ -130,10 +132,10 @@ func validateGeneratorBuildEvidence(contract GeneratorImageContract, sourceLicen
 		return errors.New("generator dependency lock metadata is invalid")
 	}
 	context := contract.BuildContext
-	if context.State != "missing" || context.DockerfilePath != "tooling/clrs-generator/Dockerfile" ||
-		context.DockerfileSHA256 != "" || context.WheelhouseManifestPath != "tooling/clrs-generator/wheelhouse.json" ||
-		context.WheelhouseManifestSHA256 != "" || context.ContextSHA256 != "" || context.InstallNetwork != "none" {
-		return errors.New("generator checksum-closed build context must remain explicitly missing")
+	if context.State != "wheelhouse-manifest-locked" || context.DockerfilePath != "tooling/clrs-generator/Dockerfile" ||
+		context.DockerfileSHA256 != "" || context.WheelhouseManifestPath != trackedGeneratorWheelhousePath ||
+		!lowerHex(context.WheelhouseManifestSHA256, 64) || context.ContextSHA256 != "" || context.InstallNetwork != "none" {
+		return errors.New("generator build context must bind the locked wheelhouse manifest and keep the Dockerfile explicitly missing")
 	}
 	license := contract.LicenseMaterial
 	if license.State != "missing" || license.SPDX != sourceLicense.SPDX || license.SourcePath != sourceLicense.Path ||

--- a/tooling/internal/clrsfixture/image_files.go
+++ b/tooling/internal/clrsfixture/image_files.go
@@ -22,6 +22,8 @@ const (
 	trackedImageContractPath           = "tooling/clrs-generator/image-contract.json"
 	trackedGeneratorProjectPath        = "tooling/clrs-generator/pyproject.toml"
 	trackedGeneratorDependencyLockPath = "tooling/clrs-generator/uv.lock"
+	trackedGeneratorWheelhousePath     = "tooling/clrs-generator/wheelhouse.json"
+	maximumGeneratorWheelLicenseBytes  = 4 << 10
 )
 
 // CheckGeneratorImageFoundation validates the complete committed foundation
@@ -87,13 +89,41 @@ func CheckGeneratorImageFoundation(repositoryRoot string) (GeneratorImageFoundat
 	); err != nil {
 		return GeneratorImageFoundation{}, err
 	}
-	for _, missing := range []string{
-		imageContract.BuildContext.DockerfilePath,
+	wheelhouseBody, err := readGeneratorFile(
+		root,
 		imageContract.BuildContext.WheelhouseManifestPath,
-	} {
-		if err := requireMissingGeneratorFile(root, missing); err != nil {
-			return GeneratorImageFoundation{}, err
-		}
+		imageContract.Limits.WheelhouseManifestBytes,
+	)
+	if err != nil {
+		return GeneratorImageFoundation{}, err
+	}
+	if rawSHA256(wheelhouseBody) != imageContract.BuildContext.WheelhouseManifestSHA256 {
+		return GeneratorImageFoundation{}, errors.New("CLRS generator wheelhouse manifest digest is invalid")
+	}
+	wheelhouseManifest, err := ParseGeneratorWheelhouseManifest(
+		wheelhouseBody,
+		dependencyLockBody,
+		lockInput,
+		imageContract,
+	)
+	if err != nil {
+		return GeneratorImageFoundation{}, err
+	}
+	promiseProvenance := wheelhouseManifest.SourceBuild.Provenance
+	promiseLicenseBody, err := readGeneratorFile(
+		root,
+		promiseProvenance.RepositoryLicensePath,
+		maximumGeneratorWheelLicenseBytes,
+	)
+	if err != nil {
+		return GeneratorImageFoundation{}, err
+	}
+	if rawSHA256(promiseLicenseBody) != promiseProvenance.LicenseSHA256 ||
+		int64(len(promiseLicenseBody)) != promiseProvenance.LicenseSizeBytes {
+		return GeneratorImageFoundation{}, errors.New("CLRS generator promise licence identity is invalid")
+	}
+	if err := requireMissingGeneratorFile(root, imageContract.BuildContext.DockerfilePath); err != nil {
+		return GeneratorImageFoundation{}, err
 	}
 	sourceID, _ := source.Identity()
 	generationID, _ := generation.Identity(source)
@@ -104,6 +134,7 @@ func CheckGeneratorImageFoundation(repositoryRoot string) (GeneratorImageFoundat
 		GenerationContract:   generationID,
 		LockInputSHA256:      rawSHA256(lockBody),
 		DependencyLockSHA256: rawSHA256(dependencyLockBody),
+		WheelhouseSHA256:     rawSHA256(wheelhouseBody),
 		ImageContractSHA256:  rawSHA256(imageBody),
 	}, nil
 }

--- a/tooling/internal/clrsfixture/image_model.go
+++ b/tooling/internal/clrsfixture/image_model.go
@@ -82,7 +82,7 @@ type GeneratorImageContract struct {
 	LockInput            GeneratorFileBinding     `json:"lock_input"`
 	Builder              GeneratorBuilder         `json:"builder"`
 	DependencyLock       GeneratorDependencyLock  `json:"dependency_lock"`
-	BuildContext         MissingBuildContext      `json:"build_context"`
+	BuildContext         GeneratorBuildContext    `json:"build_context"`
 	LicenseMaterial      MissingLicenseMaterial   `json:"license_material"`
 	ImageIdentity        MissingImageIdentity     `json:"image_identity"`
 	SBOM                 MissingSBOM              `json:"sbom"`
@@ -120,7 +120,7 @@ type GeneratorDependencyLock struct {
 	ArtifactCount int    `json:"artifact_count"`
 }
 
-type MissingBuildContext struct {
+type GeneratorBuildContext struct {
 	State                    string `json:"state"`
 	DockerfilePath           string `json:"dockerfile_path"`
 	DockerfileSHA256         string `json:"dockerfile_sha256"`
@@ -240,5 +240,69 @@ type GeneratorImageFoundation struct {
 	GenerationContract   ContractID
 	LockInputSHA256      string
 	DependencyLockSHA256 string
+	WheelhouseSHA256     string
 	ImageContractSHA256  string
+}
+
+// GeneratorWheelhouseManifest binds the one Linux amd64 artifact selected for
+// every locked runtime package. It is a construction input, not an admitted
+// image or scientific result.
+type GeneratorWheelhouseManifest struct {
+	SchemaVersion         int                        `json:"schema_version"`
+	Authority             string                     `json:"authority"`
+	State                 string                     `json:"state"`
+	Platform              string                     `json:"platform"`
+	PythonVersion         string                     `json:"python_version"`
+	BaseImage             string                     `json:"base_image"`
+	GlibcVersion          string                     `json:"glibc_version"`
+	DependencyLockSHA256  string                     `json:"dependency_lock_sha256"`
+	SourceDateEpoch       int64                      `json:"source_date_epoch"`
+	PackageCount          int                        `json:"package_count"`
+	ArtifactCount         int                        `json:"artifact_count"`
+	DownloadedWheelCount  int                        `json:"downloaded_wheel_count"`
+	SourceBuiltWheelCount int                        `json:"source_built_wheel_count"`
+	TotalSizeBytes        int64                      `json:"total_size_bytes"`
+	Artifacts             []GeneratorWheelhouseEntry `json:"artifacts"`
+	SourceBuild           GeneratorWheelSourceBuild  `json:"source_build"`
+}
+
+type GeneratorWheelhouseEntry struct {
+	Package   string `json:"package"`
+	Version   string `json:"version"`
+	Kind      string `json:"kind"`
+	Filename  string `json:"filename"`
+	URL       string `json:"url"`
+	SHA256    string `json:"sha256"`
+	SizeBytes int64  `json:"size_bytes"`
+}
+
+type GeneratorWheelSourceBuild struct {
+	ProcedureState            string                         `json:"procedure_state"`
+	ReproductionReceiptState  string                         `json:"reproduction_receipt_state"`
+	Package                   string                         `json:"package"`
+	Version                   string                         `json:"version"`
+	Provenance                GeneratorWheelSourceProvenance `json:"provenance"`
+	SourceURL                 string                         `json:"source_url"`
+	SourceSHA256              string                         `json:"source_sha256"`
+	SourceSizeBytes           int64                          `json:"source_size_bytes"`
+	BuilderImage              string                         `json:"builder_image"`
+	BuildRequirements         []GeneratorWheelhouseEntry     `json:"build_requirements"`
+	CandidateWorkingDirectory string                         `json:"candidate_working_directory"`
+	CandidateBootstrapCommand []string                       `json:"candidate_bootstrap_argv"`
+	CandidateInstallCommand   []string                       `json:"candidate_install_argv"`
+	CandidateBuildCommand     []string                       `json:"candidate_build_argv"`
+	CandidateEnvironment      []string                       `json:"candidate_environment"`
+	RequiredReproductions     int                            `json:"required_reproductions"`
+}
+
+type GeneratorWheelSourceProvenance struct {
+	AcquiredOn            string `json:"acquired_on"`
+	AccessRoute           string `json:"access_route"`
+	UploadTime            string `json:"upload_time"`
+	SPDX                  string `json:"spdx"`
+	RepositoryLicensePath string `json:"repository_license_path"`
+	SourceLicensePath     string `json:"source_license_path"`
+	BuiltWheelLicensePath string `json:"built_wheel_license_path"`
+	LicenseSHA256         string `json:"license_sha256"`
+	LicenseSizeBytes      int64  `json:"license_size_bytes"`
 }

--- a/tooling/internal/clrsfixture/image_test.go
+++ b/tooling/internal/clrsfixture/image_test.go
@@ -12,7 +12,8 @@ import (
 const (
 	expectedGeneratorLockInputSHA256  = "ea0e8f7d2d3ce347e82cbdd0e956dceca3da27ee499b52e18a6f6010526a5a19"
 	expectedGeneratorDependencySHA256 = "1aff6ff0e589539e07b3ee75579803ebd66636ab35568661680a703ed38ab640"
-	expectedGeneratorImageSHA256      = "75ee2897e844d9509a504c09d80a8ffbbc3ad424a18d0556ee281233d419c51f"
+	expectedGeneratorWheelhouseSHA256 = "06f86574c8457337919bc2380b1fca899215bacd3c040cb127ea2d27ff9dcd06"
+	expectedGeneratorImageSHA256      = "01c7572913795e3a930e73224b2c63f6a9361fd3542a956dad2d181db91c46a5"
 )
 
 func TestTrackedGeneratorImageFoundationIsClosedAndBlocked(t *testing.T) {
@@ -30,11 +31,13 @@ func TestTrackedGeneratorImageFoundationIsClosedAndBlocked(t *testing.T) {
 	}
 	if foundation.LockInputSHA256 != expectedGeneratorLockInputSHA256 ||
 		foundation.DependencyLockSHA256 != expectedGeneratorDependencySHA256 ||
+		foundation.WheelhouseSHA256 != expectedGeneratorWheelhouseSHA256 ||
 		foundation.ImageContractSHA256 != expectedGeneratorImageSHA256 {
 		t.Fatalf(
-			"foundation input/dependency/image hashes = %s/%s/%s",
+			"foundation input/dependency/wheelhouse/image hashes = %s/%s/%s/%s",
 			foundation.LockInputSHA256,
 			foundation.DependencyLockSHA256,
+			foundation.WheelhouseSHA256,
 			foundation.ImageContractSHA256,
 		)
 	}
@@ -165,15 +168,34 @@ func TestParseGeneratorImageContractRejectsPretendedAcceptance(t *testing.T) {
 	lockBody := trackedGeneratorFile(t, "lock-input.json")
 	valid := string(trackedGeneratorFile(t, "image-contract.json"))
 	tests := map[string]string{
-		"duplicate":            strings.Replace(valid, `"state": "blocked"`, `"state": "blocked", "state": "blocked"`, 1),
-		"unknown":              strings.Replace(valid, `"schema_version": 1`, `"schema_version": 1, "extra": true`, 1),
-		"trailing":             valid + `{}`,
-		"ready header":         strings.Replace(valid, `"state": "blocked"`, `"state": "ready"`, 1),
-		"result authority":     strings.Replace(valid, `"NO_RESULT"`, `"RESULT"`, 1),
-		"wrong source":         strings.Replace(valid, contractSourceIdentity(t), "sha256:"+strings.Repeat("a", 64), 1),
-		"wrong contract":       strings.Replace(valid, expectedContractIdentity, "sha256:"+strings.Repeat("b", 64), 1),
-		"wrong lock digest":    strings.Replace(valid, expectedGeneratorLockInputSHA256, strings.Repeat("c", 64), 1),
-		"dependency missing":   strings.Replace(valid, `"state": "locked"`, `"state": "missing"`, 1),
+		"duplicate":          strings.Replace(valid, `"state": "blocked"`, `"state": "blocked", "state": "blocked"`, 1),
+		"unknown":            strings.Replace(valid, `"schema_version": 1`, `"schema_version": 1, "extra": true`, 1),
+		"trailing":           valid + `{}`,
+		"ready header":       strings.Replace(valid, `"state": "blocked"`, `"state": "ready"`, 1),
+		"result authority":   strings.Replace(valid, `"NO_RESULT"`, `"RESULT"`, 1),
+		"wrong source":       strings.Replace(valid, contractSourceIdentity(t), "sha256:"+strings.Repeat("a", 64), 1),
+		"wrong contract":     strings.Replace(valid, expectedContractIdentity, "sha256:"+strings.Repeat("b", 64), 1),
+		"wrong lock digest":  strings.Replace(valid, expectedGeneratorLockInputSHA256, strings.Repeat("c", 64), 1),
+		"dependency missing": strings.Replace(valid, `"state": "locked"`, `"state": "missing"`, 1),
+		"wheelhouse missing": strings.Replace(
+			valid,
+			`"state": "wheelhouse-manifest-locked"`,
+			`"state": "missing"`,
+			1,
+		),
+		"wheelhouse path": strings.Replace(
+			valid,
+			`"wheelhouse_manifest_path": "tooling/clrs-generator/wheelhouse.json"`,
+			`"wheelhouse_manifest_path": "wheelhouse.json"`,
+			1,
+		),
+		"invalid wheelhouse digest": strings.Replace(valid, expectedGeneratorWheelhouseSHA256, strings.Repeat("f", 63), 1),
+		"dockerfile pretence": strings.Replace(
+			valid,
+			`"dockerfile_sha256": ""`,
+			`"dockerfile_sha256": "`+strings.Repeat("e", 64)+`"`,
+			1,
+		),
 		"networked install":    strings.Replace(valid, `"install_network": "none"`, `"install_network": "default"`, 1),
 		"licence SPDX":         strings.Replace(valid, `"spdx": "Apache-2.0"`, `"spdx": "MIT"`, 1),
 		"licence digest":       strings.Replace(valid, `"source_sha256": "cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30"`, `"source_sha256": "`+strings.Repeat("d", 64)+`"`, 1),
@@ -205,6 +227,13 @@ func TestParseGeneratorImageContractRejectsPretendedAcceptance(t *testing.T) {
 		"ready acceptance":     strings.Replace(valid, `"source_context": "locked"`, `"source_context": "ready"`, 1),
 		"dropped blocker":      strings.Replace(valid, `"pinned_source_import_smoke",`, ``, 1),
 		"dropped licence gate": strings.Replace(valid, `"pinned_upstream_license_material",`, ``, 1),
+		"procedure gate":       strings.Replace(valid, `"promise_source_build_procedure",`, ``, 1),
+		"source receipt gate": strings.Replace(
+			valid,
+			`"promise_source_build_reproduction_receipt",`,
+			``,
+			1,
+		),
 	}
 	for name, body := range tests {
 		name, body := name, body
@@ -255,6 +284,24 @@ func TestGeneratorImageFoundationRejectsSymlinkAndDependencyLockTamper(t *testin
 	}
 	if _, err := CheckGeneratorImageFoundation(root); err == nil || !strings.Contains(err.Error(), "digest is invalid") {
 		t.Fatalf("CheckGeneratorImageFoundation project error = %v", err)
+	}
+
+	root = copyGeneratorFoundation(t)
+	wheelhousePath := filepath.Join(root, filepath.FromSlash(trackedGeneratorWheelhousePath))
+	if err := os.WriteFile(wheelhousePath, []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := CheckGeneratorImageFoundation(root); err == nil || !strings.Contains(err.Error(), "manifest digest is invalid") {
+		t.Fatalf("CheckGeneratorImageFoundation wheelhouse-manifest error = %v", err)
+	}
+
+	root = copyGeneratorFoundation(t)
+	promiseLicense := filepath.Join(root, filepath.FromSlash(promiseLicensePath))
+	if err := os.WriteFile(promiseLicense, []byte("not the MIT licence\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := CheckGeneratorImageFoundation(root); err == nil || !strings.Contains(err.Error(), "licence identity is invalid") {
+		t.Fatalf("CheckGeneratorImageFoundation promise-licence error = %v", err)
 	}
 }
 
@@ -340,6 +387,8 @@ func copyGeneratorFoundation(t *testing.T) string {
 		trackedImageContractPath,
 		trackedGeneratorProjectPath,
 		trackedGeneratorDependencyLockPath,
+		trackedGeneratorWheelhousePath,
+		promiseLicensePath,
 		"tooling/pdf-renderer/lock.json",
 	}
 	for _, relative := range paths {

--- a/tooling/internal/clrsfixture/image_wheelhouse.go
+++ b/tooling/internal/clrsfixture/image_wheelhouse.go
@@ -1,0 +1,918 @@
+package clrsfixture
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	generatorRuntimePackageCount = 61
+	generatorSourceDateEpoch     = int64(1_787_658_740)
+	generatorGlibcVersion        = "2.36"
+	generatorMaximumGlibcMinor   = 36
+	promiseWheelFilename         = "promise-2.3-py3-none-any.whl"
+	promiseWheelSHA256           = "bef8aedf1f65bca04bed59a7dd784f94075ceeb61c13ea9aaf86c91f569f861b"
+	promiseWheelSize             = int64(21_582)
+	promiseLicensePath           = "LICENSES/promise-MIT.txt"
+	promiseLicenseSHA256         = "5d328768394abffaa84512c90783941dd899a62bcc8009a4181e28b2743228ec"
+	promiseLicenseSize           = int64(1_079)
+)
+
+var generatorSourceBuildEnvironment = []string{
+	"LANG=C.UTF-8",
+	"LC_ALL=C.UTF-8",
+	"PYTHONHASHSEED=0",
+	"SOURCE_DATE_EPOCH=1787658740",
+	"TZ=UTC",
+}
+
+type lockedGeneratorArtifact struct {
+	Package    string
+	Version    string
+	Filename   string
+	URL        string
+	SHA256     string
+	SizeBytes  int64
+	UploadTime string
+	Wheel      bool
+}
+
+type lockedGeneratorPackage struct {
+	Name      string
+	Version   string
+	Artifacts []lockedGeneratorArtifact
+}
+
+// ParseGeneratorWheelhouseManifest validates the complete selected artifact
+// set against the exact uv lock. It does not require the artifact bytes to be
+// present and grants no image or result authority.
+func ParseGeneratorWheelhouseManifest(
+	body, dependencyLockBody []byte,
+	input GeneratorLockInput,
+	imageContract GeneratorImageContract,
+) (GeneratorWheelhouseManifest, error) {
+	if len(body) == 0 || int64(len(body)) > imageContract.Limits.WheelhouseManifestBytes {
+		return GeneratorWheelhouseManifest{}, fmt.Errorf(
+			"CLRS generator wheelhouse manifest size = %d, want 1..%d",
+			len(body),
+			imageContract.Limits.WheelhouseManifestBytes,
+		)
+	}
+	var manifest GeneratorWheelhouseManifest
+	if err := decodeCanonicalGeneratorJSON(body, 8, &manifest); err != nil {
+		return GeneratorWheelhouseManifest{}, fmt.Errorf("parse CLRS generator wheelhouse manifest: %w", err)
+	}
+	if rawSHA256(dependencyLockBody) != imageContract.DependencyLock.SHA256 {
+		return GeneratorWheelhouseManifest{}, errors.New("CLRS generator wheelhouse dependency-lock digest is invalid")
+	}
+	packages, err := parseLockedGeneratorPackages(dependencyLockBody)
+	if err != nil {
+		return GeneratorWheelhouseManifest{}, err
+	}
+	if err := manifest.validate(input, imageContract, packages); err != nil {
+		return GeneratorWheelhouseManifest{}, err
+	}
+	return manifest, nil
+}
+
+func (manifest GeneratorWheelhouseManifest) validate(
+	input GeneratorLockInput,
+	imageContract GeneratorImageContract,
+	packages []lockedGeneratorPackage,
+) error {
+	if manifest.SchemaVersion != 1 || manifest.Authority != ResultAuthority || manifest.State != "locked-selection" ||
+		manifest.Platform != input.Platform || manifest.PythonVersion != input.Python.Version ||
+		manifest.BaseImage != input.Python.BaseImage || manifest.GlibcVersion != generatorGlibcVersion ||
+		manifest.DependencyLockSHA256 != imageContract.DependencyLock.SHA256 ||
+		manifest.SourceDateEpoch != generatorSourceDateEpoch {
+		return errors.New("generator wheelhouse manifest header is invalid")
+	}
+	if manifest.PackageCount != generatorRuntimePackageCount || manifest.ArtifactCount != generatorRuntimePackageCount ||
+		manifest.DownloadedWheelCount != generatorRuntimePackageCount-1 || manifest.SourceBuiltWheelCount != 1 ||
+		len(manifest.Artifacts) != generatorRuntimePackageCount {
+		return errors.New("generator wheelhouse manifest counts are invalid")
+	}
+	if manifest.TotalSizeBytes <= 0 || manifest.TotalSizeBytes > imageContract.Limits.DependencyArtifactBytes {
+		return errors.New("generator wheelhouse manifest byte total is invalid")
+	}
+	locked := make(map[string]lockedGeneratorPackage, len(packages))
+	for _, pkg := range packages {
+		if pkg.Name == "twenty-watts-clrs-generator" {
+			continue
+		}
+		locked[pkg.Name] = pkg
+	}
+	seen := make(map[string]bool, len(manifest.Artifacts))
+	var total int64
+	downloaded := 0
+	built := 0
+	previous := ""
+	for _, artifact := range manifest.Artifacts {
+		if artifact.Package <= previous || artifact.Package != canonicalGeneratorPackageName(artifact.Package) ||
+			seen[artifact.Package] {
+			return errors.New("generator wheelhouse artifacts must be unique and sorted by canonical package name")
+		}
+		previous = artifact.Package
+		seen[artifact.Package] = true
+		pkg, present := locked[artifact.Package]
+		if !present || artifact.Version != pkg.Version || !validGeneratorWheelFilename(artifact.Filename) ||
+			!lowerHex(artifact.SHA256, 64) || artifact.SizeBytes <= 0 {
+			return fmt.Errorf("generator wheelhouse artifact %q is invalid", artifact.Package)
+		}
+		if artifact.SizeBytes > limitsSafeAddend(total) {
+			return errors.New("generator wheelhouse byte total overflows")
+		}
+		total += artifact.SizeBytes
+		switch artifact.Kind {
+		case "downloaded-wheel":
+			if !matchesLockedWheel(artifact, pkg.Artifacts) {
+				return fmt.Errorf("generator wheelhouse artifact %q is not one exact locked wheel", artifact.Package)
+			}
+			downloaded++
+		case "source-built-wheel":
+			if artifact.Package != "promise" || artifact.Filename != promiseWheelFilename || artifact.URL != "" ||
+				artifact.SHA256 != promiseWheelSHA256 || artifact.SizeBytes != promiseWheelSize {
+				return errors.New("generator promise wheel differs from the frozen source-build output")
+			}
+			built++
+		default:
+			return fmt.Errorf("generator wheelhouse artifact %q has an invalid kind", artifact.Package)
+		}
+	}
+	if len(seen) != len(locked) || downloaded != manifest.DownloadedWheelCount ||
+		built != manifest.SourceBuiltWheelCount || total != manifest.TotalSizeBytes {
+		return errors.New("generator wheelhouse manifest coverage or totals are invalid")
+	}
+	for name := range locked {
+		if !seen[name] {
+			return fmt.Errorf("generator wheelhouse manifest omits package %q", name)
+		}
+	}
+	wantSourceBuild, err := lockedPromiseSourceBuild(input, packages, manifest.Artifacts)
+	if err != nil {
+		return err
+	}
+	if !equalGeneratorSourceBuild(manifest.SourceBuild, wantSourceBuild) {
+		return errors.New("generator wheelhouse source-build recipe is invalid")
+	}
+	return nil
+}
+
+func matchesLockedWheel(entry GeneratorWheelhouseEntry, artifacts []lockedGeneratorArtifact) bool {
+	for _, artifact := range artifacts {
+		if artifact.Wheel && compatibleGeneratorWheelFilename(artifact.Filename) &&
+			entry.Filename == artifact.Filename && entry.URL == artifact.URL &&
+			entry.SHA256 == artifact.SHA256 && entry.SizeBytes == artifact.SizeBytes {
+			return true
+		}
+	}
+	return false
+}
+
+func validGeneratorWheelFilename(value string) bool {
+	return value != "" && value == path.Base(value) && !strings.ContainsAny(value, "/\\\x00") &&
+		strings.HasSuffix(value, ".whl")
+}
+
+func compatibleGeneratorWheelFilename(value string) bool {
+	if !validGeneratorWheelFilename(value) {
+		return false
+	}
+	fields := strings.Split(strings.TrimSuffix(value, ".whl"), "-")
+	if len(fields) < 5 {
+		return false
+	}
+	pythonTag := fields[len(fields)-3]
+	abiTag := fields[len(fields)-2]
+	platformTag := fields[len(fields)-1]
+	if platformTag == "any" {
+		return abiTag == "none" && (pythonTag == "py3" || pythonTag == "py2.py3")
+	}
+	for _, tag := range strings.Split(platformTag, ".") {
+		if !compatibleGeneratorManylinuxTag(tag) {
+			return false
+		}
+	}
+	if pythonTag == "py3" || pythonTag == "py2.py3" {
+		return abiTag == "none"
+	}
+	if pythonTag == "cp313" {
+		return abiTag == "cp313" || abiTag == "abi3"
+	}
+	if !strings.HasPrefix(pythonTag, "cp3") || abiTag != "abi3" {
+		return false
+	}
+	minor, err := strconv.Atoi(strings.TrimPrefix(pythonTag, "cp3"))
+	return err == nil && minor >= 6 && minor <= 13
+}
+
+func compatibleGeneratorManylinuxTag(tag string) bool {
+	switch tag {
+	case "manylinux1_x86_64", "manylinux2010_x86_64", "manylinux2014_x86_64":
+		return true
+	}
+	const prefix = "manylinux_2_"
+	const suffix = "_x86_64"
+	if !strings.HasPrefix(tag, prefix) || !strings.HasSuffix(tag, suffix) {
+		return false
+	}
+	minorText := strings.TrimSuffix(strings.TrimPrefix(tag, prefix), suffix)
+	minor, err := strconv.Atoi(minorText)
+	return err == nil && minor >= 5 && minor <= generatorMaximumGlibcMinor
+}
+
+func lockedPromiseSourceBuild(
+	input GeneratorLockInput,
+	packages []lockedGeneratorPackage,
+	selected []GeneratorWheelhouseEntry,
+) (GeneratorWheelSourceBuild, error) {
+	var source lockedGeneratorArtifact
+	sourceCount := 0
+	buildPackages := map[string]bool{"packaging": true, "setuptools": true, "wheel": true}
+	lockedBuildPackages := make(map[string]lockedGeneratorPackage, len(buildPackages))
+	for _, pkg := range packages {
+		if pkg.Name == "promise" {
+			for _, artifact := range pkg.Artifacts {
+				if !artifact.Wheel {
+					source = artifact
+					sourceCount++
+				}
+			}
+		}
+		if buildPackages[pkg.Name] {
+			lockedBuildPackages[pkg.Name] = pkg
+		}
+	}
+	if sourceCount != 1 || source.Package != "promise" || source.Version != "2.3" || source.Wheel ||
+		source.Filename != "promise-2.3.tar.gz" {
+		return GeneratorWheelSourceBuild{}, errors.New("generator promise source artifact is invalid")
+	}
+	buildRequirements := make([]GeneratorWheelhouseEntry, 0, len(buildPackages))
+	seenBuildPackages := make(map[string]bool, len(buildPackages))
+	for _, artifact := range selected {
+		if !buildPackages[artifact.Package] {
+			continue
+		}
+		pkg, present := lockedBuildPackages[artifact.Package]
+		if !present || seenBuildPackages[artifact.Package] || artifact.Version != pkg.Version ||
+			artifact.Kind != "downloaded-wheel" || !matchesLockedWheel(artifact, pkg.Artifacts) {
+			return GeneratorWheelSourceBuild{}, fmt.Errorf(
+				"generator source-build requirement %q is not one selected exact locked wheel",
+				artifact.Package,
+			)
+		}
+		seenBuildPackages[artifact.Package] = true
+		buildRequirements = append(buildRequirements, artifact)
+	}
+	for name := range buildPackages {
+		if !seenBuildPackages[name] {
+			return GeneratorWheelSourceBuild{}, fmt.Errorf(
+				"generator source-build requirement %q is not selected",
+				name,
+			)
+		}
+	}
+	sort.Slice(buildRequirements, func(left, right int) bool {
+		return buildRequirements[left].Package < buildRequirements[right].Package
+	})
+	installCommand := []string{
+		"/opt/build/bin/python", "-m", "pip", "install", "--isolated", "--disable-pip-version-check",
+		"--no-input", "--no-cache-dir", "--no-index", "--no-deps",
+	}
+	for _, requirement := range buildRequirements {
+		installCommand = append(installCommand, "/inputs/wheelhouse/"+requirement.Filename)
+	}
+	return GeneratorWheelSourceBuild{
+		ProcedureState: "missing", ReproductionReceiptState: "missing",
+		Package: "promise", Version: "2.3",
+		Provenance: GeneratorWheelSourceProvenance{
+			AcquiredOn: "2026-09-05", AccessRoute: "https-download-from-uv-lock-url", UploadTime: source.UploadTime,
+			SPDX: "MIT", RepositoryLicensePath: promiseLicensePath, SourceLicensePath: "LICENSE",
+			BuiltWheelLicensePath: "promise-2.3.dist-info/licenses/LICENSE",
+			LicenseSHA256:         promiseLicenseSHA256, LicenseSizeBytes: promiseLicenseSize,
+		},
+		SourceURL: source.URL, SourceSHA256: source.SHA256, SourceSizeBytes: source.SizeBytes,
+		BuilderImage:              input.Python.BaseImage,
+		BuildRequirements:         buildRequirements,
+		CandidateWorkingDirectory: "/work/promise-2.3",
+		CandidateBootstrapCommand: []string{"python", "-m", "venv", "/opt/build"},
+		CandidateInstallCommand:   installCommand,
+		CandidateBuildCommand: []string{
+			"/opt/build/bin/python", "setup.py", "bdist_wheel", "--dist-dir", "/output",
+		},
+		CandidateEnvironment:  slices.Clone(generatorSourceBuildEnvironment),
+		RequiredReproductions: 2,
+	}, nil
+}
+
+func equalGeneratorSourceBuild(left, right GeneratorWheelSourceBuild) bool {
+	return left.ProcedureState == right.ProcedureState &&
+		left.ReproductionReceiptState == right.ReproductionReceiptState &&
+		left.Package == right.Package && left.Version == right.Version && left.Provenance == right.Provenance &&
+		left.SourceURL == right.SourceURL &&
+		left.SourceSHA256 == right.SourceSHA256 && left.SourceSizeBytes == right.SourceSizeBytes &&
+		left.BuilderImage == right.BuilderImage && slices.Equal(left.BuildRequirements, right.BuildRequirements) &&
+		left.CandidateWorkingDirectory == right.CandidateWorkingDirectory &&
+		slices.Equal(left.CandidateBootstrapCommand, right.CandidateBootstrapCommand) &&
+		slices.Equal(left.CandidateInstallCommand, right.CandidateInstallCommand) &&
+		slices.Equal(left.CandidateBuildCommand, right.CandidateBuildCommand) &&
+		slices.Equal(left.CandidateEnvironment, right.CandidateEnvironment) &&
+		left.RequiredReproductions == right.RequiredReproductions
+}
+
+func parseLockedGeneratorPackages(body []byte) ([]lockedGeneratorPackage, error) {
+	var packages []lockedGeneratorPackage
+	var current *lockedGeneratorPackage
+	for _, line := range strings.Split(string(body), "\n") {
+		switch {
+		case line == "[[package]]":
+			packages = append(packages, lockedGeneratorPackage{})
+			current = &packages[len(packages)-1]
+		case current != nil && strings.HasPrefix(line, "name = \""):
+			value, ok := quotedGeneratorField(line, "name")
+			if !ok || current.Name != "" {
+				return nil, errors.New("generator uv lock package name is malformed")
+			}
+			current.Name = canonicalGeneratorPackageName(value)
+		case current != nil && strings.HasPrefix(line, "version = \""):
+			value, ok := quotedGeneratorField(line, "version")
+			if !ok || current.Version != "" {
+				return nil, errors.New("generator uv lock package version is malformed")
+			}
+			current.Version = value
+		case current != nil && (strings.HasPrefix(line, "sdist = { url = \"") || strings.HasPrefix(line, "    { url = \"")):
+			artifact, err := lockedGeneratorArtifactFromLine(current.Name, current.Version, line)
+			if err != nil {
+				return nil, err
+			}
+			current.Artifacts = append(current.Artifacts, artifact)
+		}
+	}
+	if len(packages) != lockedGeneratorPackageCount {
+		return nil, fmt.Errorf("generator uv lock package count = %d, want %d", len(packages), lockedGeneratorPackageCount)
+	}
+	seen := make(map[string]bool, len(packages))
+	for _, pkg := range packages {
+		if pkg.Name == "" || pkg.Version == "" || seen[pkg.Name] {
+			return nil, errors.New("generator uv lock contains an incomplete or duplicate package")
+		}
+		seen[pkg.Name] = true
+	}
+	return packages, nil
+}
+
+func lockedGeneratorArtifactFromLine(packageName, version, line string) (lockedGeneratorArtifact, error) {
+	if packageName == "" || version == "" {
+		return lockedGeneratorArtifact{}, errors.New("generator uv lock artifact precedes its package identity")
+	}
+	artifactURL, ok := quotedGeneratorField(line, "url")
+	if !ok {
+		return lockedGeneratorArtifact{}, errors.New("generator uv lock artifact URL is malformed")
+	}
+	parsed, err := url.Parse(artifactURL)
+	if err != nil || parsed.Path == "" {
+		return lockedGeneratorArtifact{}, errors.New("generator uv lock artifact URL is invalid")
+	}
+	filename := path.Base(parsed.Path)
+	if filename == "." || filename == "/" || strings.Contains(filename, "%") {
+		return lockedGeneratorArtifact{}, errors.New("generator uv lock artifact filename is invalid")
+	}
+	hash, ok := quotedGeneratorField(line, "hash")
+	if !ok || !strings.HasPrefix(hash, "sha256:") {
+		return lockedGeneratorArtifact{}, errors.New("generator uv lock artifact digest is malformed")
+	}
+	size, uploadTime, err := inspectGeneratorArtifact(line)
+	if err != nil {
+		return lockedGeneratorArtifact{}, err
+	}
+	return lockedGeneratorArtifact{
+		Package: packageName, Version: version, Filename: filename, URL: artifactURL,
+		SHA256: strings.TrimPrefix(hash, "sha256:"), SizeBytes: size,
+		UploadTime: uploadTime.Format(time.RFC3339Nano), Wheel: strings.HasSuffix(filename, ".whl"),
+	}, nil
+}
+
+// RenderGeneratorWheelhouseManifest derives a candidate manifest from one
+// already materialised exact wheel directory. It performs no network access.
+func RenderGeneratorWheelhouseManifest(repositoryRoot, wheelhouseDirectory string) ([]byte, error) {
+	input, imageContract, dependencyLockBody, err := loadGeneratorWheelhouseInputs(repositoryRoot)
+	if err != nil {
+		return nil, err
+	}
+	packages, err := parseLockedGeneratorPackages(dependencyLockBody)
+	if err != nil {
+		return nil, err
+	}
+	artifacts, total, err := inspectMaterializedGeneratorWheelhouse(
+		wheelhouseDirectory,
+		packages,
+		imageContract.Limits.DependencyArtifactBytes,
+	)
+	if err != nil {
+		return nil, err
+	}
+	sourceBuild, err := lockedPromiseSourceBuild(input, packages, artifacts)
+	if err != nil {
+		return nil, err
+	}
+	manifest := GeneratorWheelhouseManifest{
+		SchemaVersion: 1, Authority: ResultAuthority, State: "locked-selection", Platform: input.Platform,
+		PythonVersion: input.Python.Version, BaseImage: input.Python.BaseImage, GlibcVersion: generatorGlibcVersion,
+		DependencyLockSHA256: imageContract.DependencyLock.SHA256,
+		SourceDateEpoch:      generatorSourceDateEpoch, PackageCount: len(artifacts), ArtifactCount: len(artifacts),
+		DownloadedWheelCount: len(artifacts) - 1, SourceBuiltWheelCount: 1, TotalSizeBytes: total,
+		Artifacts: artifacts, SourceBuild: sourceBuild,
+	}
+	var output bytes.Buffer
+	encoder := json.NewEncoder(&output)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(manifest); err != nil {
+		return nil, fmt.Errorf("encode CLRS generator wheelhouse manifest: %w", err)
+	}
+	body := output.Bytes()
+	if _, err := ParseGeneratorWheelhouseManifest(body, dependencyLockBody, input, imageContract); err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+
+// VerifyGeneratorWheelhouse checks a materialised directory against the
+// tracked manifest without invoking Python, a resolver, or the network.
+func VerifyGeneratorWheelhouse(repositoryRoot, wheelhouseDirectory string) (GeneratorWheelhouseManifest, error) {
+	if _, err := CheckGeneratorImageFoundation(repositoryRoot); err != nil {
+		return GeneratorWheelhouseManifest{}, err
+	}
+	input, imageContract, dependencyLockBody, err := loadGeneratorWheelhouseInputs(repositoryRoot)
+	if err != nil {
+		return GeneratorWheelhouseManifest{}, err
+	}
+	root, err := cleanGeneratorRoot(repositoryRoot)
+	if err != nil {
+		return GeneratorWheelhouseManifest{}, err
+	}
+	tracked, err := readGeneratorFile(root, trackedGeneratorWheelhousePath, imageContract.Limits.WheelhouseManifestBytes)
+	if err != nil {
+		return GeneratorWheelhouseManifest{}, err
+	}
+	manifest, err := ParseGeneratorWheelhouseManifest(tracked, dependencyLockBody, input, imageContract)
+	if err != nil {
+		return GeneratorWheelhouseManifest{}, err
+	}
+	rendered, err := RenderGeneratorWheelhouseManifest(repositoryRoot, wheelhouseDirectory)
+	if err != nil {
+		return GeneratorWheelhouseManifest{}, err
+	}
+	if !bytes.Equal(rendered, tracked) {
+		return GeneratorWheelhouseManifest{}, errors.New("materialised CLRS generator wheelhouse differs from the tracked manifest")
+	}
+	return manifest, nil
+}
+
+// WriteGeneratorWheelhouseManifest writes one new candidate manifest without
+// replacing an existing path. Review and commit remain separate operations.
+func WriteGeneratorWheelhouseManifest(repositoryRoot, wheelhouseDirectory, output string) (string, int64, error) {
+	body, err := RenderGeneratorWheelhouseManifest(repositoryRoot, wheelhouseDirectory)
+	if err != nil {
+		return "", 0, err
+	}
+	return writeNewGeneratorWheelhouseManifest(wheelhouseDirectory, output, body)
+}
+
+func writeNewGeneratorWheelhouseManifest(wheelhouseDirectory, output string, body []byte) (string, int64, error) {
+	return writeNewGeneratorWheelhouseManifestWithInterlock(wheelhouseDirectory, output, body, nil)
+}
+
+func writeNewGeneratorWheelhouseManifestWithInterlock(
+	wheelhouseDirectory, output string,
+	body []byte,
+	afterClose func() error,
+) (digest string, size int64, writeErr error) {
+	if output == "" {
+		return "", 0, errors.New("CLRS generator wheelhouse manifest output is required")
+	}
+	if len(body) == 0 {
+		return "", 0, errors.New("CLRS generator wheelhouse manifest body is required")
+	}
+	absolute, err := filepath.Abs(output)
+	if err != nil {
+		return "", 0, fmt.Errorf("resolve CLRS generator wheelhouse manifest output: %w", err)
+	}
+	absolute = filepath.Clean(absolute)
+	parent, err := cleanGeneratorRoot(filepath.Dir(absolute))
+	if err != nil || parent != filepath.Dir(absolute) {
+		return "", 0, errors.New("CLRS generator wheelhouse manifest output parent must be one real canonical directory")
+	}
+	wheelhouse, err := cleanGeneratorRoot(wheelhouseDirectory)
+	if err != nil {
+		return "", 0, fmt.Errorf("inspect CLRS generator wheelhouse output boundary: %w", err)
+	}
+	if relative, relativeErr := filepath.Rel(wheelhouse, absolute); relativeErr == nil &&
+		(relative == "." || (relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator)))) {
+		return "", 0, errors.New("CLRS generator wheelhouse manifest output must be outside the wheel directory")
+	}
+	name := filepath.Base(absolute)
+	if name == "." || name == string(filepath.Separator) {
+		return "", 0, errors.New("CLRS generator wheelhouse manifest output needs a file name")
+	}
+	namedParentState, err := inspectGeneratorRootPath(parent)
+	if err != nil {
+		return "", 0, fmt.Errorf("inspect CLRS generator wheelhouse manifest output parent: %w", err)
+	}
+	parentRoot, err := os.OpenRoot(parent)
+	if err != nil {
+		return "", 0, fmt.Errorf("open CLRS generator wheelhouse manifest output parent: %w", err)
+	}
+	defer parentRoot.Close()
+	parentState, err := parentRoot.Stat(".")
+	if err != nil || !sameGeneratorDirectoryIdentity(namedParentState, parentState) {
+		return "", 0, errors.New("CLRS generator wheelhouse manifest output parent is not a stable directory")
+	}
+	file, err := parentRoot.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return "", 0, fmt.Errorf("create CLRS generator wheelhouse manifest output: %w", err)
+	}
+	createdState, err := file.Stat()
+	if err != nil || !createdState.Mode().IsRegular() {
+		_ = file.Close()
+		return "", 0, errors.New("created CLRS generator wheelhouse manifest is not a regular file")
+	}
+	defer func() {
+		_ = file.Close()
+		if writeErr != nil {
+			writeErr = fmt.Errorf(
+				"%w; output name %q was left untouched under the opened output directory",
+				writeErr,
+				name,
+			)
+		}
+	}()
+	if _, err := file.Write(body); err != nil {
+		return "", 0, fmt.Errorf("write CLRS generator wheelhouse manifest: %w", err)
+	}
+	if err := file.Sync(); err != nil {
+		return "", 0, fmt.Errorf("synchronise CLRS generator wheelhouse manifest: %w", err)
+	}
+	if err := file.Chmod(0o644); err != nil {
+		return "", 0, fmt.Errorf("set CLRS generator wheelhouse manifest mode: %w", err)
+	}
+	writtenState, err := file.Stat()
+	if err != nil || !writtenState.Mode().IsRegular() || writtenState.Size() != int64(len(body)) {
+		return "", 0, errors.New("written CLRS generator wheelhouse manifest is not the expected regular file")
+	}
+	if err := file.Close(); err != nil {
+		return "", 0, fmt.Errorf("close CLRS generator wheelhouse manifest: %w", err)
+	}
+	if afterClose != nil {
+		if err := afterClose(); err != nil {
+			return "", 0, fmt.Errorf("run CLRS generator manifest write interlock: %w", err)
+		}
+	}
+	published, err := parentRoot.Open(name)
+	if err != nil {
+		return "", 0, errors.New("published CLRS generator wheelhouse manifest could not be reopened")
+	}
+	defer published.Close()
+	publishedState, err := published.Stat()
+	if err != nil || !publishedState.Mode().IsRegular() || !os.SameFile(writtenState, publishedState) ||
+		publishedState.Size() != int64(len(body)) {
+		return "", 0, errors.New("published CLRS generator wheelhouse manifest is not the expected regular file")
+	}
+	publishedBody, err := io.ReadAll(io.LimitReader(published, int64(len(body))+1))
+	if err != nil || len(publishedBody) != len(body) || !bytes.Equal(publishedBody, body) {
+		return "", 0, errors.New("published CLRS generator wheelhouse manifest bytes do not match the candidate")
+	}
+	readState, err := published.Stat()
+	if err != nil || !unchangedGeneratorFile(publishedState, readState) {
+		return "", 0, errors.New("published CLRS generator wheelhouse manifest changed during confirmation")
+	}
+	if _, err := published.Seek(0, io.SeekStart); err != nil {
+		return "", 0, errors.New("published CLRS generator wheelhouse manifest could not be rewound")
+	}
+	confirmation, err := io.ReadAll(io.LimitReader(published, int64(len(body))+1))
+	if err != nil || !bytes.Equal(publishedBody, confirmation) {
+		return "", 0, errors.New("published CLRS generator wheelhouse manifest changed during confirmation")
+	}
+	confirmedState, err := published.Stat()
+	if err != nil || !unchangedGeneratorFile(readState, confirmedState) ||
+		!unchangedGeneratorFile(writtenState, confirmedState) {
+		return "", 0, errors.New("published CLRS generator wheelhouse manifest changed during confirmation")
+	}
+	rootInformation, err := parentRoot.Lstat(name)
+	if err != nil || !unchangedGeneratorFile(confirmedState, rootInformation) {
+		return "", 0, errors.New("published CLRS generator wheelhouse manifest is not the expected regular file")
+	}
+	namedParentState, err = os.Lstat(parent)
+	if err != nil || !sameGeneratorDirectoryIdentity(parentState, namedParentState) {
+		return "", 0, errors.New("CLRS generator wheelhouse manifest output parent changed during creation")
+	}
+	information, err := os.Lstat(absolute)
+	if err != nil || !information.Mode().IsRegular() || information.Mode()&os.ModeSymlink != 0 ||
+		!os.SameFile(rootInformation, information) || information.Size() != int64(len(body)) {
+		return "", 0, errors.New("published CLRS generator wheelhouse manifest is not the expected regular file")
+	}
+	return rawSHA256(confirmation), int64(len(confirmation)), nil
+}
+
+func loadGeneratorWheelhouseInputs(
+	repositoryRoot string,
+) (GeneratorLockInput, GeneratorImageContract, []byte, error) {
+	root, err := cleanGeneratorRoot(repositoryRoot)
+	if err != nil {
+		return GeneratorLockInput{}, GeneratorImageContract{}, nil, err
+	}
+	sourceBody, err := readGeneratorFile(root, trackedSourcePath, maximumSourceRecordBytes)
+	if err != nil {
+		return GeneratorLockInput{}, GeneratorImageContract{}, nil, err
+	}
+	source, err := ParseSourceRecord(sourceBody)
+	if err != nil {
+		return GeneratorLockInput{}, GeneratorImageContract{}, nil, err
+	}
+	generationBody, err := readGeneratorFile(root, trackedGenerationPath, maximumGenerationContractBytes)
+	if err != nil {
+		return GeneratorLockInput{}, GeneratorImageContract{}, nil, err
+	}
+	generation, err := ParseGenerationContract(generationBody, source)
+	if err != nil {
+		return GeneratorLockInput{}, GeneratorImageContract{}, nil, err
+	}
+	lockInputBody, err := readGeneratorFile(root, trackedLockInputPath, maximumGeneratorLockInputBytes)
+	if err != nil {
+		return GeneratorLockInput{}, GeneratorImageContract{}, nil, err
+	}
+	input, err := ParseGeneratorLockInput(lockInputBody, source)
+	if err != nil {
+		return GeneratorLockInput{}, GeneratorImageContract{}, nil, err
+	}
+	imageBody, err := readGeneratorFile(root, trackedImageContractPath, maximumGeneratorImageContractBytes)
+	if err != nil {
+		return GeneratorLockInput{}, GeneratorImageContract{}, nil, err
+	}
+	imageContract, err := ParseGeneratorImageContract(imageBody, lockInputBody, source, generation)
+	if err != nil {
+		return GeneratorLockInput{}, GeneratorImageContract{}, nil, err
+	}
+	projectBody, err := readGeneratorFile(root, imageContract.DependencyLock.ProjectPath, maximumGeneratorProjectBytes)
+	if err != nil {
+		return GeneratorLockInput{}, GeneratorImageContract{}, nil, err
+	}
+	dependencyLockBody, err := readGeneratorFile(
+		root,
+		imageContract.DependencyLock.Path,
+		maximumGeneratorDependencyLockBytes,
+	)
+	if err != nil {
+		return GeneratorLockInput{}, GeneratorImageContract{}, nil, err
+	}
+	if err := validateGeneratorDependencyFiles(
+		imageContract.DependencyLock,
+		projectBody,
+		dependencyLockBody,
+		input,
+		imageContract.Limits,
+	); err != nil {
+		return GeneratorLockInput{}, GeneratorImageContract{}, nil, err
+	}
+	return input, imageContract, dependencyLockBody, nil
+}
+
+func inspectMaterializedGeneratorWheelhouse(
+	directory string,
+	packages []lockedGeneratorPackage,
+	maximumBytes int64,
+) ([]GeneratorWheelhouseEntry, int64, error) {
+	root, err := cleanGeneratorRoot(directory)
+	if err != nil {
+		return nil, 0, fmt.Errorf("inspect CLRS generator wheelhouse: %w", err)
+	}
+	initial, err := readGeneratorWheelhouseSnapshot(root, generatorRuntimePackageCount)
+	if err != nil {
+		return nil, 0, err
+	}
+	byFilename := make(map[string]lockedGeneratorArtifact)
+	for _, pkg := range packages {
+		for _, artifact := range pkg.Artifacts {
+			if artifact.Wheel && compatibleGeneratorWheelFilename(artifact.Filename) {
+				if _, duplicate := byFilename[artifact.Filename]; duplicate {
+					return nil, 0, fmt.Errorf("generator uv lock repeats wheel filename %q", artifact.Filename)
+				}
+				byFilename[artifact.Filename] = artifact
+			}
+		}
+	}
+	selected := make([]GeneratorWheelhouseEntry, 0, len(initial.Entries))
+	seenPackages := make(map[string]bool, len(initial.Entries))
+	var total int64
+	for _, snapshot := range initial.Entries {
+		name := snapshot.Name
+		var selectedEntry GeneratorWheelhouseEntry
+		var expectedSHA256 string
+		var expectedSize int64
+		if name == promiseWheelFilename {
+			expectedSHA256 = promiseWheelSHA256
+			expectedSize = promiseWheelSize
+			selectedEntry = GeneratorWheelhouseEntry{
+				Package: "promise", Version: "2.3", Kind: "source-built-wheel", Filename: name,
+				URL: "", SHA256: expectedSHA256, SizeBytes: expectedSize,
+			}
+		} else {
+			locked, present := byFilename[name]
+			if !present {
+				return nil, 0, fmt.Errorf("CLRS generator wheelhouse entry %q is not a compatible uv-lock wheel", name)
+			}
+			expectedSHA256 = locked.SHA256
+			expectedSize = locked.SizeBytes
+			selectedEntry = GeneratorWheelhouseEntry{
+				Package: locked.Package, Version: locked.Version, Kind: "downloaded-wheel", Filename: locked.Filename,
+				URL: locked.URL, SHA256: locked.SHA256, SizeBytes: locked.SizeBytes,
+			}
+		}
+		if snapshot.Information.Size() != expectedSize || expectedSize <= 0 || maximumBytes <= 0 ||
+			expectedSize > limitsSafeAddend(total) || expectedSize > maximumBytes-total {
+			return nil, 0, fmt.Errorf("CLRS generator wheelhouse entry %q has an invalid or unbounded size", name)
+		}
+		digest, err := digestGeneratorWheel(filepath.Join(root, name), snapshot.Information, expectedSize)
+		if err != nil {
+			return nil, 0, err
+		}
+		if digest != expectedSHA256 {
+			return nil, 0, fmt.Errorf("CLRS generator wheelhouse entry %q has the wrong digest", name)
+		}
+		if seenPackages[selectedEntry.Package] {
+			return nil, 0, fmt.Errorf("CLRS generator wheelhouse repeats package %q", selectedEntry.Package)
+		}
+		seenPackages[selectedEntry.Package] = true
+		total += expectedSize
+		selected = append(selected, selectedEntry)
+	}
+	if err := confirmGeneratorWheelhouseSnapshot(root, initial); err != nil {
+		return nil, 0, err
+	}
+	sort.Slice(selected, func(left, right int) bool { return selected[left].Package < selected[right].Package })
+	return selected, total, nil
+}
+
+type generatorWheelhouseSnapshot struct {
+	Directory os.FileInfo
+	Entries   []generatorWheelhouseSnapshotEntry
+}
+
+type generatorWheelhouseSnapshotEntry struct {
+	Name        string
+	Information os.FileInfo
+}
+
+func readGeneratorWheelhouseSnapshot(root string, expectedCount int) (generatorWheelhouseSnapshot, error) {
+	if expectedCount < 1 || expectedCount > generatorRuntimePackageCount {
+		return generatorWheelhouseSnapshot{}, errors.New("CLRS generator wheelhouse expected count is outside the bounded runtime set")
+	}
+	directory, err := os.Open(root)
+	if err != nil {
+		return generatorWheelhouseSnapshot{}, fmt.Errorf("open CLRS generator wheelhouse: %w", err)
+	}
+	defer directory.Close()
+	opened, err := directory.Stat()
+	if err != nil || !opened.IsDir() {
+		return generatorWheelhouseSnapshot{}, errors.New("CLRS generator wheelhouse is not a stable directory")
+	}
+	named, err := os.Lstat(root)
+	if err != nil || !unchangedGeneratorDirectory(opened, named) {
+		return generatorWheelhouseSnapshot{}, errors.New("CLRS generator wheelhouse changed before it was opened")
+	}
+	entries := make([]os.DirEntry, 0, expectedCount+1)
+	for len(entries) <= expectedCount {
+		batch, readErr := directory.ReadDir(expectedCount + 1 - len(entries))
+		entries = append(entries, batch...)
+		if errors.Is(readErr, io.EOF) {
+			break
+		}
+		if readErr != nil {
+			return generatorWheelhouseSnapshot{}, fmt.Errorf("read CLRS generator wheelhouse: %w", readErr)
+		}
+		if len(batch) == 0 {
+			return generatorWheelhouseSnapshot{}, errors.New("read CLRS generator wheelhouse made no bounded progress")
+		}
+	}
+	if len(entries) != expectedCount {
+		return generatorWheelhouseSnapshot{}, fmt.Errorf(
+			"CLRS generator wheelhouse contains %d files, want %d",
+			len(entries),
+			expectedCount,
+		)
+	}
+	sort.Slice(entries, func(left, right int) bool { return entries[left].Name() < entries[right].Name() })
+	snapshot := generatorWheelhouseSnapshot{Directory: opened, Entries: make([]generatorWheelhouseSnapshotEntry, 0, len(entries))}
+	for _, entry := range entries {
+		if entry.IsDir() || entry.Type()&os.ModeSymlink != 0 || !validGeneratorWheelFilename(entry.Name()) {
+			return generatorWheelhouseSnapshot{}, fmt.Errorf("CLRS generator wheelhouse entry %q is not one regular wheel", entry.Name())
+		}
+		information, inspectErr := os.Lstat(filepath.Join(root, entry.Name()))
+		if inspectErr != nil || !information.Mode().IsRegular() || information.Mode()&os.ModeSymlink != 0 ||
+			information.Size() <= 0 {
+			return generatorWheelhouseSnapshot{}, fmt.Errorf("CLRS generator wheelhouse entry %q changed before hashing", entry.Name())
+		}
+		snapshot.Entries = append(snapshot.Entries, generatorWheelhouseSnapshotEntry{
+			Name: entry.Name(), Information: information,
+		})
+	}
+	closed, err := directory.Stat()
+	if err != nil || !unchangedGeneratorDirectory(opened, closed) {
+		return generatorWheelhouseSnapshot{}, errors.New("CLRS generator wheelhouse changed while it was listed")
+	}
+	named, err = os.Lstat(root)
+	if err != nil || !unchangedGeneratorDirectory(closed, named) {
+		return generatorWheelhouseSnapshot{}, errors.New("CLRS generator wheelhouse changed while it was listed")
+	}
+	return snapshot, nil
+}
+
+func confirmGeneratorWheelhouseSnapshot(root string, initial generatorWheelhouseSnapshot) error {
+	final, err := readGeneratorWheelhouseSnapshot(root, len(initial.Entries))
+	if err != nil {
+		return err
+	}
+	if !unchangedGeneratorDirectory(initial.Directory, final.Directory) || len(initial.Entries) != len(final.Entries) {
+		return errors.New("CLRS generator wheelhouse changed while it was verified")
+	}
+	for index := range initial.Entries {
+		before := initial.Entries[index]
+		after := final.Entries[index]
+		if before.Name != after.Name || !unchangedGeneratorFile(before.Information, after.Information) {
+			return errors.New("CLRS generator wheelhouse changed while it was verified")
+		}
+	}
+	return nil
+}
+
+func unchangedGeneratorDirectory(before, after os.FileInfo) bool {
+	return sameGeneratorDirectoryIdentity(before, after) && before.Mode() == after.Mode() &&
+		before.Size() == after.Size() && before.ModTime().Equal(after.ModTime())
+}
+
+func sameGeneratorDirectoryIdentity(before, after os.FileInfo) bool {
+	return before.IsDir() && after.IsDir() && before.Mode()&os.ModeSymlink == 0 && after.Mode()&os.ModeSymlink == 0 &&
+		os.SameFile(before, after)
+}
+
+func digestGeneratorWheel(file string, initial os.FileInfo, expectedSize int64) (string, error) {
+	return digestGeneratorWheelWithInterlock(file, initial, expectedSize, nil)
+}
+
+func digestGeneratorWheelWithInterlock(
+	file string,
+	initial os.FileInfo,
+	expectedSize int64,
+	afterRead func() error,
+) (string, error) {
+	namedBefore, err := os.Lstat(file)
+	if err != nil || !unchangedGeneratorFile(initial, namedBefore) {
+		return "", errors.New("CLRS generator wheel changed before it was opened")
+	}
+	input, err := os.Open(file)
+	if err != nil {
+		return "", fmt.Errorf("open CLRS generator wheel: %w", err)
+	}
+	defer input.Close()
+	opened, err := input.Stat()
+	if err != nil || !unchangedGeneratorFile(initial, opened) {
+		return "", errors.New("CLRS generator wheel changed before it was opened")
+	}
+	namedOpened, err := os.Lstat(file)
+	if err != nil || !unchangedGeneratorFile(opened, namedOpened) {
+		return "", errors.New("CLRS generator wheel changed before it was hashed")
+	}
+	digest := sha256.New()
+	written, err := io.Copy(digest, io.LimitReader(input, expectedSize+1))
+	if err != nil || written != expectedSize {
+		return "", errors.New("CLRS generator wheel changed while it was read")
+	}
+	if afterRead != nil {
+		if err := afterRead(); err != nil {
+			return "", fmt.Errorf("run CLRS generator wheel stable-read interlock: %w", err)
+		}
+	}
+	final, err := input.Stat()
+	if err != nil || !unchangedGeneratorFile(opened, final) {
+		return "", errors.New("CLRS generator wheel changed while it was hashed")
+	}
+	namedFinal, err := os.Lstat(file)
+	if err != nil || !unchangedGeneratorFile(final, namedFinal) {
+		return "", errors.New("CLRS generator wheel changed while it was hashed")
+	}
+	return hex.EncodeToString(digest.Sum(nil)), nil
+}

--- a/tooling/internal/clrsfixture/image_wheelhouse_test.go
+++ b/tooling/internal/clrsfixture/image_wheelhouse_test.go
@@ -1,0 +1,510 @@
+package clrsfixture
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestTrackedGeneratorWheelhouseManifestLocksEveryRuntimePackage(t *testing.T) {
+	t.Parallel()
+	manifest, _, _, _ := trackedGeneratorWheelhouseManifest(t)
+	if manifest.PackageCount != generatorRuntimePackageCount || manifest.ArtifactCount != generatorRuntimePackageCount ||
+		manifest.DownloadedWheelCount != 60 || manifest.SourceBuiltWheelCount != 1 ||
+		manifest.TotalSizeBytes != 823_932_066 {
+		t.Fatalf("tracked wheelhouse counts/bytes = %#v", manifest)
+	}
+	if len(manifest.Artifacts) != generatorRuntimePackageCount || manifest.Artifacts[0].Package != "absl-py" ||
+		manifest.Artifacts[len(manifest.Artifacts)-1].Package != "zipp" {
+		t.Fatalf("tracked wheelhouse package ordering is invalid")
+	}
+	var promise GeneratorWheelhouseEntry
+	for _, artifact := range manifest.Artifacts {
+		if artifact.Package == "promise" {
+			promise = artifact
+		}
+	}
+	if promise.Kind != "source-built-wheel" || promise.Filename != promiseWheelFilename ||
+		promise.SHA256 != promiseWheelSHA256 || promise.SizeBytes != promiseWheelSize {
+		t.Fatalf("tracked promise wheel = %#v", promise)
+	}
+	sourceBuild := manifest.SourceBuild
+	if sourceBuild.ProcedureState != "missing" || sourceBuild.ReproductionReceiptState != "missing" ||
+		sourceBuild.Provenance.SPDX != "MIT" || sourceBuild.Provenance.RepositoryLicensePath != promiseLicensePath ||
+		sourceBuild.Provenance.LicenseSHA256 != promiseLicenseSHA256 ||
+		sourceBuild.Provenance.LicenseSizeBytes != promiseLicenseSize {
+		t.Fatalf("tracked promise build boundary/provenance = %#v", sourceBuild)
+	}
+}
+
+func TestLockedPromiseSourceBuildBindsRecipeToSelectedWheels(t *testing.T) {
+	t.Parallel()
+	manifest, input, _, lockBody := trackedGeneratorWheelhouseManifest(t)
+	packages, err := parseLockedGeneratorPackages(lockBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	alternative := lockedGeneratorArtifact{
+		Package: "packaging", Version: "26.3", Filename: "packaging-26.3-1-py3-none-any.whl",
+		URL:    "https://files.pythonhosted.org/packages/test/packaging-26.3-1-py3-none-any.whl",
+		SHA256: strings.Repeat("d", 64), SizeBytes: 130_001, Wheel: true,
+	}
+	for index := range packages {
+		if packages[index].Name == alternative.Package {
+			packages[index].Artifacts = append(packages[index].Artifacts, alternative)
+		}
+	}
+	selected := append([]GeneratorWheelhouseEntry(nil), manifest.Artifacts...)
+	for index := range selected {
+		if selected[index].Package == alternative.Package {
+			selected[index] = GeneratorWheelhouseEntry{
+				Package: alternative.Package, Version: alternative.Version, Kind: "downloaded-wheel",
+				Filename: alternative.Filename, URL: alternative.URL, SHA256: alternative.SHA256,
+				SizeBytes: alternative.SizeBytes,
+			}
+		}
+	}
+	recipe, err := lockedPromiseSourceBuild(input, packages, selected)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if recipe.BuildRequirements[0].Filename != alternative.Filename {
+		t.Fatalf("selected packaging build requirement = %#v", recipe.BuildRequirements[0])
+	}
+	wantPath := "/inputs/wheelhouse/" + alternative.Filename
+	if recipe.CandidateInstallCommand[len(recipe.CandidateInstallCommand)-3] != wantPath {
+		t.Fatalf("selected packaging install argument = %q, want %q", recipe.CandidateInstallCommand[len(recipe.CandidateInstallCommand)-3], wantPath)
+	}
+
+	withoutPackaging := make([]GeneratorWheelhouseEntry, 0, len(selected)-1)
+	for _, artifact := range selected {
+		if artifact.Package != "packaging" {
+			withoutPackaging = append(withoutPackaging, artifact)
+		}
+	}
+	if _, err := lockedPromiseSourceBuild(input, packages, withoutPackaging); err == nil ||
+		!strings.Contains(err.Error(), `requirement "packaging" is not selected`) {
+		t.Fatalf("lockedPromiseSourceBuild missing-selection error = %v", err)
+	}
+}
+
+func TestGeneratorWheelhouseManifestRejectsArtifactAndRecipeDrift(t *testing.T) {
+	t.Parallel()
+	_, input, contract, lockBody := trackedGeneratorWheelhouseManifest(t)
+	valid := string(trackedGeneratorFile(t, "wheelhouse.json"))
+	tests := map[string]string{
+		"duplicate": strings.Replace(
+			valid,
+			`"authority": "NO_RESULT"`,
+			`"authority": "NO_RESULT", "authority": "NO_RESULT"`,
+			1,
+		),
+		"wrong authority": strings.Replace(valid, `"authority": "NO_RESULT"`, `"authority": "RESULT"`, 1),
+		"package count":   strings.Replace(valid, `"package_count": 61`, `"package_count": 60`, 1),
+		"byte total":      strings.Replace(valid, `"total_size_bytes": 823932066`, `"total_size_bytes": 823932067`, 1),
+		"mutable base": strings.Replace(
+			valid,
+			input.Python.BaseImage,
+			"docker.io/library/python:3.13.15-slim-bookworm",
+			1,
+		),
+		"glibc drift":        strings.Replace(valid, `"glibc_version": "2.36"`, `"glibc_version": "2.37"`, 1),
+		"procedure pretence": strings.Replace(valid, `"procedure_state": "missing"`, `"procedure_state": "complete"`, 1),
+		"receipt pretence": strings.Replace(
+			valid,
+			`"reproduction_receipt_state": "missing"`,
+			`"reproduction_receipt_state": "complete"`,
+			1,
+		),
+		"acquisition date": strings.Replace(valid, `"acquired_on": "2026-09-05"`, `"acquired_on": "2026-09-04"`, 1),
+		"licence SPDX":     strings.Replace(valid, `"spdx": "MIT"`, `"spdx": "Apache-2.0"`, 1),
+		"licence digest":   strings.Replace(valid, promiseLicenseSHA256, strings.Repeat("c", 64), 1),
+		"foreign URL": strings.Replace(
+			valid,
+			"https://files.pythonhosted.org/packages/58/0a/",
+			"https://example.invalid/packages/58/0a/",
+			1,
+		),
+		"wheel digest":  strings.Replace(valid, "0f17b89f2a4eaaedc4f28c622998aa690564b3012a396a4ffad0821007fe03ba", strings.Repeat("a", 64), 1),
+		"built wheel":   strings.Replace(valid, promiseWheelSHA256, strings.Repeat("b", 64), 1),
+		"builder image": strings.Replace(valid, `"builder_image": "`+input.Python.BaseImage+`"`, `"builder_image": "docker.io/library/python:3.13.15-slim-bookworm"`, 1),
+		"build command": strings.Replace(valid, `"bdist_wheel"`, `"sdist"`, 1),
+		"build environment": strings.Replace(
+			valid,
+			`"PYTHONHASHSEED=0"`,
+			`"PYTHONHASHSEED=random"`,
+			1,
+		),
+		"one reproduction": strings.Replace(valid, `"required_reproductions": 2`, `"required_reproductions": 1`, 1),
+	}
+	for name, body := range tests {
+		name, body := name, body
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := ParseGeneratorWheelhouseManifest([]byte(body), lockBody, input, contract); err == nil {
+				t.Fatalf("ParseGeneratorWheelhouseManifest accepted %s", name)
+			}
+		})
+	}
+	if _, err := ParseGeneratorWheelhouseManifest(
+		trackedGeneratorFile(t, "wheelhouse.json"),
+		append(lockBody, '\n'),
+		input,
+		contract,
+	); err == nil || !strings.Contains(err.Error(), "dependency-lock digest") {
+		t.Fatalf("ParseGeneratorWheelhouseManifest mutated-lock error = %v", err)
+	}
+}
+
+func TestGeneratorWheelhouseManifestRejectsReorderedPackages(t *testing.T) {
+	t.Parallel()
+	manifest, input, contract, lockBody := trackedGeneratorWheelhouseManifest(t)
+	manifest.Artifacts[0], manifest.Artifacts[1] = manifest.Artifacts[1], manifest.Artifacts[0]
+	var body bytes.Buffer
+	encoder := json.NewEncoder(&body)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(manifest); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ParseGeneratorWheelhouseManifest(body.Bytes(), lockBody, input, contract); err == nil {
+		t.Fatal("ParseGeneratorWheelhouseManifest accepted reordered packages")
+	}
+}
+
+func TestGeneratorWheelhouseManifestRejectsLockedButIncompatibleWheels(t *testing.T) {
+	t.Parallel()
+	manifest, input, contract, lockBody := trackedGeneratorWheelhouseManifest(t)
+	packages, err := parseLockedGeneratorPackages(lockBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, marker := range map[string]string{
+		"pyemscripten":  "pyemscripten_",
+		"musllinux":     "musllinux_",
+		"free-threaded": "cp313t-",
+	} {
+		name, marker := name, marker
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			var alternative lockedGeneratorArtifact
+			for _, pkg := range packages {
+				for _, artifact := range pkg.Artifacts {
+					if artifact.Wheel && strings.Contains(artifact.Filename, marker) {
+						alternative = artifact
+						break
+					}
+				}
+				if alternative.Filename != "" {
+					break
+				}
+			}
+			if alternative.Filename == "" {
+				t.Fatalf("uv lock has no %s wheel", name)
+			}
+			candidate := manifest
+			candidate.Artifacts = append([]GeneratorWheelhouseEntry(nil), manifest.Artifacts...)
+			replaced := false
+			for index := range candidate.Artifacts {
+				if candidate.Artifacts[index].Package != alternative.Package {
+					continue
+				}
+				candidate.TotalSizeBytes += alternative.SizeBytes - candidate.Artifacts[index].SizeBytes
+				candidate.Artifacts[index] = GeneratorWheelhouseEntry{
+					Package: alternative.Package, Version: alternative.Version, Kind: "downloaded-wheel",
+					Filename: alternative.Filename, URL: alternative.URL, SHA256: alternative.SHA256,
+					SizeBytes: alternative.SizeBytes,
+				}
+				replaced = true
+				break
+			}
+			if !replaced {
+				t.Fatalf("tracked manifest has no package %q", alternative.Package)
+			}
+			var body bytes.Buffer
+			encoder := json.NewEncoder(&body)
+			encoder.SetEscapeHTML(false)
+			encoder.SetIndent("", "  ")
+			if err := encoder.Encode(candidate); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := ParseGeneratorWheelhouseManifest(body.Bytes(), lockBody, input, contract); err == nil {
+				t.Fatalf("ParseGeneratorWheelhouseManifest accepted %s wheel %q", name, alternative.Filename)
+			}
+		})
+	}
+}
+
+func TestGeneratorWheelCompatibilityIsBoundToCPython313AndBookwormAMD64(t *testing.T) {
+	t.Parallel()
+	for _, filename := range []string{
+		"pure-1.0-py3-none-any.whl",
+		"legacy_pure-1.0-py2.py3-none-any.whl",
+		"native-1.0-cp313-cp313-manylinux_2_36_x86_64.whl",
+		"abi3-1.0-cp310-abi3-manylinux2014_x86_64.whl",
+		"old_abi3-1.0-cp36-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.whl",
+		"libclang-1.0-py2.py3-none-manylinux2010_x86_64.whl",
+	} {
+		if !compatibleGeneratorWheelFilename(filename) {
+			t.Errorf("compatibleGeneratorWheelFilename(%q) = false", filename)
+		}
+	}
+	for _, filename := range []string{
+		"wasm-1.0-cp313-cp313-pyemscripten_2025_0_wasm32.whl",
+		"musl-1.0-cp313-cp313-musllinux_1_2_x86_64.whl",
+		"free_threaded-1.0-cp313-cp313t-manylinux_2_28_x86_64.whl",
+		"future_glibc-1.0-cp313-cp313-manylinux_2_37_x86_64.whl",
+		"new_python-1.0-cp314-cp314-manylinux_2_28_x86_64.whl",
+		"windows-1.0-cp313-cp313-win_amd64.whl",
+		"arm-1.0-cp313-cp313-manylinux_2_28_aarch64.whl",
+	} {
+		if compatibleGeneratorWheelFilename(filename) {
+			t.Errorf("compatibleGeneratorWheelFilename(%q) = true", filename)
+		}
+	}
+}
+
+func TestGeneratorWheelhouseSnapshotBoundsEntryCountAndDetectsMutation(t *testing.T) {
+	t.Parallel()
+	for _, count := range []int{0, generatorRuntimePackageCount + 1} {
+		if _, err := readGeneratorWheelhouseSnapshot(t.TempDir(), count); err == nil ||
+			!strings.Contains(err.Error(), "outside the bounded runtime set") {
+			t.Fatalf("readGeneratorWheelhouseSnapshot(count=%d) error = %v", count, err)
+		}
+	}
+	t.Run("bounded count", func(t *testing.T) {
+		root := t.TempDir()
+		for index := 0; index < generatorRuntimePackageCount+1; index++ {
+			name := fmt.Sprintf("artifact_%02d-1-py3-none-any.whl", index)
+			if err := os.WriteFile(filepath.Join(root, name), []byte{byte(index)}, 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if _, err := readGeneratorWheelhouseSnapshot(root, generatorRuntimePackageCount); err == nil ||
+			!strings.Contains(err.Error(), "62 files") {
+			t.Fatalf("readGeneratorWheelhouseSnapshot() error = %v, want bounded extra-entry rejection", err)
+		}
+	})
+
+	t.Run("added name", func(t *testing.T) {
+		root := t.TempDir()
+		if err := os.WriteFile(filepath.Join(root, "first-1-py3-none-any.whl"), []byte("first"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		initial, err := readGeneratorWheelhouseSnapshot(root, 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(root, "second-1-py3-none-any.whl"), []byte("second"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := confirmGeneratorWheelhouseSnapshot(root, initial); err == nil {
+			t.Fatal("confirmGeneratorWheelhouseSnapshot accepted an added wheel")
+		}
+	})
+
+	t.Run("replaced name", func(t *testing.T) {
+		root := t.TempDir()
+		filename := filepath.Join(root, "only-1-py3-none-any.whl")
+		if err := os.WriteFile(filename, []byte("same bytes"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		initial, err := readGeneratorWheelhouseSnapshot(root, 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Remove(filename); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filename, []byte("same bytes"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := confirmGeneratorWheelhouseSnapshot(root, initial); err == nil {
+			t.Fatal("confirmGeneratorWheelhouseSnapshot accepted a replaced wheel")
+		}
+	})
+}
+
+func TestDigestGeneratorWheelIsBoundedAndRejectsNamedSymlinkReplacement(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	filename := filepath.Join(root, "artifact-1-py3-none-any.whl")
+	body := []byte("bounded wheel fixture")
+	if err := os.WriteFile(filename, body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	information, err := os.Lstat(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest, err := digestGeneratorWheel(filename, information, int64(len(body)))
+	if err != nil || digest != rawSHA256(body) {
+		t.Fatalf("digestGeneratorWheel() = %q, %v", digest, err)
+	}
+	if _, err := digestGeneratorWheel(filename, information, int64(len(body))-1); err == nil {
+		t.Fatal("digestGeneratorWheel accepted an undersized read limit")
+	}
+
+	target := filepath.Join(t.TempDir(), "replacement.whl")
+	if err := os.WriteFile(target, body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err = digestGeneratorWheelWithInterlock(filename, information, int64(len(body)), func() error {
+		if err := os.Remove(filename); err != nil {
+			return err
+		}
+		return os.Symlink(target, filename)
+	})
+	if err != nil && strings.Contains(err.Error(), "operation not permitted") {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	if err == nil || !strings.Contains(err.Error(), "changed while it was hashed") {
+		t.Fatalf("digestGeneratorWheelWithInterlock() error = %v, want named-path replacement rejection", err)
+	}
+}
+
+func TestMaterializedGeneratorWheelhouseRejectsWrongSizeBeforeHashing(t *testing.T) {
+	t.Parallel()
+	manifest, _, contract, lockBody := trackedGeneratorWheelhouseManifest(t)
+	packages, err := parseLockedGeneratorPackages(lockBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	for _, artifact := range manifest.Artifacts {
+		if err := os.WriteFile(filepath.Join(root, artifact.Filename), []byte{0}, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, _, err := inspectMaterializedGeneratorWheelhouse(
+		root,
+		packages,
+		contract.Limits.DependencyArtifactBytes,
+	); err == nil || !strings.Contains(err.Error(), "invalid or unbounded size") {
+		t.Fatalf("inspectMaterializedGeneratorWheelhouse() error = %v, want pre-hash size rejection", err)
+	}
+}
+
+func TestWriteNewGeneratorWheelhouseManifestIsNewOutsideAndIdentityChecked(t *testing.T) {
+	t.Parallel()
+	wheelhouse := t.TempDir()
+	output := filepath.Join(t.TempDir(), "candidate.json")
+	body := []byte("{\n  \"authority\": \"NO_RESULT\"\n}\n")
+	digest, size, err := writeNewGeneratorWheelhouseManifest(wheelhouse, output, body)
+	if err != nil || digest != rawSHA256(body) || size != int64(len(body)) {
+		t.Fatalf("writeNewGeneratorWheelhouseManifest() = %q, %d, %v", digest, size, err)
+	}
+	information, err := os.Lstat(output)
+	if err != nil || !information.Mode().IsRegular() || information.Mode().Perm() != 0o644 {
+		t.Fatalf("written manifest mode/state = %v, %v", information, err)
+	}
+	if _, _, err := writeNewGeneratorWheelhouseManifest(wheelhouse, output, body); err == nil {
+		t.Fatal("writeNewGeneratorWheelhouseManifest overwrote an existing path")
+	}
+	inside := filepath.Join(wheelhouse, "candidate.json")
+	if _, _, err := writeNewGeneratorWheelhouseManifest(wheelhouse, inside, body); err == nil {
+		t.Fatal("writeNewGeneratorWheelhouseManifest wrote inside the wheel directory")
+	}
+}
+
+func TestWriteNewGeneratorWheelhouseManifestAnchorsParentAndPreservesReplacement(t *testing.T) {
+	t.Parallel()
+	body := []byte("{\n  \"authority\": \"NO_RESULT\"\n}\n")
+	t.Run("parent replacement", func(t *testing.T) {
+		base := t.TempDir()
+		parent := filepath.Join(base, "parent")
+		parked := filepath.Join(base, "parked")
+		if err := os.Mkdir(parent, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		output := filepath.Join(parent, "candidate.json")
+		_, _, err := writeNewGeneratorWheelhouseManifestWithInterlock(t.TempDir(), output, body, func() error {
+			if err := os.Rename(parent, parked); err != nil {
+				return err
+			}
+			return os.Mkdir(parent, 0o755)
+		})
+		if err == nil || !strings.Contains(err.Error(), "output parent changed") {
+			t.Fatalf("write after parent replacement error = %v", err)
+		}
+		if _, statErr := os.Lstat(output); !os.IsNotExist(statErr) {
+			t.Fatalf("failed write populated replacement parent %s: %v", output, statErr)
+		}
+		retained, readErr := os.ReadFile(filepath.Join(parked, "candidate.json"))
+		if readErr != nil || !bytes.Equal(retained, body) {
+			t.Fatalf("failed write did not retain its anchored candidate: %q, %v", retained, readErr)
+		}
+	})
+
+	t.Run("name replacement", func(t *testing.T) {
+		parent := t.TempDir()
+		output := filepath.Join(parent, "candidate.json")
+		replacement := []byte("replacement owned elsewhere")
+		_, _, err := writeNewGeneratorWheelhouseManifestWithInterlock(t.TempDir(), output, body, func() error {
+			if err := os.Remove(output); err != nil {
+				return err
+			}
+			return os.WriteFile(output, replacement, 0o644)
+		})
+		if err == nil || !strings.Contains(err.Error(), "not the expected regular file") {
+			t.Fatalf("write after name replacement error = %v", err)
+		}
+		retained, readErr := os.ReadFile(output)
+		if readErr != nil || !bytes.Equal(retained, replacement) {
+			t.Fatalf("replacement was not preserved: %q, %v", retained, readErr)
+		}
+	})
+
+	t.Run("same-inode byte replacement", func(t *testing.T) {
+		parent := t.TempDir()
+		output := filepath.Join(parent, "candidate.json")
+		replacement := bytes.Repeat([]byte("x"), len(body))
+		_, _, err := writeNewGeneratorWheelhouseManifestWithInterlock(t.TempDir(), output, body, func() error {
+			return os.WriteFile(output, replacement, 0o644)
+		})
+		if err == nil || !strings.Contains(err.Error(), "bytes do not match") {
+			t.Fatalf("write after same-inode byte replacement error = %v", err)
+		}
+		retained, readErr := os.ReadFile(output)
+		if readErr != nil || !bytes.Equal(retained, replacement) {
+			t.Fatalf("same-inode replacement was not preserved: %q, %v", retained, readErr)
+		}
+	})
+}
+
+func trackedGeneratorWheelhouseManifest(
+	t *testing.T,
+) (GeneratorWheelhouseManifest, GeneratorLockInput, GeneratorImageContract, []byte) {
+	t.Helper()
+	source := trackedSourceRecord(t)
+	generation := trackedGenerationContract(t, source)
+	lockInputBody := trackedGeneratorFile(t, "lock-input.json")
+	input, err := ParseGeneratorLockInput(lockInputBody, source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	contract, err := ParseGeneratorImageContract(
+		trackedGeneratorFile(t, "image-contract.json"),
+		lockInputBody,
+		source,
+		generation,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dependencyLockBody := trackedGeneratorFile(t, "uv.lock")
+	manifest, err := ParseGeneratorWheelhouseManifest(
+		trackedGeneratorFile(t, "wheelhouse.json"),
+		dependencyLockBody,
+		input,
+		contract,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return manifest, input, contract, dependencyLockBody
+}


### PR DESCRIPTION
# Pull request

## Summary

- Lock one canonical Python 3.13/Linux `amd64` wheel selection for the pinned
  CLRS-Text generator instead of letting a future image build choose artifacts
  from a mutable package index.
- Add standard-library Go commands to render a candidate manifest into a new
  file and verify a complete materialised wheelhouse without Python, a resolver
  or network access. The Promise build-tool recipe and install arguments are
  derived from the same selected, exact-lock wheel entries rather than a second
  independent choice.
- Retain Promise's MIT text, bind its source-built wheel candidate, and record
  the supply-chain boundary in Decision 0071 while leaving image admission
  blocked.

Tracks #12

This is construction input only. It publishes no container or fixture and
remains `NO_RESULT`.

## Frozen selection

- Upstream CLRS commit:
  `d33c3cfc765a18950194205a1ddb92a0981a355e`.
- Base image:
  `docker.io/library/python:3.13.15-slim-bookworm@sha256:c45a22ea000adfd9cda29364bbe7edd23001ce5cc2ad15857cfbf7766943b9ca`
  with glibc 2.36.
- Dependency lock:
  `sha256:1aff6ff0e589539e07b3ee75579803ebd66636ab35568661680a703ed38ab640`.
- Wheelhouse manifest:
  `sha256:06f86574c8457337919bc2380b1fca899215bacd3c040cb127ea2d27ff9dcd06`;
  61 files and 823,932,066 bytes. Sixty wheels map directly to exact
  `uv.lock` artifacts.
- `promise==2.3` source:
  19,534 bytes at
  `sha256:dfd18337c523ba4b6a58801c164c1904a9d4d1b1747c7d5dbf45b693a49d93d0`.
  Two bounded, no-network reconnaissance builds produced the same 21,582-byte
  candidate wheel at
  `sha256:bef8aedf1f65bca04bed59a7dd784f94075ceeb61c13ea9aaf86c91f569f861b`.
  The complete executable procedure and retained reproduction receipt remain
  admission gates, so those observations do not admit the wheel or image.

## Verification

```text
PASS  go test -race ./internal/clrsfixture ./cmd/20w
PASS  go vet ./internal/clrsfixture ./cmd/20w
PASS  go test -race ./...
PASS  go vet ./...
PASS  go run ./cmd/20w experiment verify-clrs-wheelhouse --root .. \
        --wheelhouse <ignored-materialised-wheelhouse>
      61 artifacts, 823932066 bytes, NO_RESULT
PASS  npm run validate:book-pdf
PASS  npm run check (Node 26.8.1; 20 bounded workstation jobs)
PASS  independent Codex adversarial review plus two fresh, no-network Promise builds
PASS  local Qwen3.8-27B review (no blockers; bounded diff, no tool execution)
PASS  remote Google AI Ultra/AGY Gemini 120B review (no blockers; sandboxed plan mode)
```

The materialised bytes remain under ignored `.workingdir2/cache/`; Git retains
their exact names, sizes, hashes, provenance and bounded verification contract.

## Remaining admission gates

There is still no Dockerfile, complete build context, admitted image digest or
registry publication. Admission also requires the complete Promise build
procedure and receipt, final-image licence evidence, two identical isolated
no-cache image builds, an image-bound SPDX JSON SBOM, pinned-source import and
hardened runtime smoke, and two byte-identical six-file/48-example fixture
generations.

No fixture, model output, energy observation or scientific comparison is added
or promoted by this change.

## Research traceability

- **Claim IDs:** none; this is a reproducibility and supply-chain contract.
- **Principle bundles:** none; no scientific mechanism or advantage is
  proposed.
- **Experiment or fixture IDs:** the CLRS controller shakedown fixed by
  Decisions 0055 and 0071; no fixture is generated.
- **Evidence and result authority:** construction evidence only, `NO_RESULT`.
- **Contributors and accountable approver:** OpenAI Codex assisted with the
  implementation, manifest checking and test execution. `@lusoris` remains the
  accountable maintainer and prospective approver; this is not a claim-eligible
  output. Independent engineering reviews found no patch blocker; no scientific
  domain review is claimed.
- **Funding, material support, and competing interests:** no project funding or
  donated compute was disclosed. Maintainer-provided compute and public package
  and OCI registries supplied the bounded construction inputs; no competing
  interest is known.
- **Material AI, automation, or external services:** OpenAI Codex, local
  Qwen3.8-27B, the remote Google AI Ultra/AGY Gemini 120B reviewer, public PyPI,
  Docker Hub and GHCR were used on 2026-09-05. The tracked hashes, Go validator
  and repository tests remain authoritative; model opinions do not admit an
  image or result.
- **Ethics, rights, safety, misuse, and data-plan triggers:** no trigger; this
  change processes publicly licensed software artifacts and no participants,
  personal data or physical intervention.
- **Intended reader:** maintainers and contributors continuing the container
  admission work.
- **Domain-accuracy review:** no scientific assertion changes; source,
  dependency and licence identities are executable contract inputs.
- **Curious-reader review:** the generator README explains why a frozen
  selection is not an admitted image. No independent readability review is
  claimed.
