### PR TITLE
fix(ci): label Go publication and CI owners

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -51,6 +51,12 @@
           - "scripts/*book*"
           - "scripts/*reader-artifacts*"
           - "THIRD_PARTY_NOTICES.txt"
+          - "tooling/cmd/20w/pdf_tools*.go"
+          - "tooling/internal/pdfrender/**"
+          - "tooling/internal/pdfrenderlock/**"
+          - "tooling/internal/pdftools/**"
+          - "tooling/pdf-renderer/**"
+          - "tooling/pdf-tools/**"
 
 "area:governance":
   - changed-files:
@@ -93,6 +99,10 @@
           - ".github/public-transport.json"
           - "renovate.json"
           - "scripts/*policy*"
+          - "tooling/internal/ciplan/**"
+          - "tooling/internal/pdfrender/**"
+          - "tooling/internal/pdfrenderlock/**"
+          - "tooling/pdf-renderer/**"
 
 dependencies:
   - changed-files:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ the exact diff; this file records why the project changed.
 
 ### Fixed
 
+- Pull-request path labels now cover the Go PDF renderer, PDF-tools and CI
+  planner owners. Renderer-only changes retain their publication and CI labels
+  when the existing labeler synchronizes metadata.
 - The browser print regression now waits for Chrome's matching media-change
   event before inspecting overflow semantics, including the return to screen.
   Full-book pagination has its own bounded transition stage; the existing

--- a/scripts/engineering-policy.test.mjs
+++ b/scripts/engineering-policy.test.mjs
@@ -1457,6 +1457,33 @@ test("repository metadata synchronization is manifest-triggered and least-privil
   ));
 });
 
+test("Go renderer and CI owners retain their path-derived pull-request labels", () => {
+  const rules = parse(readFileSync(new URL("../.github/labeler.yml", import.meta.url), "utf8"));
+  const labelsFor = (file) => Object.entries(rules).filter(([, groups]) => groups.some(
+    (group) => group["changed-files"].some((rule) => rule["any-glob-to-any-file"].some(
+      (pattern) => path.matchesGlob(file, pattern),
+    )),
+  )).map(([label]) => label).sort();
+  const rendererLabels = ["area:ci", "area:publication"];
+  for (const file of [
+    "tooling/internal/pdfrender/installed_dependencies.go",
+    "tooling/internal/pdfrender/installed_boundaries_test.go",
+    "tooling/internal/pdfrenderlock/lock.go",
+    "tooling/pdf-renderer/lock.json",
+  ]) assert.deepEqual(labelsFor(file), rendererLabels, file);
+  assert.deepEqual(labelsFor("tooling/internal/ciplan/plan_test.go"), ["area:ci"]);
+  for (const file of [
+    "tooling/internal/pdftools/candidate_output.go",
+    "tooling/pdf-tools/contract.json",
+    "tooling/cmd/20w/pdf_tools_test.go",
+  ]) assert.deepEqual(labelsFor(file), ["area:publication"], file);
+  for (const file of [
+    "tooling/internal/pdfrender-unrelated/example.go",
+    "tooling/internal/clrsfixture/image.go",
+    "tooling/cmd/20w/main.go",
+  ]) assert.deepEqual(labelsFor(file), [], file);
+});
+
 test("pull-request metadata uses only trusted main and explicit bounded authority", () => {
   const relativePath = ".github/workflows/labeler.yml";
   const valid = workflow("labeler");


### PR DESCRIPTION
## Change

Extend the existing trusted-main path labeler to cover the Go PDF renderer,
PDF-tools and CI planner owners. PR 96 exposed the gap: synchronizing its
metadata removed the manually supplied CI label because none of the Go owner
paths matched the committed configuration.

The regression tests eight concrete positive paths and three unrelated or
shared-entrypoint paths. The old configuration gives none of the eight their
intended labels. This patch changes no workflow, permission, dependency,
milestone mapping or label vocabulary.

## Verification

- Focused ownership regression passes; independent review found no issue in
  the simple glob patterns or their compatibility with the pinned labeler.
- Full local integration gate passed on `2cfe90b`: all 20 workstation jobs,
  all five browser tests, policy/source checks and the production Pages build.
  The run took approximately 9 minutes 51 seconds on this workstation.
- Rebase onto the merged guard at `1a78499` preserves the exact patch
  (`git range-diff` equality); the final label configuration and its test are
  byte-identical. Final head is `4f3a67e`. PDF validation passes against the
  inherited 344-file source closure. Focused post-rebase common checks passed
  separately, without repeating unchanged aggregate or renderer work.
- The initial distribution-Node attempt failed the existing numerical-runtime
  sentinel before heavy tests. Reinstalling locked dependencies and using the
  official pinned Node executable corrected the environment; the assertion was
  not changed and the failed log is retained.
- None of the three changed files is in the book source closure. No PDF render
  is required for this patch. The existing policy-test owner selects full CI,
  not renderer reproducibility; that selection policy is unchanged.

The local matcher test is not live GitHub acceptance. The new configuration
can be exercised by trusted-main labeling only after merge and a later PR
event. No scientific evidence, experiment admission or publication state
changes.

Local diagnostic evidence is retained under
`.workingdir2/evidence/ci/2026-09-05-go-path-label-ownership/`.
