### PR TITLE
fix(site): wait for navigation roots in browser checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ the exact diff; this file records why the project changed.
 
 ### Fixed
 
+- Pages browser checks wait for the document root during navigation before
+  reading layout dimensions. Unexpected browser errors still fail the check.
+
 - Pull-request path labels now cover the Go PDF renderer, PDF-tools and CI
   planner owners. Renderer-only changes retain their publication and CI labels
   when the existing labeler synchronizes metadata.

--- a/scripts/github-pages.test.mjs
+++ b/scripts/github-pages.test.mjs
@@ -6,6 +6,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
+import { runInNewContext } from "node:vm";
 import {
   decodePortalFragment,
   encodePortalFragment,
@@ -88,13 +89,15 @@ async function waitForBrowserState(cdp, expression, accepts, label, timeoutMs = 
   let snapshot;
   while (Date.now() < deadline) {
     snapshot = await evaluateInBrowser(cdp, expression);
-    if (accepts(snapshot)) return snapshot;
+    if (snapshot?.documentReady !== false && accepts(snapshot)) return snapshot;
     await new Promise((resolve) => setTimeout(resolve, 100));
   }
   assert.fail(`${label}: ${JSON.stringify(snapshot)}`);
 }
 
 const portalStateExpression = `(() => {
+  const documentElement = document.documentElement;
+  if (!documentElement) return { documentReady: false };
   const active = document.activeElement;
   const title = document.getElementById("portal-reader-title");
   const header = document.querySelector(".portal-header");
@@ -118,6 +121,7 @@ const portalStateExpression = `(() => {
       + Math.max(Number.parseFloat(activeStyle.outlineOffset) || 0, 0)
     : 0;
   return {
+    documentReady: true,
     activeFocusPaintFullyVisible: Boolean(
       activeBounds
       && drawerScrollerBounds
@@ -143,8 +147,8 @@ const portalStateExpression = `(() => {
     hashTargetVisible: Boolean(hashBounds && hashBounds.bottom > 0 && hashBounds.top < innerHeight),
     headerBottom: headerBounds?.bottom ?? null,
     pathname: location.pathname,
-    pageClientWidth: document.documentElement.clientWidth,
-    pageScrollWidth: document.documentElement.scrollWidth,
+    pageClientWidth: documentElement.clientWidth,
+    pageScrollWidth: documentElement.scrollWidth,
     readerPresent: Boolean(document.getElementById("portal-reader")),
     searchValue: document.getElementById("portal-library-search")?.value ?? null,
     mobileOutlineDisplay: mobileOutline ? getComputedStyle(mobileOutline).display : "missing",
@@ -831,6 +835,59 @@ test("the portal keeps clean-route history and native Markdown links honest on t
   ]) {
     assert.ok(portalSeo.includes(requiredMetadata), `portal SEO sync lacks ${requiredMetadata}`);
   }
+});
+
+test("portal snapshots stay pending while navigation has no document root", () => {
+  const context = {
+    document: {
+      activeElement: null,
+      documentElement: null,
+      getElementById: () => null,
+      querySelector: () => null,
+      querySelectorAll: () => [],
+    },
+    location: { hash: "", pathname: "/concept/80-energy-model/" },
+    innerHeight: 720,
+    innerWidth: 320,
+  };
+  const pending = runInNewContext(portalStateExpression, context, { timeout: 1000 });
+  assert.equal(pending.documentReady, false);
+  assert.equal(pending.pageClientWidth, undefined);
+
+  context.document.documentElement = { clientWidth: 320, scrollWidth: 320 };
+  const ready = runInNewContext(portalStateExpression, context, { timeout: 1000 });
+  assert.equal(ready.documentReady, true);
+  assert.equal(ready.readerPresent, false);
+  assert.equal(ready.pageClientWidth, 320);
+  assert.equal(ready.pageScrollWidth, 320);
+});
+
+test("portal polling skips only explicit pending snapshots and propagates evaluation errors", async () => {
+  let requests = 0;
+  let acceptedSnapshots = 0;
+  const ready = { documentReady: true, readerPresent: true };
+  const cdp = {
+    async send(method, { expression }) {
+      assert.equal(method, "Runtime.evaluate");
+      assert.equal(expression, portalStateExpression);
+      requests += 1;
+      return { result: { value: requests === 1 ? { documentReady: false } : ready } };
+    },
+  };
+  const observed = await waitForBrowserState(cdp, portalStateExpression, (snapshot) => {
+    acceptedSnapshots += 1;
+    assert.equal(snapshot.documentReady, true);
+    return snapshot.readerPresent;
+  }, "pending portal snapshot did not become ready");
+  assert.equal(observed, ready);
+  assert.equal(requests, 2);
+  assert.equal(acceptedSnapshots, 1);
+
+  await assert.rejects(waitForBrowserState({
+    async send() {
+      return { exceptionDetails: { text: "unexpected evaluation error" } };
+    },
+  }, portalStateExpression, () => true, "unexpected evaluation failure"), /Browser evaluation failed/);
 });
 
 test("portal document routes preserve native links and focus their destination headings", {


### PR DESCRIPTION
## Fix

Wait for the new document root before sampling the Pages browser's layout.
The deployment of merged `1a78499` stopped in the navigation regression:
`Page.navigate` had created a document without a root, and the snapshot read
`document.documentElement.clientWidth` before its readiness predicate ran.

The snapshot now returns an explicit pending state while the root is absent.
The polling helper withholds that state from acceptance callbacks. Once the
root exists, the existing route, keyboard focus, clearance and width checks
run unchanged. Unexpected browser evaluation errors still fail immediately.

This changes only the test harness and changelog. It changes no product
layout, content, dependency, workflow, assertion threshold or timeout.

## Evidence

- Failed deployment: [Pages run 33960151301](https://github.com/lusoris/20-watts-was-enough/actions/runs/33960151301).
- A deterministic VM regression reproduced the exact old null-`clientWidth`
  exception. The old poller also failed the explicit pending-state test.
- Both regressions pass after the fix. An unrelated evaluation error is still
  required to propagate as a failure.
- The real focused browser case passes in 12.690 seconds, with the original
  assertions and deadlines.
- Existing PDF/source freshness passes for 344 files. Neither changed file
  belongs to that source closure, so no new render is needed.
- Full local integration passed on the frozen patch in 9 minutes 28 seconds:
  20 workstation jobs, 112 site checks, all five browser-group tests, and the
  final 433-file Pages build validation.
- Final head `8108b373c3a58e16c45ba7c3e3e4b54f52fc5917` is based on
  merged main `4548c62`. The actual test file is byte-identical across rebase;
  the changelog preserves both changes. Post-rebase common checks passed in
  30.871 seconds, and freshness validation still passes.
- The exact committed impact plan selects `release`, `research` and `site`.
  It does not select workstation experiments or renderer reproducibility.
  The changelog accounts for the existing release/research coverage.

The failed deployment has not been blindly rerun. Local passing tests are not
a claim that a newer revision is deployed. The complete failure log and
before/after evidence are retained under
`.workingdir2/evidence/ci/2026-09-05-pages-navigation-snapshot-root/`.
