### PR TITLE
test(publication): bind page-129 PDF semantic debt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ the exact diff; this file records why the project changed.
 - The deterministic PDF finaliser now gives Chromium's `Strong` and `Em`
   structure types an explicit PDF 1.x compatibility mapping. Poppler's 627
   unknown-type diagnostics are removed without changing the page content or
-  canonical HTML. Five nonlinear reading-order sentinels remain `known-debt`;
+  canonical HTML. Six nonlinear reading-order sentinels remain `known-debt`;
   this is not a PDF/UA or WCAG conformance claim.
 - Decision 0069 makes the CI impact planner map a deleted file through its
   former repository path instead of sending every deletion through the complete

--- a/scripts/book-pdf-semantic-baseline.json
+++ b/scripts/book-pdf-semantic-baseline.json
@@ -178,6 +178,34 @@
       "defect": "The lifecycle equation moves behind the beginning of Evidence status in raw content-stream extraction and is absent from tagged structure text."
     },
     {
+      "id": "admissible-action-equation-late",
+      "class": "table-displayed-equation",
+      "recorded_page": 129,
+      "default_anchor": "The held translation assigns controller i an admissible action set",
+      "default_fragments": [
+        "The held translation assigns controller i an admissible action set",
+        "Ui (t) = Ei",
+        "ui (t) ∈ Ui (t),",
+        "where τi is observation age in seconds",
+        "the notation does not make them interchangeable."
+      ],
+      "struct_text_fragments": [
+        "Authority follows information and remaining capability",
+        "The held translation assigns controller ",
+        " an admissible action set",
+        " is observation age in seconds",
+        "the notation does not make them interchangeable."
+      ],
+      "raw_fragments": [
+        "The held translation assigns controller an admissible action set",
+        "where is observation age in seconds",
+        "the notation does not make them interchangeable.\ni\nU",
+        "(t) ∈ U"
+      ],
+      "state": "known-debt",
+      "defect": "The admissible-action equation moves behind its explanation in raw content-stream extraction and is absent from tagged structure text."
+    },
+    {
       "id": "adiabatic-equation-fragmented",
       "class": "diagram-figure",
       "recorded_page": 377,

--- a/scripts/lib/pdf-metadata.test.mjs
+++ b/scripts/lib/pdf-metadata.test.mjs
@@ -527,7 +527,24 @@ test("the tracked semantic baseline is closed and records failing debt", async (
     new URL("../book-pdf-semantic-baseline.json", import.meta.url),
   ));
   assert.equal(baseline.expected_outcome, "known-debt");
-  assert.equal(baseline.sentinels.length, 5);
+  assert.equal(baseline.sentinels.length, 6);
+  const addedSentinel = baseline.sentinels.find(
+    ({ id }) => id === "admissible-action-equation-late",
+  );
+  assert.deepEqual(
+    addedSentinel && {
+      id: addedSentinel.id,
+      class: addedSentinel.class,
+      recorded_page: addedSentinel.recorded_page,
+      state: addedSentinel.state,
+    },
+    {
+      id: "admissible-action-equation-late",
+      class: "table-displayed-equation",
+      recorded_page: 129,
+      state: "known-debt",
+    },
+  );
   assert.equal(
     baseline.sentinels.some(({ id }) => id === "biomimetic-figure-caption-late"),
     false,


### PR DESCRIPTION
## Summary

- bind the page-129 admissible-action equation to the checked PDF semantic baseline as the sixth nonlinear `known-debt` sentinel
- lock the added record's ID, class, recorded page, and state in the release-lane test
- update the changelog's debt count without changing publication content

## Evidence

- fetched base `origin/main`: `e528d2855254c186f6d05c18cefae09c8ae8fa29` (tree `198933bb756cefdc28229d7d56711f51fd2cccb4`)
- rebased head: `2a825e65b69332cfb3bde0c7651e5385a2c8a59e` (tree `7e4ac87e22c2c545f081d6402791d5ecd35a12ae`)
- checked six-sentinel report: `6ab2d8bd9fbd7a4d631e3a0ac77b92fa3a9f43aaf3b7054977b18f19250127f7`
- the real Poppler 26.08.0 audit exits non-zero with exactly six recognized nonlinear sentinels and `passed: false`

## Validation

- `node --test --experimental-test-isolation=none scripts/lib/pdf-metadata.test.mjs` — 18/18 pass
- `npm run generate:book-pdf` — pass, two fresh renders byte-identical
- `npm run validate:book-pdf` — pass, 342 source files
- `npm run validate:docs` — pass, 370 Markdown files, 19 chapters, 59 Mermaid sources
- `npm run check:prose` — pass
- `npm run check` — pass: 20/20 bounded workstation jobs and the 433-file Pages build validated
- `go -C tooling run ./cmd/20w ci plan --root .. --base e528d2855254c186f6d05c18cefae09c8ae8fa29 --head 2a825e65b69332cfb3bde0c7651e5385a2c8a59e --json` — current selector conservatively chooses `full,renderer` because `scripts/lib/pdf-metadata.test.mjs` is unmapped; #7 owns that separate selector correction
- `git diff --check origin/main...HEAD` — pass
- checked PDF SHA-256 remains `f1578ea4cd64bc04e5608fa36e5854fdc7b1c5ae149a4393a87418d6445029aa`
- checked manifest SHA-256 remains `ea045ad1f11060977d55d454d169c1a79e70a847d25dcb4d6cc7a17c950036cd`
- book source digest remains `c8ab6fa1f741338067add8cf96d4d71d9d16d281ed1f57ddc386886f4ecad32c`

## Maintainer metadata

- title: `test(publication): bind page-129 PDF semantic debt`
- labels: `type:test`, `severity:p1`, `status:in-progress`, `area:publication`, `area:site`
- milestone: `M0 — Evidence, synthesis, and contracts`

## Boundary

This is a validation-only `NO_RESULT` change. It records an inherited extraction defect; it does not repair reading order, regenerate the PDF, or establish PDF/UA or WCAG conformance.

Tracks #17
