### PR TITLE
fix(publication): reject installed dependency drift before PDF rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ the exact diff; this file records why the project changed.
   one complete line of canonical prose in the initial `390 x 844` viewport.
   The 320-pixel reflow boundary still keeps long revisions and routes inside
   the document width.
+- Both PDF commands now reject a stale or incomplete installed npm dependency
+  tree before image work, and stop if package metadata changes before rendering
+  or publication. This catches copied installs such as KaTeX 0.18.4 against a
+  0.18.5 lock without downloading packages or claiming payload-byte attestation.
 - Decision 0072 runs the three independent site-browser contracts in
   process-isolated Node workers with a concurrency ceiling of two instead of
   one serial process. The first live three-worker run exhausted its unchanged

--- a/docs/publication-workflow.md
+++ b/docs/publication-workflow.md
@@ -152,6 +152,27 @@ dependency tree. Their byte comparison therefore tests deterministic rendering
 conditional on one clean `npm ci` realization; it does not independently
 reinstall or byte-bind two realized `node_modules` trees.
 
+Before either PDF command starts image work, Go checks the declared lock,
+npm's hidden installation lock and each installed package's name and version.
+It rejects stale identities, missing required packages, unexpected packages,
+unsafe paths and malformed metadata. Platform-optional packages and their
+optional dependency subtrees may be absent. Metadata is frozen for the command
+and rechecked before and after rendering, then before publishing the pair or
+acceptance receipt. These offline checks detect installation drift; they do
+not authenticate package payload bytes. A failure requires an explicit
+`npm ci --no-audit` with the locked toolchain, not a download during rendering.
+The check bounds each lock to 2 MiB, each package manifest to 1 MiB, combined
+metadata to 32 MiB, the inventory to 4,096 packages, paths to 16 components,
+each directory to 4,096 entries and each inspection to 30 seconds. npm shims,
+its separately checked hidden lock and known Vite/cache directories are
+outside the package inventory. Remove this check only when a replacement
+renderer binds its installed dependency inputs more strongly.
+
+npm's `inBundle` records may omit their own URL and integrity. The guard
+requires a containing locked package and its explicit `bundleDependencies`
+entry, or an already bundled parent; the enclosing archive supplies the
+binding. This includes the optional WASI subtree in the current lock.
+
 `node scripts/audit-book-pdf-semantics.mjs --evidence-dir
 .workingdir2/evidence/design/<new-directory-name>` captures plain `pdfinfo`,
 `pdfinfo -struct`, `pdfinfo -struct-text`, default text extraction and raw text

--- a/public/downloads/book-manifest.json
+++ b/public/downloads/book-manifest.json
@@ -5,7 +5,7 @@
   "source_ref": "main",
   "source_revision": null,
   "pdf": "public/downloads/20-watts-was-enough-full-concept-book.pdf",
-  "source_digest": "4217501098a3146ed81c0e0942ed49a7a5ed7fa9116895f96ff0455d3be1a199",
+  "source_digest": "befa3d4555013040ccff107a19a847ae261fa7b5b911c1b0d979656885cecc87",
   "source_files": [
     "app/book-content.ts",
     "app/components/book-edition.tsx",
@@ -330,6 +330,8 @@
     "tooling/internal/pdfrender/archive.go",
     "tooling/internal/pdfrender/command.go",
     "tooling/internal/pdfrender/dockerfile.go",
+    "tooling/internal/pdfrender/installed_dependencies.go",
+    "tooling/internal/pdfrender/installed_inventory.go",
     "tooling/internal/pdfrender/lock.go",
     "tooling/internal/pdfrender/publication.go",
     "tooling/internal/pdfrender/render.go",

--- a/scripts/book-pdf-semantic-baseline.json
+++ b/scripts/book-pdf-semantic-baseline.json
@@ -7,7 +7,7 @@
     "pdf": "public/downloads/20-watts-was-enough-full-concept-book.pdf",
     "manifest": "public/downloads/book-manifest.json",
     "pdf_sha256": "387bca765e0ae4a675f5274a0f511a0644f1d26fd4f9b665fdeb9b64236ad454",
-    "manifest_sha256": "2b1533d104e14b9395d9faef66b1aec4fc6a1db9841ded0dbc333af145bbf745",
+    "manifest_sha256": "93cb2ff72261d9d2117f32cc5aa33cb9b323d1d434a56885987246f3cc6bebe2",
     "size_bytes": 12782330,
     "pages": 412,
     "page_size_name": "A4",
@@ -18,7 +18,7 @@
     "pdf_version": "1.4",
     "tagged": true,
     "source_ref": "main",
-    "source_digest": "4217501098a3146ed81c0e0942ed49a7a5ed7fa9116895f96ff0455d3be1a199",
+    "source_digest": "befa3d4555013040ccff107a19a847ae261fa7b5b911c1b0d979656885cecc87",
     "version": "0.3.0"
   },
   "tools": {

--- a/scripts/book-route.test.mjs
+++ b/scripts/book-route.test.mjs
@@ -230,6 +230,8 @@ test("the full-book source identity includes the locked renderer dependency grap
     "tooling/internal/nodeimage/package.go",
     "tooling/internal/ocimanifest/manifest.go",
     "tooling/internal/pdfrender/dockerfile.go",
+    "tooling/internal/pdfrender/installed_dependencies.go",
+    "tooling/internal/pdfrender/installed_inventory.go",
     "tooling/internal/pdfrender/publication.go",
     "tooling/internal/pdfrender/render.go",
     "tooling/internal/pdfrender/reproducibility.go",

--- a/scripts/book-source.mjs
+++ b/scripts/book-source.mjs
@@ -133,6 +133,8 @@ export async function bookSourceFiles(projectRoot) {
     "tooling/internal/pdfrender/archive.go",
     "tooling/internal/pdfrender/command.go",
     "tooling/internal/pdfrender/dockerfile.go",
+    "tooling/internal/pdfrender/installed_dependencies.go",
+    "tooling/internal/pdfrender/installed_inventory.go",
     "tooling/internal/pdfrender/lock.go",
     "tooling/internal/pdfrender/publication.go",
     "tooling/internal/pdfrender/render.go",

--- a/tooling/internal/ciplan/plan_test.go
+++ b/tooling/internal/ciplan/plan_test.go
@@ -71,6 +71,8 @@ func TestRendererAuthorityPredicateCoversTheClosedExecutionBoundary(t *testing.T
 		"tooling/go.mod",
 		"tooling/internal/ciplan/plan.go",
 		"tooling/internal/pdfrender/reproducibility.go",
+		"tooling/internal/pdfrender/installed_dependencies.go",
+		"tooling/internal/pdfrender/installed_inventory.go",
 		"tooling/internal/strictjson/validate.go",
 		"tooling/pdf-renderer/lock.json",
 		"vite.pages.config.ts",

--- a/tooling/internal/pdfrender/installed_boundaries_test.go
+++ b/tooling/internal/pdfrender/installed_boundaries_test.go
@@ -1,0 +1,159 @@
+package pdfrender
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInstalledDependencyPreflightStopsBothCommandsBeforeDocker(t *testing.T) {
+	t.Parallel()
+	for _, verification := range []bool{false, true} {
+		t.Run(fmt.Sprint(verification), func(t *testing.T) {
+			t.Parallel()
+			configuration := renderConfiguration(t)
+			root := configuration.RepositoryRoot
+			mutateDependencyFile(t, root, "node_modules/.package-lock.json", "0.18.5", "0.18.4")
+			executor := &recordingExecutor{imageID: testImageID}
+			var err error
+			if verification {
+				_, err = verifyReproducibilityWithDependencies(context.Background(), configuration, "main", "", ".workingdir2/evidence/proof.json", noOpPreparer{}, executor)
+			} else {
+				_, err = renderWithDependencies(context.Background(), configuration, "main", "", noOpPreparer{}, executor)
+			}
+			if err == nil || !strings.Contains(err.Error(), "hidden lock identity differs") {
+				t.Fatalf("preflight error = %v", err)
+			}
+			if len(executor.requests) != 0 {
+				t.Fatalf("stale installation started %d Docker commands", len(executor.requests))
+			}
+		})
+	}
+}
+
+type installedDriftExecutor struct {
+	t           *testing.T
+	root        string
+	delegate    commandExecutor
+	trigger     string
+	triggered   bool
+	renderCount int
+}
+
+func (executor *installedDriftExecutor) run(ctx context.Context, request commandRequest) ([]byte, error) {
+	body, err := executor.delegate.run(ctx, request)
+	phase := request.operation
+	if phase == "run pinned PDF renderer image" {
+		executor.renderCount++
+		phase = fmt.Sprintf("render-%d", executor.renderCount)
+	}
+	if err == nil && !executor.triggered && phase == executor.trigger {
+		executor.triggered = true
+		// A consistent metadata edit still invalidates the frozen render input.
+		writeDependencyJSON(executor.t, executor.root, installedTestPackage+"/package.json", map[string]string{"name": "katex", "version": "0.18.5", "description": "changed during render"})
+	}
+	return body, err
+}
+
+func TestInstalledDependencyDriftNeverPublishesTheRenderedPair(t *testing.T) {
+	t.Parallel()
+	for _, phase := range []string{"build pinned PDF renderer image", "render-1", "render-2", "remove locked Docker BuildKit builder"} {
+		t.Run(phase, func(t *testing.T) {
+			t.Parallel()
+			configuration := renderConfiguration(t)
+			root := configuration.RepositoryRoot
+			pdf, manifest := []byte("old PDF"), []byte("old manifest")
+			writePublicationFixture(t, root, pdf, manifest)
+			delegate := &recordingExecutor{imageID: testImageID}
+			executor := &installedDriftExecutor{t: t, root: root, delegate: delegate, trigger: phase}
+			_, err := renderWithDependencies(context.Background(), configuration, "main", "", noOpPreparer{}, executor)
+			if !executor.triggered || err == nil || !strings.Contains(err.Error(), "metadata changed during rendering") {
+				t.Fatalf("phase %q triggered=%t error=%v", phase, executor.triggered, err)
+			}
+			assertPublicationFixture(t, root, pdf, manifest)
+			if len(requestsWithPrefix(delegate.requests, "buildx", "rm")) != 1 {
+				t.Fatal("owned builder was not cleaned exactly once")
+			}
+		})
+	}
+}
+
+func TestInstalledDependencyDriftNeverWritesAPassingReproducibilityReceipt(t *testing.T) {
+	t.Parallel()
+	configuration := renderConfiguration(t)
+	delegate := &reproducibilityExecutor{
+		imageIDs: []string{testImageID, testImageID}, manifestDigests: []string{testManifestDigest, testManifestDigest}, configDigests: []string{testImageID, testImageID},
+	}
+	executor := &installedDriftExecutor{t: t, root: configuration.RepositoryRoot, delegate: delegate, trigger: "render-2"}
+	relative := ".workingdir2/evidence/publication/dependency-drift.json"
+	_, err := verifyReproducibilityWithDependencies(context.Background(), configuration, "main", "", relative, reproducibilityFixturePreparer{}, executor)
+	if !executor.triggered || err == nil || !strings.Contains(err.Error(), "metadata changed during rendering") {
+		t.Fatalf("second-render drift: triggered=%t error=%v", executor.triggered, err)
+	}
+	if _, err := os.Stat(filepath.Join(configuration.RepositoryRoot, filepath.FromSlash(relative))); !os.IsNotExist(err) {
+		t.Fatalf("invalid receipt exists or cannot be inspected: %v", err)
+	}
+	if len(requestsWithPrefix(delegate.requests, "buildx", "rm")) != 2 || len(requestsWithPrefix(delegate.requests, "image", "rm", "--force")) != 2 {
+		t.Fatal("reproducibility failure did not clean both owned builders/images")
+	}
+}
+
+func TestInstalledDependencyInventoryRejectsInvalidEmptyScopesAndAuxiliaries(t *testing.T) {
+	t.Parallel()
+	for _, name := range []string{"@..", "@", "@bad scope", ".unknown"} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			writeInstalledDependencyFixture(t, root)
+			if err := os.Mkdir(filepath.Join(root, "node_modules", name), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			_, err := inspectInstalledDependencies(context.Background(), root)
+			if err == nil || !strings.Contains(err.Error(), "unsafe") {
+				t.Fatalf("invalid empty directory %q accepted: %v", name, err)
+			}
+		})
+	}
+	root := t.TempDir()
+	writeInstalledDependencyFixture(t, root)
+	for _, name := range []string{".bin", ".cache", ".vite", ".vite-temp", "@empty-valid"} {
+		if err := os.Mkdir(filepath.Join(root, "node_modules", name), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := inspectInstalledDependencies(context.Background(), root); err != nil {
+		t.Fatalf("npm/Vite auxiliary directories rejected: %v", err)
+	}
+}
+
+func TestInstalledDependencyInventoryBoundsDirectoryEntries(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeInstalledDependencyFixture(t, root)
+	for index := 0; index < maximumInstalledPackages; index++ {
+		if err := os.Mkdir(filepath.Join(root, "node_modules", fmt.Sprintf("@scope-%04d", index)), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := installedPackagePaths(context.Background(), root); err == nil || !strings.Contains(err.Error(), "directory bound") {
+		t.Fatalf("directory bound = %v", err)
+	}
+}
+
+func TestInstalledDependencyInventoryBoundsPackagesAcrossScopes(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	for _, scope := range []string{"@first", "@second"} {
+		for index := 0; index < maximumInstalledPackages/2+1; index++ {
+			if err := os.MkdirAll(filepath.Join(root, "node_modules", scope, fmt.Sprintf("pkg-%04d", index)), 0o755); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	if _, err := installedPackagePaths(context.Background(), root); err == nil || !strings.Contains(err.Error(), "4096-package bound") {
+		t.Fatalf("package count bound = %v", err)
+	}
+}

--- a/tooling/internal/pdfrender/installed_bundles_test.go
+++ b/tooling/internal/pdfrender/installed_bundles_test.go
@@ -1,0 +1,76 @@
+package pdfrender
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInstalledDependenciesBindBundledChildrenToTheContainingArchive(t *testing.T) {
+	t.Parallel()
+	for _, testCase := range []struct {
+		name                                string
+		installed, listed, orphan, required bool
+	}{
+		{name: "omitted-optional-bundle", listed: true},
+		{name: "installed-bundle", listed: true, installed: true},
+		{name: "unlisted-child"},
+		{name: "orphan-child", listed: true, orphan: true},
+		{name: "required-bundle-omission", listed: true, required: true},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			writeInstalledDependencyFixture(t, root)
+			body, err := os.ReadFile(filepath.Join(root, "package-lock.json"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			var lock dependencyLock
+			if err := json.Unmarshal(body, &lock); err != nil {
+				t.Fatal(err)
+			}
+			parent := map[string]any{"version": "1.0.0", "resolved": "https://example.invalid/bundle.tgz", "integrity": "sha512-parent", "optional": !testCase.required}
+			if testCase.listed {
+				parent["bundleDependencies"] = []string{"child"}
+			}
+			child := map[string]any{"version": "2.0.0", "inBundle": true, "optional": !testCase.required}
+			if !testCase.orphan {
+				lock.Packages["node_modules/@vendor/bundle"], err = json.Marshal(parent)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			lock.Packages["node_modules/@vendor/bundle/node_modules/child"], err = json.Marshal(child)
+			if err != nil {
+				t.Fatal(err)
+			}
+			writeDependencyJSON(t, root, "package-lock.json", lock)
+			if testCase.installed {
+				writeDependencyJSON(t, root, "node_modules/.package-lock.json", lock)
+				writeDependencyJSON(t, root, "node_modules/@vendor/bundle/package.json", map[string]string{"name": "@vendor/bundle", "version": "1.0.0"})
+				writeDependencyJSON(t, root, "node_modules/@vendor/bundle/node_modules/child/package.json", map[string]string{"name": "child", "version": "2.0.0"})
+			}
+			digest, err := inspectInstalledDependencies(context.Background(), root)
+			failure := ""
+			switch {
+			case testCase.orphan:
+				failure = "no locked parent"
+			case !testCase.listed:
+				failure = "not listed"
+			case testCase.required:
+				failure = "required installed package"
+			}
+			if failure == "" {
+				if err != nil || !rawSHA256Pattern.MatchString(digest) {
+					t.Fatalf("bundled metadata = %q %v", digest, err)
+				}
+			} else if err == nil || !strings.Contains(err.Error(), failure) {
+				t.Fatalf("bundled metadata error = %v, want %q", err, failure)
+			}
+		})
+	}
+}

--- a/tooling/internal/pdfrender/installed_dependencies.go
+++ b/tooling/internal/pdfrender/installed_dependencies.go
@@ -1,0 +1,268 @@
+package pdfrender
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"hash"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/lusoris/20-watts-was-enough/tooling/internal/strictjson"
+)
+
+const (
+	maximumDependencyLockBytes     = 2 * 1024 * 1024
+	maximumDependencyManifestBytes = 1024 * 1024
+	maximumDependencyMetadataBytes = 32 * 1024 * 1024
+	maximumInstalledPackages       = 4096
+	maximumDependencyPathDepth     = 16
+	installedDependencyTimeout     = 30 * time.Second
+)
+
+type dependencyLock struct {
+	LockfileVersion int                        `json:"lockfileVersion"`
+	Packages        map[string]json.RawMessage `json:"packages"`
+}
+
+type dependencyPackage struct {
+	Name      string `json:"name"`
+	Version   string `json:"version"`
+	Resolved  string `json:"resolved"`
+	Integrity string `json:"integrity"`
+	Optional  bool   `json:"optional"`
+	Link      bool   `json:"link"`
+	InBundle  bool   `json:"inBundle"`
+}
+
+// This snapshot checks installed graph metadata, not package payload bytes or
+// tarball authenticity. npm ci remains the installation/integrity boundary.
+type installedDependencySnapshot struct {
+	root   string
+	bytes  int
+	digest hash.Hash
+}
+
+func bindInstalledDependencies(ctx context.Context, configuration Configuration) (Configuration, error) {
+	digest, err := inspectInstalledDependencies(ctx, configuration.RepositoryRoot)
+	if err != nil {
+		return Configuration{}, err
+	}
+	configuration.installedDependenciesSHA256 = digest
+	return configuration, nil
+}
+
+func checkInstalledDependencies(ctx context.Context, configuration Configuration) error {
+	if configuration.installedDependenciesSHA256 == "" {
+		return errors.New("PDF installed dependencies were not bound before rendering")
+	}
+	digest, err := inspectInstalledDependencies(ctx, configuration.RepositoryRoot)
+	if err != nil {
+		return err
+	}
+	if digest != configuration.installedDependenciesSHA256 {
+		return errors.New("PDF installed dependency metadata changed during rendering; rerun npm ci --no-audit with the locked toolchain")
+	}
+	return nil
+}
+
+func inspectInstalledDependencies(ctx context.Context, root string) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, installedDependencyTimeout)
+	defer cancel()
+	snapshot := installedDependencySnapshot{root: root, digest: sha256.New()}
+	digest, err := snapshot.inspect(ctx)
+	if err != nil {
+		return "", fmt.Errorf("PDF installed dependency preflight: %w; rerun npm ci --no-audit with the locked toolchain", err)
+	}
+	return digest, nil
+}
+
+func (snapshot *installedDependencySnapshot) inspect(ctx context.Context) (string, error) {
+	declared, err := snapshot.readLock(ctx, "package-lock.json")
+	if err != nil {
+		return "", err
+	}
+	installed, err := snapshot.readLock(ctx, "node_modules/.package-lock.json")
+	if err != nil {
+		return "", err
+	}
+	paths, err := installedPackagePaths(ctx, snapshot.root)
+	if err != nil {
+		return "", err
+	}
+	if err := compareInstalledInventory(declared, installed, paths); err != nil {
+		return "", err
+	}
+	for _, relative := range paths {
+		if err := snapshot.comparePackage(ctx, relative, declared.Packages[relative], installed.Packages[relative]); err != nil {
+			return "", err
+		}
+	}
+	return hex.EncodeToString(snapshot.digest.Sum(nil)), ctx.Err()
+}
+
+func (snapshot *installedDependencySnapshot) read(ctx context.Context, relative string, maximumBytes int64) ([]byte, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	body, err := readRegularBounded(snapshot.root, filepath.Join(snapshot.root, filepath.FromSlash(relative)), maximumBytes, relative)
+	if err != nil {
+		return nil, err
+	}
+	snapshot.bytes += len(body)
+	if snapshot.bytes > maximumDependencyMetadataBytes {
+		return nil, errors.New("installed package metadata exceeds the 32 MiB total bound")
+	}
+	if err := strictjson.Validate(body, 32); err != nil {
+		return nil, fmt.Errorf("%s: %w", relative, err)
+	}
+	// Length-prefix every record so path/body concatenations cannot collide.
+	fmt.Fprintf(snapshot.digest, "%d:%s:%d:", len(relative), relative, len(body))
+	snapshot.digest.Write(body)
+	return body, ctx.Err()
+}
+
+func (snapshot *installedDependencySnapshot) readLock(ctx context.Context, relative string) (dependencyLock, error) {
+	body, err := snapshot.read(ctx, relative, maximumDependencyLockBytes)
+	if err != nil {
+		return dependencyLock{}, err
+	}
+	var lock dependencyLock
+	if err := json.Unmarshal(body, &lock); err != nil {
+		return lock, fmt.Errorf("decode %s: %w", relative, err)
+	}
+	if lock.LockfileVersion != 3 || len(lock.Packages) == 0 || len(lock.Packages) > maximumInstalledPackages+1 {
+		return lock, fmt.Errorf("%s requires lockfileVersion 3 and 1..%d package records", relative, maximumInstalledPackages+1)
+	}
+	for _, name := range sortedDependencyKeys(lock.Packages) {
+		if err := ctx.Err(); err != nil {
+			return lock, err
+		}
+		if name == "" && relative == "package-lock.json" {
+			continue
+		}
+		if !validDependencyPath(name) {
+			return lock, fmt.Errorf("%s has unsafe package path %q", relative, name)
+		}
+		metadata, err := parseDependencyPackage(lock.Packages[name])
+		if err != nil {
+			return lock, fmt.Errorf("%s package %s: %w", relative, name, err)
+		}
+		if metadata.InBundle {
+			if err := validateBundledDependency(lock, name); err != nil {
+				return lock, fmt.Errorf("%s package %s: %w", relative, name, err)
+			}
+		}
+	}
+	return lock, nil
+}
+
+func parseDependencyPackage(body []byte) (dependencyPackage, error) {
+	var metadata dependencyPackage
+	if err := json.Unmarshal(body, &metadata); err != nil {
+		return metadata, err
+	}
+	if metadata.Version == "" || metadata.Link || (!metadata.InBundle && (metadata.Resolved == "" || metadata.Integrity == "")) {
+		return metadata, errors.New("package requires version, resolved URL and integrity; linked installs are unsupported")
+	}
+	return metadata, nil
+}
+
+func validateBundledDependency(lock dependencyLock, relative string) error {
+	boundary := strings.LastIndex(relative, "/node_modules/")
+	if boundary < 0 {
+		return errors.New("bundled package has no containing package")
+	}
+	var parent struct {
+		InBundle           bool     `json:"inBundle"`
+		BundleDependencies []string `json:"bundleDependencies"`
+	}
+	body := lock.Packages[relative[:boundary]]
+	if body == nil {
+		return errors.New("bundled package has no locked parent")
+	}
+	if err := json.Unmarshal(body, &parent); err != nil {
+		return fmt.Errorf("decode bundled-package parent: %w", err)
+	}
+	name := relative[boundary+len("/node_modules/"):]
+	// Bundled descendants inherit the enclosing archive's identity. An
+	// unbundled parent must explicitly list the direct bundled dependency.
+	if !parent.InBundle && !slices.Contains(parent.BundleDependencies, name) {
+		return errors.New("bundled package is not listed by its containing archive")
+	}
+	return nil
+}
+
+func sortedDependencyKeys(packages map[string]json.RawMessage) []string {
+	keys := make([]string, 0, len(packages))
+	for key := range packages {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	return keys
+}
+
+func compareInstalledInventory(declared, installed dependencyLock, paths []string) error {
+	actual := make(map[string]bool, len(paths))
+	for _, relative := range paths {
+		actual[relative] = true
+		if declared.Packages[relative] == nil || installed.Packages[relative] == nil {
+			return fmt.Errorf("unexpected installed package %s absent from a lock", relative)
+		}
+	}
+	for _, relative := range sortedDependencyKeys(installed.Packages) {
+		if !actual[relative] {
+			return fmt.Errorf("hidden lock names missing installed package %s", relative)
+		}
+	}
+	for _, relative := range sortedDependencyKeys(declared.Packages) {
+		if relative == "" || actual[relative] {
+			continue
+		}
+		metadata, err := parseDependencyPackage(declared.Packages[relative])
+		if err != nil {
+			return err
+		}
+		// npm propagates optional:true into omitted platform-package subtrees.
+		// Do not require the 52 other-platform records in this repository's lock.
+		if !metadata.Optional {
+			return fmt.Errorf("required installed package is missing: %s", relative)
+		}
+	}
+	return nil
+}
+
+func (snapshot *installedDependencySnapshot) comparePackage(ctx context.Context, relative string, declared, installed json.RawMessage) error {
+	want, err := parseDependencyPackage(declared)
+	if err != nil {
+		return err
+	}
+	got, err := parseDependencyPackage(installed)
+	if err != nil {
+		return err
+	}
+	if want != got {
+		return fmt.Errorf("%s hidden lock identity differs from package-lock.json (declared %s, installed %s)", relative, want.Version, got.Version)
+	}
+	body, err := snapshot.read(ctx, relative+"/package.json", maximumDependencyManifestBytes)
+	if err != nil {
+		return err
+	}
+	var actual dependencyPackage
+	if err := json.Unmarshal(body, &actual); err != nil {
+		return fmt.Errorf("decode %s/package.json: %w", relative, err)
+	}
+	name := want.Name
+	if name == "" {
+		name = relative[strings.LastIndex(relative, "node_modules/")+len("node_modules/"):]
+	}
+	if actual.Name != name || actual.Version != want.Version {
+		return fmt.Errorf("%s/package.json declares %s@%s, want %s@%s", relative, actual.Name, actual.Version, name, want.Version)
+	}
+	return nil
+}

--- a/tooling/internal/pdfrender/installed_dependencies_test.go
+++ b/tooling/internal/pdfrender/installed_dependencies_test.go
@@ -1,0 +1,247 @@
+package pdfrender
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const installedTestPackage = "node_modules/katex"
+
+func writeInstalledDependencyFixture(t *testing.T, root string) {
+	t.Helper()
+	entry := dependencyPackage{Version: "0.18.5", Resolved: "https://registry.npmjs.org/katex/-/katex-0.18.5.tgz", Integrity: "sha512-test-fixture"}
+	encoded, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lock := dependencyLock{LockfileVersion: 3, Packages: map[string]json.RawMessage{installedTestPackage: encoded}}
+	writeDependencyJSON(t, root, "package-lock.json", lock)
+	writeDependencyJSON(t, root, "node_modules/.package-lock.json", lock)
+	writeDependencyJSON(t, root, installedTestPackage+"/package.json", map[string]string{"name": "katex", "version": "0.18.5"})
+}
+
+func writeDependencyJSON(t *testing.T, root, relative string, value any) {
+	t.Helper()
+	body, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeDependencyBytes(t, root, relative, body)
+}
+
+func writeDependencyBytes(t *testing.T, root, relative string, body []byte) {
+	t.Helper()
+	name := filepath.Join(root, filepath.FromSlash(relative))
+	if err := os.MkdirAll(filepath.Dir(name), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(name, body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mutateDependencyFile(t *testing.T, root, relative, old, replacement string) {
+	t.Helper()
+	body, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(relative)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body), old) {
+		t.Fatalf("fixture %s omits %q", relative, old)
+	}
+	writeDependencyBytes(t, root, relative, []byte(strings.ReplaceAll(string(body), old, replacement)))
+}
+
+func TestInstalledDependenciesAcceptMatchingMetadataWithoutWriting(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	writeInstalledDependencyFixture(t, root)
+	before, err := os.Stat(filepath.Join(root, "node_modules/.package-lock.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := inspectInstalledDependencies(context.Background(), root)
+	if err != nil || !rawSHA256Pattern.MatchString(first) {
+		t.Fatalf("inspection = %q, %v", first, err)
+	}
+	second, err := inspectInstalledDependencies(context.Background(), root)
+	after, statError := os.Stat(filepath.Join(root, "node_modules/.package-lock.json"))
+	if err != nil || statError != nil || first != second || !before.ModTime().Equal(after.ModTime()) {
+		t.Fatalf("read-only repeat changed identity or install: %q %q %v %v", first, second, err, statError)
+	}
+}
+
+func TestInstalledDependenciesRejectStaleLockAndActualManifest(t *testing.T) {
+	t.Parallel()
+	for _, testCase := range []struct{ name, file, old, replacement, failure string }{
+		{"copied-katex-0184", "node_modules/.package-lock.json", "0.18.5", "0.18.4", "hidden lock identity differs"},
+		{"forged-hidden-lock", installedTestPackage + "/package.json", "0.18.5", "0.18.4", "want katex@0.18.5"},
+		{"wrong-name", installedTestPackage + "/package.json", "katex", "unrelated", "want katex@0.18.5"},
+		{"wrong-integrity", "node_modules/.package-lock.json", "sha512-test-fixture", "sha512-other-fixture", "hidden lock identity differs"},
+		{"wrong-resolved", "node_modules/.package-lock.json", "registry.npmjs.org", "example.invalid", "hidden lock identity differs"},
+		{"unsupported-lock", "package-lock.json", "\"lockfileVersion\":3", "\"lockfileVersion\":2", "lockfileVersion 3"},
+		{"unsafe-path", "package-lock.json", "node_modules/katex", "node_modules/../katex", "unsafe package path"},
+		{"linked-lock", "package-lock.json", "\"link\":false", "\"link\":true", "linked installs"},
+		{"null-metadata", "package-lock.json", "\"version\":\"0.18.5\"", "\"version\":null", "requires version"},
+		{"missing-integrity", "package-lock.json", "sha512-test-fixture", "", "requires version"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			writeInstalledDependencyFixture(t, root)
+			mutateDependencyFile(t, root, testCase.file, testCase.old, testCase.replacement)
+			_, err := inspectInstalledDependencies(context.Background(), root)
+			if err == nil || !strings.Contains(err.Error(), testCase.failure) || !strings.Contains(err.Error(), "npm ci --no-audit") {
+				t.Fatalf("inspection error = %v, want %q and repair command", err, testCase.failure)
+			}
+		})
+	}
+}
+
+func TestInstalledDependenciesRejectMissingExtraAndMalformedMetadata(t *testing.T) {
+	t.Parallel()
+	for _, testCase := range []struct {
+		name    string
+		mutate  func(*testing.T, string)
+		failure string
+	}{
+		{"missing-hidden-lock", func(t *testing.T, r string) {
+			if err := os.Remove(filepath.Join(r, "node_modules/.package-lock.json")); err != nil {
+				t.Fatal(err)
+			}
+		}, "node_modules/.package-lock.json"},
+		{"missing-manifest", func(t *testing.T, r string) {
+			if err := os.Remove(filepath.Join(r, installedTestPackage, "package.json")); err != nil {
+				t.Fatal(err)
+			}
+		}, "package.json"},
+		{"extra-installed", func(t *testing.T, r string) {
+			writeDependencyJSON(t, r, "node_modules/extra/package.json", map[string]string{"name": "extra", "version": "1.0.0"})
+		}, "unexpected installed package"},
+		{"missing-installed", func(t *testing.T, r string) {
+			if err := os.Rename(filepath.Join(r, installedTestPackage), filepath.Join(r, "saved-katex")); err != nil {
+				t.Fatal(err)
+			}
+		}, "hidden lock names missing"},
+		{"duplicate-json", func(t *testing.T, r string) {
+			mutateDependencyFile(t, r, "package-lock.json", "\"lockfileVersion\":3", "\"lockfileVersion\":3,\"lockfileVersion\":3")
+		}, "repeats name"},
+		{"trailing-json", func(t *testing.T, r string) {
+			writeDependencyBytes(t, r, "node_modules/.package-lock.json", []byte("{} {}"))
+		}, "trailing data"},
+		{"malformed-json", func(t *testing.T, r string) {
+			writeDependencyBytes(t, r, installedTestPackage+"/package.json", []byte("{"))
+		}, "decode JSON"},
+		{"oversized-lock", func(t *testing.T, r string) {
+			writeDependencyBytes(t, r, "package-lock.json", []byte(strings.Repeat(" ", maximumDependencyLockBytes+1)))
+		}, "size must be"},
+		{"oversized-manifest", func(t *testing.T, r string) {
+			writeDependencyBytes(t, r, installedTestPackage+"/package.json", []byte(strings.Repeat(" ", maximumDependencyManifestBytes+1)))
+		}, "size must be"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			writeInstalledDependencyFixture(t, root)
+			testCase.mutate(t, root)
+			_, err := inspectInstalledDependencies(context.Background(), root)
+			if err == nil || !strings.Contains(err.Error(), testCase.failure) {
+				t.Fatalf("inspection error = %v, want %q", err, testCase.failure)
+			}
+		})
+	}
+}
+
+func TestInstalledDependenciesAllowOnlyOptionalOmissions(t *testing.T) {
+	t.Parallel()
+	for _, optional := range []bool{false, true} {
+		t.Run(map[bool]string{false: "required-child", true: "optional-platform-subtree"}[optional], func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			writeInstalledDependencyFixture(t, root)
+			body, err := os.ReadFile(filepath.Join(root, "package-lock.json"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			var lock dependencyLock
+			if err := json.Unmarshal(body, &lock); err != nil {
+				t.Fatal(err)
+			}
+			parent := dependencyPackage{Version: "1.0.0", Resolved: "https://example.invalid/platform.tgz", Integrity: "sha512-test", Optional: true}
+			lock.Packages["node_modules/@vendor/platform"], err = json.Marshal(parent)
+			if err != nil {
+				t.Fatal(err)
+			}
+			parent.Optional = optional
+			lock.Packages["node_modules/@vendor/platform/node_modules/helper"], err = json.Marshal(parent)
+			if err != nil {
+				t.Fatal(err)
+			}
+			writeDependencyJSON(t, root, "package-lock.json", lock)
+			digest, err := inspectInstalledDependencies(context.Background(), root)
+			if optional {
+				if err != nil || !rawSHA256Pattern.MatchString(digest) {
+					t.Fatalf("optional subtree = %q %v", digest, err)
+				}
+			} else if err == nil || !strings.Contains(err.Error(), "required installed package") {
+				t.Fatalf("required child error = %v", err)
+			}
+		})
+	}
+}
+
+func TestInstalledDependenciesRejectSymlinks(t *testing.T) {
+	t.Parallel()
+	for _, relative := range []string{"node_modules", "node_modules/.package-lock.json", installedTestPackage, installedTestPackage + "/package.json"} {
+		t.Run(relative, func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			writeInstalledDependencyFixture(t, root)
+			name := filepath.Join(root, filepath.FromSlash(relative))
+			saved := filepath.Join(root, "saved")
+			if err := os.Rename(name, saved); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Symlink(saved, name); err != nil {
+				t.Fatal(err)
+			}
+			_, err := inspectInstalledDependencies(context.Background(), root)
+			if err == nil || (!strings.Contains(err.Error(), "symlink") && !strings.Contains(err.Error(), "non-symlink")) {
+				t.Fatalf("linked %s accepted: %v", relative, err)
+			}
+		})
+	}
+}
+
+func TestInstalledDependenciesBoundPathsCountsMetadataAndCancellation(t *testing.T) {
+	t.Parallel()
+	for _, relative := range []string{"../node_modules/foo", "node_modules/@scope/../foo", "node_modules/foo\\bar", strings.Repeat("node_modules/foo/", 9) + "node_modules/bar", strings.Repeat("a", 2049)} {
+		if validDependencyPath(relative) {
+			t.Fatalf("unsafe or over-depth path accepted: %q", relative)
+		}
+	}
+	root := t.TempDir()
+	writeInstalledDependencyFixture(t, root)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := inspectInstalledDependencies(ctx, root); err == nil || !strings.Contains(err.Error(), "canceled") {
+		t.Fatalf("cancelled inspection = %v", err)
+	}
+	snapshot := installedDependencySnapshot{root: root, bytes: maximumDependencyMetadataBytes}
+	if _, err := snapshot.read(context.Background(), "package-lock.json", maximumDependencyLockBytes); err == nil || !strings.Contains(err.Error(), "32 MiB") {
+		t.Fatalf("metadata cap = %v", err)
+	}
+	packages := make(map[string]json.RawMessage, maximumInstalledPackages+2)
+	for index := 0; index < maximumInstalledPackages+2; index++ {
+		packages[fmt.Sprintf("node_modules/pkg-%d", index)] = json.RawMessage(`{"version":"1.0.0","resolved":"https://example.invalid/p.tgz","integrity":"sha512-test"}`)
+	}
+	writeDependencyJSON(t, root, "package-lock.json", dependencyLock{LockfileVersion: 3, Packages: packages})
+	if _, err := inspectInstalledDependencies(context.Background(), root); err == nil || !strings.Contains(err.Error(), "package records") {
+		t.Fatalf("package inventory bound = %v", err)
+	}
+}

--- a/tooling/internal/pdfrender/installed_inventory.go
+++ b/tooling/internal/pdfrender/installed_inventory.go
@@ -1,0 +1,179 @@
+package pdfrender
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+)
+
+var dependencyNamePattern = regexp.MustCompile(`^[A-Za-z0-9_-][A-Za-z0-9._-]*$`)
+
+func validDependencyPath(relative string) bool {
+	if len(relative) > 2048 || strings.Contains(relative, "\\") {
+		return false
+	}
+	parts := strings.Split(relative, "/")
+	if len(parts) > maximumDependencyPathDepth {
+		return false
+	}
+	for index := 0; index < len(parts); {
+		if parts[index] != "node_modules" || index+1 >= len(parts) {
+			return false
+		}
+		index++
+		if strings.HasPrefix(parts[index], "@") {
+			if !dependencyNamePattern.MatchString(strings.TrimPrefix(parts[index], "@")) || index+1 >= len(parts) {
+				return false
+			}
+			index++
+		}
+		if !dependencyNamePattern.MatchString(parts[index]) {
+			return false
+		}
+		index++
+	}
+	return true
+}
+
+func installedPackagePaths(ctx context.Context, root string) ([]string, error) {
+	queue := []string{"node_modules"}
+	packages := make([]string, 0)
+	for index := 0; index < len(queue); index++ {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		directory := queue[index]
+		names, err := dependencyDirectoryNames(root, directory)
+		if err != nil {
+			return nil, err
+		}
+		for _, name := range names {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+			if dependencyInstallationAuxiliary(name) {
+				continue
+			}
+			paths, err := dependencyEntryPaths(ctx, root, directory, name)
+			if err != nil {
+				return nil, err
+			}
+			packages = append(packages, paths...)
+			if len(packages) > maximumInstalledPackages {
+				return nil, errors.New("installed package inventory exceeds its 4096-package bound")
+			}
+			for _, relative := range paths {
+				if err := ctx.Err(); err != nil {
+					return nil, err
+				}
+				exists, err := nestedDependencyDirectory(root, relative)
+				if err != nil {
+					return nil, err
+				}
+				if exists {
+					queue = append(queue, relative+"/node_modules")
+				}
+			}
+		}
+	}
+	slices.Sort(packages)
+	return packages, ctx.Err()
+}
+
+func dependencyInstallationAuxiliary(name string) bool {
+	// npm command shims, its hidden lock, and Vite caches are not packages.
+	// The hidden lock is checked separately; no other dot directory is ignored.
+	switch name {
+	case ".bin", ".cache", ".vite", ".vite-temp", ".package-lock.json":
+		return true
+	default:
+		return false
+	}
+}
+
+func dependencyEntryPaths(ctx context.Context, root, directory, name string) ([]string, error) {
+	paths := []string{directory + "/" + name}
+	if strings.HasPrefix(name, "@") {
+		if !dependencyNamePattern.MatchString(strings.TrimPrefix(name, "@")) {
+			return nil, fmt.Errorf("unsafe installed package scope %q", name)
+		}
+		names, err := dependencyDirectoryNames(root, paths[0])
+		if err != nil {
+			return nil, err
+		}
+		paths = make([]string, 0, len(names))
+		for _, child := range names {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+			paths = append(paths, directory+"/"+name+"/"+child)
+		}
+	}
+	for _, relative := range paths {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if !validDependencyPath(relative) {
+			return nil, fmt.Errorf("unsafe installed package path %q", relative)
+		}
+		if err := requireContainedDirectory(root, relative, false); err != nil {
+			return nil, err
+		}
+	}
+	return paths, nil
+}
+
+func nestedDependencyDirectory(root, relative string) (bool, error) {
+	name := relative + "/node_modules"
+	_, err := os.Lstat(filepath.Join(root, filepath.FromSlash(name)))
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, requireContainedDirectory(root, name, false)
+}
+
+func dependencyDirectoryNames(root, relative string) ([]string, error) {
+	if err := requireContainedDirectory(root, relative, false); err != nil {
+		return nil, err
+	}
+	name := filepath.Join(root, filepath.FromSlash(relative))
+	before, err := os.Lstat(name)
+	if err != nil {
+		return nil, err
+	}
+	directory, err := os.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	defer directory.Close()
+	entries, err := directory.ReadDir(maximumInstalledPackages + 1)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return nil, err
+	}
+	if len(entries) > maximumInstalledPackages {
+		return nil, fmt.Errorf("%s exceeds the 4096-entry directory bound", relative)
+	}
+	opened, err := directory.Stat()
+	if err != nil {
+		return nil, err
+	}
+	after, err := os.Lstat(name)
+	if err != nil || !os.SameFile(before, opened) || !os.SameFile(before, after) || !before.ModTime().Equal(after.ModTime()) {
+		return nil, fmt.Errorf("%s changed while its inventory was read", relative)
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	slices.Sort(names)
+	return names, nil
+}

--- a/tooling/internal/pdfrender/lock.go
+++ b/tooling/internal/pdfrender/lock.go
@@ -50,10 +50,11 @@ type Limits = pdfrenderlock.Limits
 
 // Configuration is one validated renderer lock resolved beneath a repository.
 type Configuration struct {
-	RepositoryRoot string
-	LockPath       string
-	LockSHA256     string
-	Lock           Lock
+	RepositoryRoot              string
+	LockPath                    string
+	LockSHA256                  string
+	Lock                        Lock
+	installedDependenciesSHA256 string
 }
 
 // Check validates the local renderer authority without invoking Docker or the network.

--- a/tooling/internal/pdfrender/render.go
+++ b/tooling/internal/pdfrender/render.go
@@ -92,6 +92,10 @@ func renderWithDependencies(
 	if err := ValidateSourceRevision(sourceRef, sourceRevision); err != nil {
 		return Result{}, err
 	}
+	configuration, err := bindInstalledDependencies(ctx, configuration)
+	if err != nil {
+		return Result{}, err
+	}
 	if err := prepareWritableRenderPaths(configuration.RepositoryRoot); err != nil {
 		return Result{}, err
 	}
@@ -129,7 +133,7 @@ func renderWithDependencies(
 	if err := preparer.prepare(buildContext, configuration, contextRoot); err != nil {
 		return Result{}, fmt.Errorf("prepare PDF renderer build context: %w", err)
 	}
-	if err := checkAuthorityUnchanged(configuration); err != nil {
+	if err := checkAuthorityUnchanged(ctx, configuration); err != nil {
 		return Result{}, err
 	}
 	builderName, err := createLockedBuilder(buildContext, configuration, executor)
@@ -162,7 +166,7 @@ func renderWithDependencies(
 	if err := rejectTimestampRewriteWarnings(buildOutput); err != nil {
 		return Result{}, err
 	}
-	if err := checkAuthorityUnchanged(configuration); err != nil {
+	if err := checkAuthorityUnchanged(ctx, configuration); err != nil {
 		return Result{}, err
 	}
 	imageID, err := readImageID(iidPath)
@@ -182,15 +186,15 @@ func renderWithDependencies(
 		if err := runRendererOnce(ctx, configuration, executor, imageID, sourceRef, sourceRevision, outputDirectory, temporaryDirectory); err != nil {
 			return Result{}, err
 		}
-		if err := checkAuthorityUnchanged(configuration); err != nil {
-			return Result{}, err
-		}
 		renderDirectories[index] = outputDirectory
 	}
 	if err := removeBuilder(executor, builderName, configuration.Lock.Limits.OutputBytes); err != nil {
 		return Result{}, err
 	}
 	builderActive = false
+	if err := checkAuthorityUnchanged(ctx, configuration); err != nil {
+		return Result{}, err
+	}
 	if err := compareAndPublishRenderPairs(configuration.RepositoryRoot, renderDirectories[0], renderDirectories[1]); err != nil {
 		return Result{}, err
 	}
@@ -249,6 +253,9 @@ func runRendererOnce(
 	executor commandExecutor,
 	imageID, sourceRef, sourceRevision, outputDirectory, temporaryDirectory string,
 ) error {
+	if err := checkAuthorityUnchanged(ctx, configuration); err != nil {
+		return err
+	}
 	containerName, err := randomContainerName()
 	if err != nil {
 		return err
@@ -264,16 +271,17 @@ func runRendererOnce(
 	})
 	if err != nil {
 		cleanupContainer(executor, containerName, configuration.Lock.Limits.OutputBytes)
+		return err
 	}
-	return err
+	return checkAuthorityUnchanged(ctx, configuration)
 }
 
-func checkAuthorityUnchanged(configuration Configuration) error {
+func checkAuthorityUnchanged(ctx context.Context, configuration Configuration) error {
 	current, err := Check(configuration.RepositoryRoot)
 	if err != nil || current.LockSHA256 != configuration.LockSHA256 {
 		return errors.New("PDF renderer lock changed during the render operation")
 	}
-	return nil
+	return checkInstalledDependencies(ctx, configuration)
 }
 
 func buildArguments(configuration Configuration, builderName, contextRoot, iidPath string) []string {

--- a/tooling/internal/pdfrender/render_test.go
+++ b/tooling/internal/pdfrender/render_test.go
@@ -411,6 +411,7 @@ func renderConfiguration(t *testing.T) Configuration {
 			t.Fatal(err)
 		}
 	}
+	writeInstalledDependencyFixture(t, root)
 	configuration, err := Check(root)
 	if err != nil {
 		t.Fatal(err)

--- a/tooling/internal/pdfrender/reproducibility.go
+++ b/tooling/internal/pdfrender/reproducibility.go
@@ -55,6 +55,10 @@ func verifyReproducibilityWithDependencies(
 	if err := ValidateSourceRevision(sourceRef, sourceRevision); err != nil {
 		return ReproducibilityReceipt{}, err
 	}
+	configuration, err := bindInstalledDependencies(ctx, configuration)
+	if err != nil {
+		return ReproducibilityReceipt{}, err
+	}
 	receiptPath, err := prepareReproducibilityReceiptPath(configuration.RepositoryRoot, receiptRelativePath)
 	if err != nil {
 		return ReproducibilityReceipt{}, err
@@ -158,6 +162,9 @@ func verifyReproducibilityWithDependencies(
 			configuration.RepositoryRoot, filepath.FromSlash(evidence.Root),
 		)
 	}
+	if err := checkAuthorityUnchanged(ctx, configuration); err != nil {
+		return ReproducibilityReceipt{}, err
+	}
 	if err := writeReproducibilityReceipt(receiptPath, receipt); err != nil {
 		return ReproducibilityReceipt{}, err
 	}
@@ -229,7 +236,7 @@ func reproducibilityBuild(
 		return result, err
 	}
 	builderActive = false
-	if err := checkAuthorityUnchanged(configuration); err != nil {
+	if err := checkAuthorityUnchanged(ctx, configuration); err != nil {
 		return result, err
 	}
 
@@ -250,7 +257,7 @@ func reproducibilityBuild(
 	result.ManifestDigest = metadata.ManifestDigest
 	result.ConfigDigest = configDigest
 	result.Pair = pair
-	return result, checkAuthorityUnchanged(configuration)
+	return result, checkAuthorityUnchanged(ctx, configuration)
 }
 
 func reproducibilityBuildArguments(


### PR DESCRIPTION
## Summary

Stop PDF rendering before container work when the host installation disagrees
with `package-lock.json`. The renderer mounts host `node_modules`; a correct
committed lock alone did not prevent a copied KaTeX 0.18.4 installation being
used where the lock required 0.18.5.

The existing Go renderer now compares the declared lock, hidden installed lock,
actual package inventory and package manifests. It freezes their metadata
identity and rechecks it around both renders and final publication/receipt
output. Missing required packages, unexpected packages, stale identities,
unsafe paths and malformed or over-bound inputs fail closed. The guard admits
the precise npm optional/bundled-package forms used by the locked graph.

This is an offline, read-only consistency check, not package-payload byte
authentication. It does not install anything. The repair remains the existing
locked `npm ci --no-audit` workflow; no scheduler, new installer, credentials or
network authority is added.

## Verification

- Focused race tests, all Go tests/vet, source-closure tests, documentation and
  common static checks passed on source `7cbaf0c` / its unchanged pre-rebase
  implementation, with exact run boundaries retained in the local receipt.
- A real 556-package installation passed the new Go inspection in 30 ms in one
  local observation. This is a sanity check, not a general performance claim.
- Regression fixtures cover the observed stale KaTeX install, forged hidden
  metadata, required/optional/bundled dependencies, extra packages, symlinks,
  invalid empty scopes, duplicate/trailing JSON, byte/count/depth limits,
  cancellation and changes at render/publication boundaries.
- npm 12.0.2's installed primary documentation and implementation were checked
  for the hidden-lock and `inBundle` rules. Optional bundled descendants do not
  receive an unrestricted missing-integrity exception: their enclosing locked
  archive must own them.

- A fresh pinned npm install passed. The actual compiled render and
  reproducibility commands rejected the retained stale-KaTeX fixture before
  Docker lookup, even with Docker absent from PATH; no output or success
  receipt was created.
- Two fresh ordinary renders matched. The 412-page PDF remains byte-identical
  at `387bca765e0ae4a675f5274a0f511a0644f1d26fd4f9b665fdeb9b64236ad454`.
  The generated manifest binds all 344 source files, digest
  `befa3d4555013040ccff107a19a847ae261fa7b5b911c1b0d979656885cecc87`.
- Full `npm run check` passed in 8m14.219s on frozen `9b1f2e3`, including
  all 20 workstation jobs, all five browser tests and the production Pages
  build. These elapsed times are local observations, not a performance claim.
- Real two-fresh-builder renderer acceptance passed in 5m53.961s with no build
  cache, identical renderer identities and byte-identical PDF/manifest pairs.
  The guard checks one fresh installed dependency tree throughout; this is
  conditional rendering reproducibility, not independent npm reconstruction.
- Final head `27027d45078321fd5f9a53f50d309d9f5bff1747` is based on merged
  main `a40df2656360fa2ceb915ae6f40c5e4fb1fa76f0`. Its full tracked tree
  `a793fd484a59f0fd0a8dfc64d0c8b0bf8bbaca7a` exactly equals the tested
  `9b1f2e3` tree; both patches are unchanged by the identity-only parent
  replacement. Final PDF validation passed again without repeating unchanged
  builds or aggregate tests.

The exact impact plan requires `full,renderer`; remote CI remains authoritative
for merge. The real Poppler 26.08.0 audit still reports the same six known
reading-order debts and zero structure diagnostics. This is not an
accessibility-conformance pass.

Independent follow-up found a pre-existing receipt-label defect, tracked in
#97: with the current containerd-backed Docker store, `image_config_digest`
repeats the manifest identity. The matching manifest and PDF/manifest pair
observations remain valid, but the receipt does not independently observe the
config blob digest. This guard neither introduces nor repairs that separate
field; the original evidence is retained unchanged with the qualification.

## Authority

Both new production files enter the canonical book source closure. Generated
manifest/baseline bindings must be refreshed together; the existing six
reading-order debts are not waived by this change. No scientific claim,
translation review, image admission, release or compliance status changes.

OpenAI Codex and delegated agents implemented, reviewed and tested this
engineering fix. The maintenance-automation skill kept it with the existing
Go owner and explicit repair path; publication-design requires fresh
publication evidence. Retained evidence lives under
`.workingdir2/evidence/ci/2026-09-05-pdf-installed-dependency-guard/`.
