### PR TITLE
fix(ci): scope PDF semantic release inputs

### DIFF
--- a/.github/ci-impact.json
+++ b/.github/ci-impact.json
@@ -330,7 +330,9 @@
     {
       "id": "script-publication-semantic-baseline",
       "paths": [
-        "scripts/book-pdf-semantic-baseline.json"
+        "scripts/book-pdf-semantic-baseline.json",
+        "scripts/lib/book-pdf-semantic-audit.mjs",
+        "scripts/lib/pdf-metadata.test.mjs"
       ],
       "lanes": [
         "release"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ the exact diff; this file records why the project changed.
 
 ### Fixed
 
+- PDF semantic baseline tests and their dedicated audit helper now select the
+  release lane rather than expanding to full CI plus renderer reproducibility.
+  Production PDF finalisation, the manual Poppler audit, unknown scripts and
+  selector changes remain fail-closed.
 - Decision 0070 makes Fixture 026 check a missing arm commitment against
   existing evaluator state before invoking the isolated policy bank, so a
   bounded policy timeout cannot mask deterministic resume corruption. The

--- a/tooling/internal/ciplan/mapping_test.go
+++ b/tooling/internal/ciplan/mapping_test.go
@@ -34,6 +34,10 @@ func TestRepositoryImpactMappingIsClosedAndRoutesRepresentativeChanges(t *testin
 		{path: "renovate.json", mode: "impact", lanes: []string{"dependency"}},
 		{path: "package-lock.json", mode: "full", lanes: []string{"full", "renderer"}, reason: "full-authority-changed"},
 		{path: "scripts/book-pdf-semantic-baseline.json", mode: "impact", lanes: []string{"release"}},
+		{path: "scripts/lib/book-pdf-semantic-audit.mjs", mode: "impact", lanes: []string{"release"}},
+		{path: "scripts/lib/pdf-metadata.test.mjs", mode: "impact", lanes: []string{"release"}},
+		{path: "scripts/lib/pdf-metadata.mjs", mode: "full", lanes: []string{"full", "renderer"}, reason: "full-authority-changed"},
+		{path: "scripts/audit-book-pdf-semantics.mjs", mode: "full", lanes: []string{"full", "renderer"}, reason: "unmapped-path:scripts/audit-book-pdf-semantics.mjs"},
 		{path: "scripts/generate-book-pdf.mjs", mode: "full", lanes: []string{"full", "renderer"}, reason: "full-authority-changed"},
 		{path: "scripts/audit-prose-style.mjs", mode: "full", lanes: []string{"full"}, reason: "full-authority-changed"},
 		{path: "scripts/book-edition-surface.test.mjs", mode: "impact", lanes: []string{"site"}},
@@ -67,6 +71,21 @@ func TestRepositoryImpactMappingIsClosedAndRoutesRepresentativeChanges(t *testin
 			(test.reason != "" && plan.Reason != test.reason) {
 			t.Fatalf("path %s produced %#v, want %s/%v", test.path, plan, test.mode, test.lanes)
 		}
+	}
+}
+
+func TestPdfSemanticSentinelDiffSelectsOnlyItsPublicationConsumers(t *testing.T) {
+	t.Parallel()
+	root := filepath.Clean(filepath.Join("..", "..", ".."))
+	plan := selectTestPaths(t, root, testOptions(root), []string{
+		"CHANGELOG.md",
+		"scripts/book-pdf-semantic-baseline.json",
+		"scripts/lib/pdf-metadata.test.mjs",
+	})
+	want := []string{"release", "research", "site"}
+	if plan.Mode != "impact" || plan.Reason != "mapped-change-set" ||
+		!reflect.DeepEqual(plan.Lanes, want) {
+		t.Fatalf("PDF semantic sentinel plan = %#v, want impact/%v", plan, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

- map the closed PDF semantic baseline, its dedicated audit helper, and its release test to the existing release lane
- replay the exact six-sentinel change set and require `release`, `research`, and `site` without full workstation or renderer fan-out
- keep production PDF finalisation, the manual Poppler CLI, future unknown scripts, and selector authority on their existing fail-closed full/renderer paths

The release lane already runs `scripts/lib/pdf-metadata.test.mjs`, which imports and exercises every exported operation from `scripts/lib/book-pdf-semantic-audit.mjs`. Neither mapped file generates or changes PDF bytes. The manual audit remains deliberately unmapped until the digest-pinned PDF-tools consumer is admitted.

## Revision evidence

- base: `82fa5de52ba72cf03f950c920c0d3be7d65889c1`
- head: `4af4e4d85ec65c2381fd370c50b4a6dc5a895813`
- tree: `f5f326a0f8f1636fa55af174cad4486439471d80`

## Validation

- `go -C tooling test -race -shuffle=on -count=1 ./internal/ciplan` — pass
- `go -C tooling vet ./internal/ciplan` — pass
- `npm run validate:policy` — pass
- `npm run test:release` — 46/46 pass, including all 18 PDF metadata/semantic tests
- `npm run check:prose` — pass
- `git diff --check origin/main...HEAD` — pass
- exact historical replay, `e528d285...2a825e65` — `impact`, `mapped-change-set`, lanes `[release, research, site]`
- independent read-only red-team — pass; no mapping omission or fail-open path found

The local full aggregate is intentionally not duplicated for this selector-only iteration. Changing `.github/ci-impact.json` makes this PR itself select the protected full and renderer merge gates; those remote gates remain required before auto-merge.

## Boundary

This changes CI scheduling only. It does not weaken a test, alter the six recorded `known-debt` sentinels, change PDF bytes, admit the ambient Poppler audit, or make a scientific/accessibility claim. Issue #7 remains open for its separate 3–5 minute full-gate target.

Tracks #7
