### PR TITLE
feat(experiments): reproduce the pinned Promise wheel in isolated containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,12 @@ the exact diff; this file records why the project changed.
 
 ### Added
 
+- A Go-owned candidate command reproduces the locked Promise 2.3 wheel in two
+  bounded, offline containers, checks the exact wheel and embedded MIT bytes,
+  and retains a source-bound receipt with a read-only consumer. Input
+  verification precedes effects; cleanup verifies ownership and removal.
+  The CLRS generator image remains blocked and all output has `NO_RESULT`
+  authority.
 - Decision 0071 locks one 61-file, 823,932,066-byte Linux `amd64` wheel
   selection for the pinned CLRS generator graph. Sixty files map directly to
   `uv.lock`; the sole `promise==2.3` source build binds its sdist, three build

--- a/public/downloads/book-manifest.json
+++ b/public/downloads/book-manifest.json
@@ -5,7 +5,7 @@
   "source_ref": "main",
   "source_revision": null,
   "pdf": "public/downloads/20-watts-was-enough-full-concept-book.pdf",
-  "source_digest": "befa3d4555013040ccff107a19a847ae261fa7b5b911c1b0d979656885cecc87",
+  "source_digest": "c29599b2e8b286425048e6b8da741799e4f9e09872fecfb849a9407f18e2fd29",
   "source_files": [
     "app/book-content.ts",
     "app/components/book-edition.tsx",

--- a/scripts/book-pdf-semantic-baseline.json
+++ b/scripts/book-pdf-semantic-baseline.json
@@ -7,7 +7,7 @@
     "pdf": "public/downloads/20-watts-was-enough-full-concept-book.pdf",
     "manifest": "public/downloads/book-manifest.json",
     "pdf_sha256": "387bca765e0ae4a675f5274a0f511a0644f1d26fd4f9b665fdeb9b64236ad454",
-    "manifest_sha256": "93cb2ff72261d9d2117f32cc5aa33cb9b323d1d434a56885987246f3cc6bebe2",
+    "manifest_sha256": "f4a6205bf2f1e9eca950feb397855730899eb690259e266b28e0cf793aa9d940",
     "size_bytes": 12782330,
     "pages": 412,
     "page_size_name": "A4",
@@ -18,7 +18,7 @@
     "pdf_version": "1.4",
     "tagged": true,
     "source_ref": "main",
-    "source_digest": "befa3d4555013040ccff107a19a847ae261fa7b5b911c1b0d979656885cecc87",
+    "source_digest": "c29599b2e8b286425048e6b8da741799e4f9e09872fecfb849a9407f18e2fd29",
     "version": "0.3.0"
   },
   "tools": {

--- a/tooling/clrs-generator/README.md
+++ b/tooling/clrs-generator/README.md
@@ -110,7 +110,15 @@ Before writing or invoking Docker, Go verifies all four input hashes and
 sizes, checks the source MIT text, and prepares a bounded canonical source
 archive. Each of two sequential runs gets a fresh container and private
 staging directory. Only the three read-only build wheels are host-mounted;
-Go streams the source archive into container storage. The requested container
+Go streams the source archive to a fixed Python materializer through direct
+`docker exec -i`. The materializer checks its exact size and SHA-256 before
+extraction into `/work`, then checks the fixed modes, timestamps and ownership.
+A fixed Python reader runs inside the same container, inspects at most two
+output directory entries, opens only the named regular wheel without following
+symlinks, and returns one bounded USTAR member. This accesses the running
+container's tmpfs; Docker's archive-copy API uses a
+[separate filesystem view](https://github.com/moby/moby/blob/6a43e3d5af/daemon/containerfs_linux.go#L26).
+The requested container
 configuration fixes UID/GID 65532, no network, a read-only root, one CPU,
 1 GiB memory without extra swap, 64 processes, and temporary filesystems of
 16 MiB at `/work`, 128 MiB at `/opt/build`, 1 MiB at `/output` and 16 MiB at
@@ -126,8 +134,8 @@ Each run retains at most 768 KiB of command output plus 64 KiB for cleanup;
 the encoded log is capped at 2 MiB. Private staged inputs are removed after
 the run. Failure leaves bounded diagnostics and no success receipt.
 
-A schema-1 `NO_RESULT` receipt requires two exact wheel hashes, independent
-embedded MIT checks and complete cleanup evidence. The read-only `--check`
+A schema-1 `NO_RESULT` receipt for procedure version 2 requires two exact wheel
+hashes, independent embedded MIT checks and complete cleanup evidence. The read-only `--check`
 path verifies both retained wheel files and command logs, reconstructs the
 fixed requested arguments, and rejects changed repository authority or
 procedure source files. It does not need Docker. The receipt records the

--- a/tooling/clrs-generator/README.md
+++ b/tooling/clrs-generator/README.md
@@ -2,9 +2,10 @@
 
 No generator image is admitted yet. This directory records the exact Linux
 `amd64` dependency graph and the selected 61-file wheelhouse manifest. The
-wheel bytes, Dockerfile, complete build context and retained acceptance
-receipts are still absent. Registry absence has not been checked; the state
-remains `blocked` and `NO_RESULT`.
+committed foundation contains no wheel payload, Dockerfile, complete build
+context or admitted acceptance receipt. Ignored local candidate inputs and
+receipts do not change that status. Registry absence has not been checked;
+the state remains `blocked` and `NO_RESULT`.
 
 The Python image is a narrow exception to the Go-first tooling rule. The pinned
 official CLRS-Text generator imports TensorFlow and JAX; rewriting that path
@@ -135,16 +136,16 @@ the encoded log is capped at 2 MiB. Private staged inputs are removed after
 the run. Failure leaves bounded diagnostics and no success receipt.
 
 A schema-1 `NO_RESULT` receipt for procedure version 2 requires two exact wheel
-hashes, independent embedded MIT checks and complete cleanup evidence. The read-only `--check`
-path verifies both retained wheel files and command logs, reconstructs the
-fixed requested arguments, and rejects changed repository authority or
-procedure source files. It does not need Docker. The receipt records the
-executable hash and build identity separately from workspace source hashes:
-those observations alone do not prove that the executable was compiled from
-the recorded source. Retain the clean commit and build command for a reviewed
-run. Requested flags are not an independent inspection of Docker's runtime
-state. No receipt from this command admits the CLRS image or establishes a
-scientific result; the existing image blockers remain unchanged.
+hashes, independent embedded MIT checks and complete cleanup evidence. The
+read-only `--check` path verifies both retained wheel files and command logs,
+reconstructs the fixed requested arguments, and rejects changed repository
+authority or procedure source files. It does not need Docker. The receipt
+records the executable hash and build identity separately from workspace
+source hashes: those observations alone do not prove that the executable was
+compiled from the recorded source. Retain the clean commit and build command
+for a reviewed run. Requested flags are not an independent inspection of
+Docker's runtime state. No receipt from this command admits the CLRS image or
+establishes a scientific result; the existing image blockers remain unchanged.
 
 ## Admission sequence
 

--- a/tooling/clrs-generator/README.md
+++ b/tooling/clrs-generator/README.md
@@ -33,8 +33,9 @@ the controller, validator and fixture-import boundary.
   base. `promise==2.3` has no upstream wheel, so the manifest fixes its
   19,534-byte sdist, the three locked build-tool wheels, candidate step
   arguments and the output identity seen in two local reconnaissance builds.
-  The complete executable container procedure and reproduction receipt remain
-  explicitly missing. The Promise MIT text is retained at
+  The reviewed executable procedure and admitted reproduction receipt remain
+  explicitly missing; the candidate command below does not change those
+  authority fields. The Promise MIT text is retained at
   [`LICENSES/promise-MIT.txt`](../../LICENSES/promise-MIT.txt); the manifest
   binds its source and built-wheel paths, hash and size. The complete selected
   set is 823,932,066 bytes; those bytes remain ignored build inputs rather than
@@ -86,6 +87,56 @@ go -C tooling run ./cmd/20w experiment verify-clrs-wheelhouse \
 To reproduce the reviewed manifest into a new file for comparison, use
 `experiment render-clrs-wheelhouse-manifest`; it refuses to overwrite an
 existing output. Rendering a candidate does not change repository authority.
+
+## Candidate Promise wheel reproduction
+
+The Go command below tests the sole source-built dependency from
+[Decision 0071](../../decisions/0071-lock-the-clrs-generator-wheel-selection.md).
+It needs a Unix host with the default local Docker socket and the pinned Python
+image already present. It never pulls an image or resolves dependencies.
+Place the locked sdist in `source-build-inputs/` and the three locked build
+wheels in `build-tools/` beneath the supplied input directory. The output
+parent must already exist; the command creates a new evidence directory.
+
+```bash
+go -C tooling run ./cmd/20w experiment reproduce-clrs-promise-wheel \
+  --root .. --inputs /path/to/retained-inputs --output /path/to/new-evidence
+
+go -C tooling run ./cmd/20w experiment reproduce-clrs-promise-wheel \
+  --root .. --check --output /path/to/new-evidence
+```
+
+Before writing or invoking Docker, Go verifies all four input hashes and
+sizes, checks the source MIT text, and prepares a bounded canonical source
+archive. Each of two sequential runs gets a fresh container and private
+staging directory. Only the three read-only build wheels are host-mounted;
+Go streams the source archive into container storage. The requested container
+configuration fixes UID/GID 65532, no network, a read-only root, one CPU,
+1 GiB memory without extra swap, 64 processes, and temporary filesystems of
+16 MiB at `/work`, 128 MiB at `/opt/build`, 1 MiB at `/output` and 16 MiB at
+`/tmp`. A cleared environment precedes each frozen build step.
+
+One 120-second deadline covers the whole run, not each command. The container
+also has a finite 120-second lease. Cleanup gets a separate 30-second
+deadline, checks the unique ownership label, forcibly removes the container
+and verifies its absence. Host command cancellation kills its process group.
+The wheel returns through a tar stream capped at 128 KiB; regular-file and
+archive checks reject unexpected names, links, duplicates and extra data.
+Each run retains at most 768 KiB of command output plus 64 KiB for cleanup;
+the encoded log is capped at 2 MiB. Private staged inputs are removed after
+the run. Failure leaves bounded diagnostics and no success receipt.
+
+A schema-1 `NO_RESULT` receipt requires two exact wheel hashes, independent
+embedded MIT checks and complete cleanup evidence. The read-only `--check`
+path verifies both retained wheel files and command logs, reconstructs the
+fixed requested arguments, and rejects changed repository authority or
+procedure source files. It does not need Docker. The receipt records the
+executable hash and build identity separately from workspace source hashes:
+those observations alone do not prove that the executable was compiled from
+the recorded source. Retain the clean commit and build command for a reviewed
+run. Requested flags are not an independent inspection of Docker's runtime
+state. No receipt from this command admits the CLRS image or establishes a
+scientific result; the existing image blockers remain unchanged.
 
 ## Admission sequence
 

--- a/tooling/cmd/20w/clrs_promise.go
+++ b/tooling/cmd/20w/clrs_promise.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/lusoris/20-watts-was-enough/tooling/internal/clrsfixture"
+)
+
+func runExperimentReproducePromise(arguments []string, stdout, stderr io.Writer) int {
+	flags := flag.NewFlagSet("experiment reproduce-clrs-promise-wheel", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	root := flags.String("root", ".", "repository root")
+	inputs := flags.String("inputs", "", "retained source-build-inputs and build-tools parent")
+	output := flags.String("output", "", "new evidence bundle directory, or existing bundle with --check")
+	check := flags.Bool("check", false, "verify an existing bundle without writes or Docker")
+	if flags.Parse(arguments) != nil || flags.NArg() != 0 {
+		return 2
+	}
+	if *output == "" || (!*check && *inputs == "") || (*check && *inputs != "") {
+		fmt.Fprintln(stderr, "reproduce-clrs-promise-wheel requires --inputs and --output, or --check and --output")
+		return 2
+	}
+	var err error
+	if *check {
+		err = clrsfixture.CheckPromiseWheelReproduction(*root, *output)
+	} else {
+		ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+		defer cancel()
+		err = clrsfixture.ReproducePromiseWheel(ctx, *root, *inputs, *output)
+	}
+	if err != nil {
+		fmt.Fprintf(stderr, "Promise wheel reproduction: %v\n", err)
+		return 1
+	}
+	fmt.Fprintln(stdout, "Promise wheel reproduction verified: two exact wheels and MIT licenses, NO_RESULT; generator image remains blocked.")
+	return 0
+}

--- a/tooling/cmd/20w/clrs_promise_test.go
+++ b/tooling/cmd/20w/clrs_promise_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestPromiseCommandCLIUsage(t *testing.T) {
+	for _, arguments := range [][]string{
+		{}, {"--output", "x"}, {"--inputs", "x"}, {"--check"},
+		{"--check", "--output", "x", "--inputs", "y"}, {"--output", "x", "positional"}, {"--unknown"},
+	} {
+		var stdout, stderr bytes.Buffer
+		full := append([]string{"experiment", "reproduce-clrs-promise-wheel"}, arguments...)
+		if code := run(full, &stdout, &stderr); code != 2 || stdout.Len() != 0 {
+			t.Fatalf("%v: code=%d stdout=%s stderr=%s", arguments, code, &stdout, &stderr)
+		}
+	}
+}
+
+func TestPromiseCommandCheckDoesNotRequireDocker(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"experiment", "reproduce-clrs-promise-wheel", "--check", "--output", t.TempDir(), "--root", t.TempDir()}, &stdout, &stderr)
+	if code != 1 || stdout.Len() != 0 || strings.Contains(stderr.String(), "Docker CLI") {
+		t.Fatalf("code=%d stdout=%s stderr=%s", code, &stdout, &stderr)
+	}
+}

--- a/tooling/cmd/20w/main.go
+++ b/tooling/cmd/20w/main.go
@@ -58,6 +58,7 @@ func usage(writer io.Writer) {
 	fmt.Fprintln(writer, "  20w experiment package-node-image --artifact <id> --output <directory> [--root <repository>]")
 	fmt.Fprintln(writer, "  20w experiment render-clrs-wheelhouse-manifest --wheelhouse <directory> --output <new.json> [--root <repository>]")
 	fmt.Fprintln(writer, "  20w experiment verify-clrs-wheelhouse --wheelhouse <directory> [--root <repository>]")
+	fmt.Fprintln(writer, "  20w experiment reproduce-clrs-promise-wheel --output <directory> (--inputs <directory> | --check) [--root <repository>]")
 	fmt.Fprintln(writer, "  20w publication render-pdf [--root <repository>] [--ref main|vMAJOR.MINOR.PATCH] [--revision <commit>] [--check]")
 	fmt.Fprintln(writer, "  20w publication verify-pdf-tools [--root <repository>]")
 	fmt.Fprintln(writer, "  20w publication reproduce-pdf-tools-image --receipt <new.json> [--candidate-bundle <new.tar> --final-archive <new.tar> --spdx <new.spdx.json> --source-bundle <new.tar.gz>] [--root <repository>]")
@@ -120,6 +121,9 @@ func run(arguments []string, stdout, stderr io.Writer) int {
 		}
 		if len(arguments) >= 2 && arguments[1] == "verify-clrs-wheelhouse" {
 			return runExperimentVerifyCLRSWheelhouse(arguments[2:], stdout, stderr)
+		}
+		if len(arguments) >= 2 && arguments[1] == "reproduce-clrs-promise-wheel" {
+			return runExperimentReproducePromise(arguments[2:], stdout, stderr)
 		}
 	case "release":
 		if len(arguments) >= 2 && arguments[1] == "inspect-image" {

--- a/tooling/internal/clrsfixture/promise_archive.go
+++ b/tooling/internal/clrsfixture/promise_archive.go
@@ -1,0 +1,343 @@
+package clrsfixture
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"path"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	promiseArchiveRoot      = "promise-2.3"
+	promiseWheelLicense     = "promise-2.3.dist-info/licenses/LICENSE"
+	promiseArchiveBytes     = 256 << 10
+	promiseArchiveFileBytes = 64 << 10
+	promiseArchiveEntries   = 64
+	promiseArchiveDepth     = 8
+	promiseTarBlockBytes    = 512
+)
+
+type promiseTarEntry struct {
+	header *tar.Header
+	body   []byte
+}
+
+func preparePromiseSource(body []byte, source GeneratorWheelSourceBuild) ([]byte, error) {
+	decoded, err := decodePromiseSource(body)
+	if err != nil {
+		return nil, err
+	}
+	entries, err := readPromiseTar(decoded, promiseArchiveBytes)
+	if err != nil {
+		return nil, fmt.Errorf("inspect promise source tar: %w", err)
+	}
+	if err := checkPromiseSourceEntries(entries, source.Provenance); err != nil {
+		return nil, err
+	}
+	return canonicalPromiseTar(entries)
+}
+
+func decodePromiseSource(body []byte) ([]byte, error) {
+	if len(body) == 0 || len(body) > promiseArchiveBytes {
+		return nil, errors.New("promise source gzip exceeds compressed byte limit or is empty")
+	}
+	compressed := bytes.NewReader(body)
+	reader, err := gzip.NewReader(compressed)
+	if err != nil {
+		return nil, fmt.Errorf("open promise source gzip: %w", err)
+	}
+	// bytes.Reader implements io.ByteReader, so disabling multistream leaves it
+	// exactly after the first stream, including the checked gzip trailer.
+	reader.Multistream(false)
+	decoded, readErr := io.ReadAll(io.LimitReader(reader, promiseArchiveBytes+1))
+	closeErr := reader.Close()
+	if readErr != nil || closeErr != nil {
+		return nil, fmt.Errorf("read promise source gzip: %w", errors.Join(readErr, closeErr))
+	}
+	if len(decoded) > promiseArchiveBytes {
+		return nil, errors.New("promise source gzip exceeds expanded byte limit")
+	}
+	if compressed.Len() != 0 {
+		return nil, errors.New("promise source gzip has a second member or trailing data")
+	}
+	return decoded, nil
+}
+
+func readPromiseTar(body []byte, limit int) ([]promiseTarEntry, error) {
+	if len(body) < 2*promiseTarBlockBytes || len(body) > limit || len(body)%promiseTarBlockBytes != 0 {
+		return nil, errors.New("tar byte count is empty, oversized, or not block aligned")
+	}
+	entries := make([]promiseTarEntry, 0, promiseArchiveEntries)
+	for offset := 0; offset < len(body); {
+		block := body[offset : offset+promiseTarBlockBytes]
+		if promiseZeroBytes(block) {
+			if len(body)-offset < 2*promiseTarBlockBytes || !promiseZeroBytes(body[offset:]) {
+				return nil, errors.New("tar terminator is incomplete or followed by nonzero data")
+			}
+			return entries, nil
+		}
+		if len(entries) >= promiseArchiveEntries {
+			return nil, errors.New("tar exceeds entry count limit")
+		}
+		// tar.Reader.Next hides PAX and GNU long-name records. Check the raw
+		// type byte first, then let archive/tar own checksums and header parsing.
+		if block[156] != tar.TypeReg && block[156] != tar.TypeDir {
+			return nil, errors.New("tar contains a link, special entry, or metadata record")
+		}
+		header, err := tar.NewReader(bytes.NewReader(body[offset:])).Next()
+		if err != nil {
+			return nil, fmt.Errorf("parse tar header at byte %d: %w", offset, err)
+		}
+		if err := checkPromiseTarHeader(header); err != nil {
+			return nil, err
+		}
+		start := offset + promiseTarBlockBytes
+		end := start + int(header.Size)
+		next := start + ((int(header.Size)+promiseTarBlockBytes-1)/promiseTarBlockBytes)*promiseTarBlockBytes
+		if next > len(body) || !promiseZeroBytes(body[end:next]) {
+			return nil, fmt.Errorf("tar member %q is truncated or has nonzero padding", header.Name)
+		}
+		entries = append(entries, promiseTarEntry{header: header, body: body[start:end]})
+		offset = next
+	}
+	return nil, errors.New("tar is missing its two-block terminator")
+}
+
+func checkPromiseTarHeader(header *tar.Header) error {
+	if header.Format != tar.FormatUSTAR && header.Format != tar.FormatGNU {
+		return fmt.Errorf("tar member %q uses an unsupported format", header.Name)
+	}
+	if header.Linkname != "" || len(header.PAXRecords) != 0 || len(header.Xattrs) != 0 ||
+		header.Devmajor != 0 || header.Devminor != 0 || header.Mode < 0 || header.Mode&^0o777 != 0 {
+		return fmt.Errorf("tar member %q has unsupported metadata or mode", header.Name)
+	}
+	if header.Size < 0 || header.Size > promiseArchiveFileBytes || (header.Typeflag == tar.TypeDir && header.Size != 0) {
+		return fmt.Errorf("tar member %q has an invalid size", header.Name)
+	}
+	return nil
+}
+
+func promiseZeroBytes(body []byte) bool {
+	for _, value := range body {
+		if value != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func promiseSafePath(name string) bool {
+	if !fs.ValidPath(name) || name == "." || len(name) > 255 || strings.ContainsAny(name, "\\:") ||
+		strings.Count(name, "/")+1 > promiseArchiveDepth {
+		return false
+	}
+	for _, value := range name {
+		if value < 0x20 || value == 0x7f {
+			return false
+		}
+	}
+	return true
+}
+
+func checkPromiseSourceEntries(entries []promiseTarEntry, provenance GeneratorWheelSourceProvenance) error {
+	seen := make(map[string]bool, len(entries))
+	licenseFound := false
+	for _, entry := range entries {
+		name := entry.header.Name
+		isDirectory := entry.header.Typeflag == tar.TypeDir
+		if isDirectory {
+			name = strings.TrimSuffix(name, "/")
+		}
+		if !promiseSafePath(name) || (name != promiseArchiveRoot && !strings.HasPrefix(name, promiseArchiveRoot+"/")) {
+			return fmt.Errorf("promise source contains unsafe or foreign path %q", entry.header.Name)
+		}
+		if _, duplicate := seen[name]; duplicate {
+			return fmt.Errorf("promise source contains duplicate path %q", name)
+		}
+		seen[name] = isDirectory
+		if name == promiseArchiveRoot+"/"+provenance.SourceLicensePath {
+			if isDirectory || int64(len(entry.body)) != provenance.LicenseSizeBytes ||
+				rawSHA256(entry.body) != provenance.LicenseSHA256 {
+				return errors.New("promise source LICENSE does not match provenance")
+			}
+			licenseFound = true
+		}
+	}
+	if !seen[promiseArchiveRoot] || !licenseFound {
+		return errors.New("promise source root directory or provenance LICENSE is missing")
+	}
+	for _, entry := range entries {
+		name := strings.TrimSuffix(entry.header.Name, "/")
+		for parent := path.Dir(name); parent != "."; parent = path.Dir(parent) {
+			if !seen[parent] {
+				return fmt.Errorf("promise source path %q has missing or non-directory parent %q", name, parent)
+			}
+		}
+	}
+	return nil
+}
+
+func canonicalPromiseTar(entries []promiseTarEntry) ([]byte, error) {
+	for _, entry := range entries {
+		if entry.header.Typeflag == tar.TypeDir {
+			entry.header.Name = strings.TrimSuffix(entry.header.Name, "/") + "/"
+		}
+	}
+	sort.Slice(entries, func(left, right int) bool { return entries[left].header.Name < entries[right].header.Name })
+	var body bytes.Buffer
+	writer := tar.NewWriter(&body)
+	for _, entry := range entries {
+		header := &tar.Header{
+			Name: entry.header.Name, Typeflag: entry.header.Typeflag, Size: int64(len(entry.body)),
+			Mode: 0o644, Uid: 65532, Gid: 65532, ModTime: time.Unix(generatorSourceDateEpoch, 0),
+			Format: tar.FormatUSTAR,
+		}
+		if header.Typeflag == tar.TypeDir {
+			header.Mode = 0o755
+		}
+		if err := writer.WriteHeader(header); err != nil {
+			return nil, fmt.Errorf("write canonical promise tar header %q: %w", header.Name, err)
+		}
+		if _, err := writer.Write(entry.body); err != nil {
+			return nil, fmt.Errorf("write canonical promise tar member %q: %w", header.Name, err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		return nil, fmt.Errorf("close canonical promise tar: %w", err)
+	}
+	return body.Bytes(), nil
+}
+
+func verifyPromiseWheel(body []byte) error {
+	if int64(len(body)) != promiseWheelSize || rawSHA256(body) != promiseWheelSHA256 {
+		return errors.New("promise wheel size or SHA-256 differs from the selected wheel")
+	}
+	return checkPromiseWheelContents(body)
+}
+
+func checkPromiseWheelContents(body []byte) error {
+	if err := checkPromiseZipEnvelope(body); err != nil {
+		return err
+	}
+	reader, err := zip.NewReader(bytes.NewReader(body), int64(len(body)))
+	if err != nil {
+		return fmt.Errorf("open promise wheel ZIP: %w", err)
+	}
+	if len(reader.File) == 0 || len(reader.File) > promiseArchiveEntries {
+		return errors.New("promise wheel ZIP has an invalid member count")
+	}
+	seen := make(map[string]bool, len(reader.File))
+	var expanded uint64
+	licenseFound := false
+	for _, file := range reader.File {
+		if !promiseSafePath(file.Name) || !file.Mode().IsRegular() || file.Mode()&(fs.ModeSetuid|fs.ModeSetgid|fs.ModeSticky) != 0 ||
+			file.Flags&^uint16(0x808) != 0 || (file.Method != zip.Store && file.Method != zip.Deflate) {
+			return fmt.Errorf("promise wheel ZIP member %q has an unsafe path, type, or encoding", file.Name)
+		}
+		if seen[file.Name] {
+			return fmt.Errorf("promise wheel ZIP has duplicate member %q", file.Name)
+		}
+		seen[file.Name] = true
+		if file.UncompressedSize64 > promiseArchiveFileBytes || file.CompressedSize64 > uint64(len(body)) {
+			return fmt.Errorf("promise wheel ZIP member %q exceeds its byte limit", file.Name)
+		}
+		expanded += file.UncompressedSize64
+		if expanded > promiseArchiveBytes {
+			return errors.New("promise wheel ZIP exceeds expanded byte limit")
+		}
+		content, err := readPromiseZipMember(file)
+		if err != nil {
+			return err
+		}
+		if file.Name == promiseWheelLicense {
+			if int64(len(content)) != promiseLicenseSize || rawSHA256(content) != promiseLicenseSHA256 {
+				return errors.New("promise wheel embedded MIT LICENSE differs from the pinned license")
+			}
+			licenseFound = true
+		}
+	}
+	for _, file := range reader.File {
+		for parent := path.Dir(file.Name); parent != "."; parent = path.Dir(parent) {
+			if seen[parent] {
+				return fmt.Errorf("promise wheel ZIP member %q has non-directory parent %q", file.Name, parent)
+			}
+		}
+	}
+	if !licenseFound {
+		return errors.New("promise wheel embedded MIT LICENSE is missing")
+	}
+	return nil
+}
+
+func checkPromiseZipEnvelope(body []byte) error {
+	if len(body) < 22 || len(body) > promiseArchiveBytes || !bytes.HasPrefix(body, []byte("PK\x03\x04")) {
+		return errors.New("promise wheel ZIP is empty, oversized, or has a prefix")
+	}
+	end := body[len(body)-22:]
+	if !bytes.Equal(end[:4], []byte("PK\x05\x06")) || binary.LittleEndian.Uint16(end[20:22]) != 0 {
+		return errors.New("promise wheel ZIP has a comment, trailing data, or missing terminator")
+	}
+	count := binary.LittleEndian.Uint16(end[10:12])
+	directoryBytes := uint64(binary.LittleEndian.Uint32(end[12:16]))
+	directoryOffset := uint64(binary.LittleEndian.Uint32(end[16:20]))
+	if binary.LittleEndian.Uint16(end[4:6]) != 0 || binary.LittleEndian.Uint16(end[6:8]) != 0 ||
+		binary.LittleEndian.Uint16(end[8:10]) != count || count == 0 || count > promiseArchiveEntries ||
+		directoryOffset+directoryBytes != uint64(len(body)-22) {
+		return errors.New("promise wheel ZIP central directory is not one bounded complete disk")
+	}
+	return nil
+}
+
+func readPromiseZipMember(file *zip.File) ([]byte, error) {
+	reader, err := file.Open()
+	if err != nil {
+		return nil, fmt.Errorf("open promise wheel ZIP member %q: %w", file.Name, err)
+	}
+	body, readErr := io.ReadAll(io.LimitReader(reader, promiseArchiveFileBytes+1))
+	closeErr := reader.Close()
+	if readErr != nil || closeErr != nil {
+		return nil, fmt.Errorf("read promise wheel ZIP member %q: %w", file.Name, errors.Join(readErr, closeErr))
+	}
+	if uint64(len(body)) != file.UncompressedSize64 || len(body) > promiseArchiveFileBytes {
+		return nil, fmt.Errorf("promise wheel ZIP member %q has an invalid expanded size", file.Name)
+	}
+	return body, nil
+}
+
+func parsePromiseOutput(body []byte) ([]byte, error) {
+	entries, err := readPromiseTar(body, int(promiseMaximumOutputTarBytes))
+	if err != nil {
+		return nil, fmt.Errorf("inspect promise Docker output tar: %w", err)
+	}
+	seen := make(map[string]bool, len(entries))
+	var wheel []byte
+	for _, entry := range entries {
+		name := entry.header.Name
+		if entry.header.Typeflag == tar.TypeDir && (name == "." || name == "./") {
+			name = "."
+		} else {
+			name = strings.TrimPrefix(name, "./")
+			if name != promiseWheelFilename || entry.header.Typeflag != tar.TypeReg {
+				return nil, fmt.Errorf("promise Docker output tar has unexpected member %q", entry.header.Name)
+			}
+			wheel = entry.body
+		}
+		if seen[name] {
+			return nil, fmt.Errorf("promise Docker output tar has duplicate member %q", name)
+		}
+		seen[name] = true
+	}
+	if err := verifyPromiseWheel(wheel); err != nil {
+		return nil, err
+	}
+	return bytes.Clone(wheel), nil
+}

--- a/tooling/internal/clrsfixture/promise_archive_test.go
+++ b/tooling/internal/clrsfixture/promise_archive_test.go
@@ -1,0 +1,470 @@
+package clrsfixture
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+type promiseTestTarMember struct {
+	header tar.Header
+	body   []byte
+}
+
+func TestPromiseSourceCanonicalizesGNUHeadersAndPadding(t *testing.T) {
+	t.Parallel()
+	members, source := promiseTestSource(t)
+	padded := append(promiseTestTar(t, members), make([]byte, 9*promiseTarBlockBytes)...)
+	canonical, err := preparePromiseSource(promiseTestGzip(t, padded), source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	slices.Reverse(members)
+	for index := range members {
+		members[index].header.ModTime = time.Unix(123, 0)
+		members[index].header.Uid = 42
+		members[index].header.Gid = 43
+		members[index].header.Mode = 0o700
+		if members[index].header.Typeflag == tar.TypeDir {
+			members[index].header.Name = strings.TrimSuffix(members[index].header.Name, "/")
+		}
+	}
+	reordered, err := preparePromiseSource(promiseTestGzip(t, promiseTestTar(t, members)), source)
+	if err != nil || !bytes.Equal(canonical, reordered) {
+		t.Fatalf("source metadata/order changed canonical tar: %v", err)
+	}
+	entries, err := readPromiseTar(canonical, promiseArchiveBytes)
+	if err != nil || len(entries) != len(members) {
+		t.Fatalf("canonical tar entries = %d, error = %v", len(entries), err)
+	}
+	wantBodies := make(map[string][]byte, len(members))
+	for _, member := range members {
+		name := member.header.Name
+		if member.header.Typeflag == tar.TypeDir {
+			name += "/"
+		}
+		wantBodies[name] = member.body
+	}
+	previous := ""
+	for _, entry := range entries {
+		header := entry.header
+		mode := int64(0o644)
+		if header.Typeflag == tar.TypeDir {
+			mode = 0o755
+		}
+		if header.Format != tar.FormatUSTAR || header.Mode != mode || header.Uid != 65532 || header.Gid != 65532 ||
+			header.ModTime.Unix() != generatorSourceDateEpoch || header.Uname != "" || header.Gname != "" ||
+			len(header.PAXRecords) != 0 || header.Name <= previous {
+			t.Fatalf("canonical header = %#v", header)
+		}
+		if !bytes.Equal(entry.body, wantBodies[header.Name]) {
+			t.Fatalf("canonical member bytes changed: %s", header.Name)
+		}
+		previous = header.Name
+	}
+}
+
+func TestPromiseSourceRejectsUnsafeMembers(t *testing.T) {
+	t.Parallel()
+	valid, source := promiseTestSource(t)
+	tests := map[string]struct {
+		member promiseTestTarMember
+		want   string
+	}{
+		"parent escape":  {promiseTestFile("promise-2.3/../escape", nil), "unsafe"},
+		"absolute":       {promiseTestFile("/promise-2.3/escape", nil), "unsafe"},
+		"backslash":      {promiseTestFile("promise-2.3/dir\\escape", nil), "unsafe"},
+		"foreign root":   {promiseTestFile("other/file", nil), "foreign"},
+		"dot segment":    {promiseTestFile("promise-2.3/./file", nil), "unsafe"},
+		"double slash":   {promiseTestFile("promise-2.3//file", nil), "unsafe"},
+		"duplicate":      {valid[1], "duplicate"},
+		"missing parent": {promiseTestFile("promise-2.3/missing/file", nil), "missing or non-directory"},
+		"file parent":    {promiseTestFile("promise-2.3/LICENSE/file", nil), "non-directory"},
+		"deep path":      {promiseTestFile("promise-2.3/"+strings.Repeat("d/", promiseArchiveDepth)+"file", nil), "unsafe"},
+		"large member":   {promiseTestFile("promise-2.3/large", make([]byte, promiseArchiveFileBytes+1)), "invalid size"},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			members := append(slices.Clone(valid), test.member)
+			promiseRequireSourceError(t, promiseTestGzip(t, promiseTestTar(t, members)), source, test.want)
+		})
+	}
+}
+
+func TestPromiseSourceRejectsLinksSpecialModesAndMetadata(t *testing.T) {
+	t.Parallel()
+	valid, source := promiseTestSource(t)
+	for _, kind := range []byte{tar.TypeLink, tar.TypeSymlink, tar.TypeFifo, tar.TypeChar, tar.TypeBlock} {
+		t.Run(fmt.Sprintf("type-%c", kind), func(t *testing.T) {
+			t.Parallel()
+			member := promiseTestFile("promise-2.3/special", nil)
+			member.header.Typeflag = kind
+			if kind == tar.TypeLink || kind == tar.TypeSymlink {
+				member.header.Linkname = "promise-2.3/LICENSE"
+			}
+			members := append(slices.Clone(valid), member)
+			promiseRequireSourceError(t, promiseTestGzip(t, promiseTestTar(t, members)), source, "special entry")
+		})
+	}
+	for name, mutate := range map[string]func(*tar.Header){
+		"setuid": func(header *tar.Header) { header.Mode = 0o4644 },
+		"PAX": func(header *tar.Header) {
+			header.Format = tar.FormatPAX
+			header.PAXRecords = map[string]string{"vendor.key": "value"}
+		},
+		"GNU long name": func(header *tar.Header) {
+			header.Name = "promise-2.3/" + strings.Repeat("a", 110)
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			member := promiseTestFile("promise-2.3/metadata", nil)
+			mutate(&member.header)
+			promiseRequireSourceError(t, promiseTestGzip(t, promiseTestTar(t, append(slices.Clone(valid), member))), source, "metadata")
+		})
+	}
+}
+
+func TestPromiseSourceRejectsMissingAuthorityAndExhaustion(t *testing.T) {
+	t.Parallel()
+	valid, source := promiseTestSource(t)
+	withoutRoot := slices.Clone(valid[1:])
+	withoutLicense := append(slices.Clone(valid[:1]), valid[2:]...)
+	wrongLicense := slices.Clone(valid)
+	wrongLicense[1].body = []byte("different license")
+	tooMany := slices.Clone(valid)
+	for index := len(tooMany); index <= promiseArchiveEntries; index++ {
+		tooMany = append(tooMany, promiseTestFile(fmt.Sprintf("promise-2.3/file-%d", index), nil))
+	}
+	for name, test := range map[string]struct {
+		members []promiseTestTarMember
+		want    string
+	}{
+		"missing root":    {withoutRoot, "root directory"},
+		"missing license": {withoutLicense, "LICENSE is missing"},
+		"wrong license":   {wrongLicense, "does not match provenance"},
+		"entry count":     {tooMany, "entry count limit"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			promiseRequireSourceError(t, promiseTestGzip(t, promiseTestTar(t, test.members)), source, test.want)
+		})
+	}
+	changed := source
+	changed.Provenance.LicenseSHA256 = strings.Repeat("0", 64)
+	promiseRequireSourceError(t, promiseTestGzip(t, promiseTestTar(t, valid)), changed, "does not match provenance")
+	promiseRequireSourceError(t, make([]byte, promiseArchiveBytes+1), source, "compressed byte limit")
+	promiseRequireSourceError(t, promiseTestGzip(t, make([]byte, promiseArchiveBytes+1)), source, "expanded byte limit")
+}
+
+func TestPromiseSourceRejectsMalformedFramingAndGzipTail(t *testing.T) {
+	t.Parallel()
+	members, source := promiseTestSource(t)
+	valid := promiseTestTar(t, members)
+	checksum := bytes.Clone(valid)
+	checksum[0] ^= 1
+	padding := bytes.Clone(valid)
+	padding[2*promiseTarBlockBytes+int(promiseLicenseSize)] = 1
+	for name, body := range map[string][]byte{
+		"checksum":           checksum,
+		"file padding":       padding,
+		"one terminator":     valid[:len(valid)-promiseTarBlockBytes],
+		"missing terminator": valid[:len(valid)-2*promiseTarBlockBytes],
+		"fractional block":   valid[:len(valid)-1],
+		"appended tar":       append(bytes.Clone(valid), valid...),
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			promiseRequireSourceError(t, promiseTestGzip(t, body), source, "tar")
+		})
+	}
+	compressed := promiseTestGzip(t, valid)
+	badCRC := bytes.Clone(compressed)
+	badCRC[len(badCRC)-8] ^= 1
+	for name, body := range map[string][]byte{
+		"CRC":           badCRC,
+		"truncated":     compressed[:len(compressed)-5],
+		"second member": append(bytes.Clone(compressed), promiseTestGzip(t, nil)...),
+		"trailing zero": append(bytes.Clone(compressed), 0),
+		"trailing data": append(bytes.Clone(compressed), 'x'),
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			promiseRequireSourceError(t, body, source, "gzip")
+		})
+	}
+}
+
+func TestPromiseWheelInspectsContentsAndIndependentLicense(t *testing.T) {
+	t.Parallel()
+	license := promiseTestLicense(t)
+	valid := []promiseTestZipMember{{promiseWheelLicense, license, 0o644}, {"promise/example.py", []byte("pass\n"), 0o644}}
+	if err := checkPromiseWheelContents(promiseTestZip(t, valid)); err != nil {
+		t.Fatal(err)
+	}
+	for name, test := range map[string]struct {
+		members []promiseTestZipMember
+		want    string
+	}{
+		"missing license": {valid[1:], "LICENSE is missing"},
+		"wrong license":   {[]promiseTestZipMember{{promiseWheelLicense, []byte("different license"), 0o644}}, "pinned license"},
+		"duplicate":       {append(slices.Clone(valid), valid[0]), "duplicate"},
+		"parent escape":   {append(slices.Clone(valid), promiseTestZipMember{"../escape", nil, 0o644}), "unsafe"},
+		"backslash":       {append(slices.Clone(valid), promiseTestZipMember{"promise\\escape", nil, 0o644}), "unsafe"},
+		"absolute":        {append(slices.Clone(valid), promiseTestZipMember{"/escape", nil, 0o644}), "unsafe"},
+		"directory":       {append(slices.Clone(valid), promiseTestZipMember{"promise/", nil, fs.ModeDir | 0o755}), "unsafe"},
+		"symlink":         {append(slices.Clone(valid), promiseTestZipMember{"promise/link", []byte("LICENSE"), fs.ModeSymlink | 0o777}), "unsafe"},
+		"setuid":          {append(slices.Clone(valid), promiseTestZipMember{"promise/setuid", nil, fs.ModeSetuid | 0o755}), "unsafe"},
+		"file parent":     {append(slices.Clone(valid), promiseTestZipMember{"promise", nil, 0o644}), "non-directory"},
+		"member limit":    {append(slices.Clone(valid), promiseTestZipMember{"promise/large", make([]byte, promiseArchiveFileBytes+1), 0o644}), "byte limit"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			err := checkPromiseWheelContents(promiseTestZip(t, test.members))
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("wheel error = %v, want %q", err, test.want)
+			}
+		})
+	}
+	if err := verifyPromiseWheel(promiseTestZip(t, valid)); err == nil || !strings.Contains(err.Error(), "selected wheel") {
+		t.Fatalf("synthetic wheel acquired exact artifact authority: %v", err)
+	}
+}
+
+func TestPromiseWheelRejectsCountExpansionAndTrailingData(t *testing.T) {
+	t.Parallel()
+	valid := []promiseTestZipMember{{promiseWheelLicense, promiseTestLicense(t), 0o644}}
+	tooMany := slices.Clone(valid)
+	for index := len(tooMany); index <= promiseArchiveEntries; index++ {
+		tooMany = append(tooMany, promiseTestZipMember{fmt.Sprintf("promise/file-%d", index), nil, 0o644})
+	}
+	tooLarge := slices.Clone(valid)
+	for index := range 4 {
+		tooLarge = append(tooLarge, promiseTestZipMember{fmt.Sprintf("promise/large-%d", index), make([]byte, promiseArchiveFileBytes), 0o644})
+	}
+	encoded := promiseTestZip(t, valid)
+	badCRC := bytes.Clone(encoded)
+	directoryOffset := binary.LittleEndian.Uint32(badCRC[len(badCRC)-6 : len(badCRC)-2])
+	badCRC[int(directoryOffset)+16] ^= 1
+	for name, body := range map[string][]byte{
+		"count":     promiseTestZip(t, tooMany),
+		"expansion": promiseTestZip(t, tooLarge),
+		"prefix":    append([]byte("prefix"), encoded...),
+		"trailing":  append(bytes.Clone(encoded), 'x'),
+		"oversized": make([]byte, promiseArchiveBytes+1),
+		"truncated": encoded[:len(encoded)-1],
+		"CRC":       badCRC,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if err := checkPromiseWheelContents(body); err == nil {
+				t.Fatal("invalid wheel ZIP accepted")
+			}
+		})
+	}
+}
+
+func TestPromiseOutputRejectsUnexpectedMembersAndIdentity(t *testing.T) {
+	t.Parallel()
+	wheel := promiseTestFile(promiseWheelFilename, []byte("not the pinned wheel"))
+	root := promiseTestDirectory("./")
+	for name, test := range map[string]struct {
+		members []promiseTestTarMember
+		want    string
+	}{
+		"foreign directory": {[]promiseTestTarMember{promiseTestDirectory("output/")}, "unexpected"},
+		"foreign file":      {[]promiseTestTarMember{promiseTestFile("other.whl", nil)}, "unexpected"},
+		"parent escape":     {[]promiseTestTarMember{promiseTestFile("../"+promiseWheelFilename, nil)}, "unexpected"},
+		"double dot prefix": {[]promiseTestTarMember{promiseTestFile("././"+promiseWheelFilename, nil)}, "unexpected"},
+		"duplicate root":    {[]promiseTestTarMember{root, promiseTestDirectory(".")}, "duplicate"},
+		"duplicate wheel":   {[]promiseTestTarMember{wheel, wheel}, "duplicate"},
+		"directory wheel":   {[]promiseTestTarMember{promiseTestDirectory(promiseWheelFilename)}, "unexpected"},
+		"wrong wheel":       {[]promiseTestTarMember{root, wheel}, "selected wheel"},
+		"missing wheel":     {[]promiseTestTarMember{root}, "selected wheel"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			body, err := parsePromiseOutput(promiseTestTar(t, test.members))
+			if err == nil || body != nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("output bytes = %d, error = %v, want %q", len(body), err, test.want)
+			}
+		})
+	}
+	if _, err := parsePromiseOutput(make([]byte, promiseMaximumOutputTarBytes+1)); err == nil {
+		t.Fatal("oversized Docker output accepted")
+	}
+}
+
+func TestRetainedPromiseArchiveInputs(t *testing.T) {
+	sourcePath := os.Getenv("CLRS_PROMISE_TEST_SOURCE")
+	wheelPath := os.Getenv("CLRS_PROMISE_TEST_WHEEL")
+	if sourcePath == "" && wheelPath == "" {
+		t.Skip("set explicit CLRS_PROMISE_TEST_SOURCE and CLRS_PROMISE_TEST_WHEEL for retained-byte inspection")
+	}
+	if sourcePath == "" || wheelPath == "" {
+		t.Fatal("both retained artifact paths are required")
+	}
+	manifest, _, _, _ := trackedGeneratorWheelhouseManifest(t)
+	source := promiseReadTestInput(t, sourcePath)
+	if int64(len(source)) != manifest.SourceBuild.SourceSizeBytes || rawSHA256(source) != manifest.SourceBuild.SourceSHA256 {
+		t.Fatal("retained source differs from locked identity")
+	}
+	canonical, err := preparePromiseSource(source, manifest.SourceBuild)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if int64(len(canonical)) != promiseCanonicalTarSize || rawSHA256(canonical) != promiseCanonicalTarSHA256 {
+		t.Fatal("retained source canonical transfer differs from its frozen identity")
+	}
+	entries, err := readPromiseTar(canonical, promiseArchiveBytes)
+	if err != nil || len(entries) != 32 {
+		t.Fatalf("retained source canonical entries = %d: %v", len(entries), err)
+	}
+	wheel := promiseReadTestInput(t, wheelPath)
+	if err := verifyPromiseWheel(wheel); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{promiseWheelFilename, "./" + promiseWheelFilename} {
+		output := promiseTestTar(t, []promiseTestTarMember{promiseTestDirectory("./"), promiseTestFile(name, wheel)})
+		parsed, err := parsePromiseOutput(output)
+		if err != nil || !bytes.Equal(parsed, wheel) {
+			t.Fatalf("retained wheel Docker output %q differs: %v", name, err)
+		}
+	}
+	t.Logf("canonical source tar: bytes=%d SHA256=%s entries=%d; pinned wheel bytes=%d SHA256=%s",
+		len(canonical), rawSHA256(canonical), len(entries), len(wheel), rawSHA256(wheel))
+}
+
+func promiseTestSource(t *testing.T) ([]promiseTestTarMember, GeneratorWheelSourceBuild) {
+	t.Helper()
+	return []promiseTestTarMember{
+		promiseTestDirectory("promise-2.3/"),
+		promiseTestFile("promise-2.3/LICENSE", promiseTestLicense(t)),
+		promiseTestDirectory("promise-2.3/promise/"),
+		promiseTestFile("promise-2.3/promise/example.py", []byte("pass\n")),
+		promiseTestFile("promise-2.3/promise/py.typed", nil),
+	}, GeneratorWheelSourceBuild{Provenance: GeneratorWheelSourceProvenance{
+		SourceLicensePath: "LICENSE", LicenseSizeBytes: promiseLicenseSize, LicenseSHA256: promiseLicenseSHA256,
+	}}
+}
+
+func promiseTestLicense(t *testing.T) []byte {
+	t.Helper()
+	body, err := os.ReadFile(filepath.Join(trackedRepositoryRoot(t), promiseLicensePath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if int64(len(body)) != promiseLicenseSize || rawSHA256(body) != promiseLicenseSHA256 {
+		t.Fatal("tracked Promise MIT license differs from pinned bytes")
+	}
+	return body
+}
+
+func promiseTestFile(name string, body []byte) promiseTestTarMember {
+	return promiseTestTarMember{header: tar.Header{
+		Name: name, Typeflag: tar.TypeReg, Mode: 0o644, Uid: 501, Gid: 20,
+		Uname: "source-owner", Gname: "source-group", ModTime: time.Unix(1_576_657_474, 0), Format: tar.FormatGNU,
+	}, body: body}
+}
+
+func promiseTestDirectory(name string) promiseTestTarMember {
+	member := promiseTestFile(name, nil)
+	member.header.Typeflag = tar.TypeDir
+	member.header.Mode = 0o755
+	return member
+}
+
+func promiseTestTar(t *testing.T, members []promiseTestTarMember) []byte {
+	t.Helper()
+	var body bytes.Buffer
+	writer := tar.NewWriter(&body)
+	for _, member := range members {
+		header := member.header
+		header.Size = int64(len(member.body))
+		if err := writer.WriteHeader(&header); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := writer.Write(member.body); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return body.Bytes()
+}
+
+func promiseTestGzip(t *testing.T, body []byte) []byte {
+	t.Helper()
+	var compressed bytes.Buffer
+	writer := gzip.NewWriter(&compressed)
+	writer.Name = "dist/promise-2.3.tar"
+	if _, err := writer.Write(body); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return compressed.Bytes()
+}
+
+func promiseRequireSourceError(t *testing.T, body []byte, source GeneratorWheelSourceBuild, want string) {
+	t.Helper()
+	output, err := preparePromiseSource(body, source)
+	if err == nil || output != nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("source output bytes = %d, error = %v, want %q", len(output), err, want)
+	}
+}
+
+type promiseTestZipMember struct {
+	name string
+	body []byte
+	mode fs.FileMode
+}
+
+func promiseTestZip(t *testing.T, members []promiseTestZipMember) []byte {
+	t.Helper()
+	var body bytes.Buffer
+	writer := zip.NewWriter(&body)
+	for _, member := range members {
+		header := &zip.FileHeader{Name: member.name, Method: zip.Deflate}
+		header.SetMode(member.mode)
+		file, err := writer.CreateHeader(header)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := file.Write(member.body); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return body.Bytes()
+}
+
+func promiseReadTestInput(t *testing.T, name string) []byte {
+	t.Helper()
+	file, err := os.Open(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, readErr := io.ReadAll(io.LimitReader(file, promiseArchiveBytes+1))
+	closeErr := file.Close()
+	if readErr != nil || closeErr != nil || len(body) > promiseArchiveBytes {
+		t.Fatalf("read retained input %q: read=%v close=%v bytes=%d", name, readErr, closeErr, len(body))
+	}
+	return body
+}

--- a/tooling/internal/clrsfixture/promise_command.go
+++ b/tooling/internal/clrsfixture/promise_command.go
@@ -1,0 +1,281 @@
+package clrsfixture
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"reflect"
+	"strings"
+	"sync"
+	"time"
+)
+
+type promiseDockerRequest struct {
+	operation string
+	arguments []string
+	stdin     []byte
+	limit     int64
+}
+
+type promiseDockerResult struct {
+	stdout []byte
+	stderr []byte
+}
+
+type promiseDocker interface {
+	run(context.Context, promiseDockerRequest) (promiseDockerResult, error)
+}
+
+type localPromiseDocker struct{}
+
+type promiseCapture struct {
+	mutex     sync.Mutex
+	remaining int64
+	exceeded  bool
+	cancel    context.CancelFunc
+	stdout    bytes.Buffer
+	stderr    bytes.Buffer
+}
+
+type promiseCaptureWriter struct {
+	capture *promiseCapture
+	stderr  bool
+}
+
+func (writer promiseCaptureWriter) Write(body []byte) (int, error) {
+	capture := writer.capture
+	capture.mutex.Lock()
+	defer capture.mutex.Unlock()
+	accepted := min(int64(len(body)), capture.remaining)
+	if accepted > 0 {
+		buffer := &capture.stdout
+		if writer.stderr {
+			buffer = &capture.stderr
+		}
+		_, _ = buffer.Write(body[:accepted])
+		capture.remaining -= accepted
+	}
+	if accepted < int64(len(body)) {
+		capture.exceeded = true
+		capture.cancel()
+	}
+	return len(body), nil
+}
+
+func (localPromiseDocker) run(ctx context.Context, request promiseDockerRequest) (promiseDockerResult, error) {
+	if request.operation == "" || len(request.arguments) == 0 || request.limit < 1 || request.limit > promiseMaximumRunOutputBytes ||
+		len(request.stdin) > 256<<10 {
+		return promiseDockerResult{}, errors.New("invalid bounded Promise Docker request")
+	}
+	commandContext, cancel := context.WithCancel(ctx)
+	defer cancel()
+	binary, err := exec.LookPath("docker")
+	if err != nil {
+		return promiseDockerResult{}, errors.New("Promise reproduction needs the local Docker CLI and preloaded pinned runtime")
+	}
+	command := exec.CommandContext(commandContext, binary, append([]string{"--context", "default"}, request.arguments...)...)
+	command.Env = promiseHostEnvironment()
+	command.Stdin = bytes.NewReader(request.stdin)
+	command.WaitDelay = 2 * time.Second
+	capture := &promiseCapture{remaining: request.limit, cancel: cancel}
+	command.Stdout = promiseCaptureWriter{capture: capture}
+	command.Stderr = promiseCaptureWriter{capture: capture, stderr: true}
+	cleanup, err := configurePromiseProcess(command)
+	if err != nil {
+		return promiseDockerResult{}, err
+	}
+	runErr := command.Run()
+	cleanupErr := cleanup()
+	result := promiseDockerResult{capture.stdout.Bytes(), capture.stderr.Bytes()}
+	if capture.exceeded {
+		return result, errors.Join(errors.New("Promise Docker captured output exceeded its remaining byte budget"), cleanupErr)
+	}
+	return result, errors.Join(runErr, cleanupErr, ctx.Err())
+}
+
+func promiseHostEnvironment() []string {
+	environment := []string{"LANG=C.UTF-8", "LC_ALL=C.UTF-8", "TZ=UTC"}
+	for _, key := range []string{"HOME", "PATH", "XDG_RUNTIME_DIR"} {
+		if value, present := os.LookupEnv(key); present {
+			environment = append(environment, key+"="+value)
+		}
+	}
+	return environment
+}
+
+type promiseCommandEvidence struct {
+	Operation      string   `json:"operation"`
+	Arguments      []string `json:"arguments"`
+	StdinSHA256    string   `json:"stdin_sha256"`
+	StdinSizeBytes int64    `json:"stdin_size_bytes"`
+	Stdout         []byte   `json:"stdout"`
+	Stderr         []byte   `json:"stderr"`
+	Error          string   `json:"error"`
+}
+
+type promiseCommandLog struct {
+	docker           promiseDocker
+	entries          []promiseCommandEvidence
+	workRemaining    int64
+	cleanupRemaining int64
+}
+
+func newPromiseCommandLog(docker promiseDocker) *promiseCommandLog {
+	return &promiseCommandLog{docker: docker, workRemaining: 768 << 10, cleanupRemaining: 64 << 10}
+}
+
+func (log *promiseCommandLog) execute(ctx context.Context, operation string, arguments []string, stdin []byte, cleanup bool) (promiseDockerResult, error) {
+	remaining := &log.workRemaining
+	if cleanup {
+		remaining = &log.cleanupRemaining
+	}
+	limit := *remaining
+	if operation == "read-wheel" {
+		limit = min(limit, promiseMaximumOutputTarBytes)
+	}
+	if limit < 1 {
+		return promiseDockerResult{}, errors.New("Promise captured output budget exhausted")
+	}
+	result, err := log.docker.run(ctx, promiseDockerRequest{operation: operation, arguments: arguments, stdin: stdin, limit: limit})
+	size := int64(len(result.stdout) + len(result.stderr))
+	if size > limit {
+		result.stdout = bytes.Clone(result.stdout[:min(int64(len(result.stdout)), limit)])
+		result.stderr = bytes.Clone(result.stderr[:min(int64(len(result.stderr)), limit-int64(len(result.stdout)))])
+		err = errors.Join(err, errors.New("Promise Docker executor exceeded output bound"))
+		size = int64(len(result.stdout) + len(result.stderr))
+	}
+	*remaining -= size
+	entry := promiseCommandEvidence{Operation: operation, Arguments: arguments, StdinSHA256: rawSHA256(stdin),
+		StdinSizeBytes: int64(len(stdin)), Stdout: result.stdout, Stderr: result.stderr}
+	if err != nil {
+		entry.Error = boundedPromiseError(err)
+	}
+	log.entries = append(log.entries, entry)
+	return result, err
+}
+
+func validatePromiseCommandLog(body []byte, run promiseRunReceipt, procedure promiseProcedure) error {
+	var entries []promiseCommandEvidence
+	if err := decodeCanonicalGeneratorJSON(body, 6, &entries); err != nil {
+		return fmt.Errorf("parse Promise command evidence: %w", err)
+	}
+	want := []string{"verify-endpoint", "verify-image", "create", "start", "copy-source", "bootstrap", "install", "build", "read-wheel", "find-owned", "inspect-owner", "remove", "verify-absence"}
+	if len(entries) != len(want) {
+		return errors.New("Promise command evidence has incomplete step coverage")
+	}
+	var size int64
+	for index, entry := range entries {
+		size += int64(len(entry.Stdout) + len(entry.Stderr))
+		if entry.Operation != want[index] || entry.Error != "" || len(entry.Arguments) < 1 || len(entry.Arguments) > 100 ||
+			entry.StdinSizeBytes < 0 || entry.StdinSizeBytes > 256<<10 || !lowerHex(entry.StdinSHA256, 64) {
+			return errors.New("Promise command evidence contains an invalid or unsuccessful step")
+		}
+		if entry.Operation == "copy-source" && (entry.StdinSHA256 != run.SourceTarSHA256 || entry.StdinSizeBytes != run.SourceTarSizeBytes) {
+			return errors.New("Promise source transfer differs from its run identity")
+		}
+		if entry.Operation != "copy-source" && (entry.StdinSizeBytes != 0 || entry.StdinSHA256 != rawSHA256(nil)) {
+			return errors.New("Promise command evidence has unexpected stdin")
+		}
+		arguments, err := expectedPromiseArguments(entry, run, procedure)
+		if err != nil || !reflect.DeepEqual(entry.Arguments, arguments) {
+			return fmt.Errorf("Promise command %s argv differs from the fixed procedure", entry.Operation)
+		}
+	}
+	if size > promiseMaximumRunOutputBytes || strings.TrimSpace(string(entries[2].Stdout)) != run.ContainerID ||
+		len(bytes.TrimSpace(entries[len(entries)-1].Stdout)) != 0 {
+		return errors.New("Promise command evidence exceeds limits or lacks container creation/removal readback")
+	}
+	if err := validatePromiseRuntimeEvidence(entries, run, procedure); err != nil {
+		return err
+	}
+	wheel, err := parsePromiseOutput(entries[8].Stdout)
+	if err != nil || rawSHA256(wheel) != run.Wheel.SHA256 {
+		return errors.New("Promise retained container output does not contain the recorded wheel")
+	}
+	return nil
+}
+
+func expectedPromiseArguments(entry promiseCommandEvidence, run promiseRunReceipt, procedure promiseProcedure) ([]string, error) {
+	inputs := promiseInputs{manifest: GeneratorWheelhouseManifest{Platform: procedure.Platform, SourceBuild: procedure.SourceBuild}}
+	source := procedure.SourceBuild
+	switch entry.Operation {
+	case "verify-endpoint":
+		return promiseEndpointArguments(), nil
+	case "verify-image":
+		return promiseImageArguments(inputs), nil
+	case "create":
+		wheels, err := promiseRecordedWheelhouse(entry.Arguments, run.Name)
+		if err != nil {
+			return nil, err
+		}
+		return promiseContainerArguments(inputs, run.Name, wheels), nil
+	case "start":
+		return []string{"container", "start", run.Name}, nil
+	case "copy-source":
+		return []string{"container", "cp", "-a", "-", run.Name + ":/work"}, nil
+	case "bootstrap":
+		return promiseExecArguments(source, run.Name, "bootstrap", source.CandidateBootstrapCommand), nil
+	case "install":
+		return promiseExecArguments(source, run.Name, "install", source.CandidateInstallCommand), nil
+	case "build":
+		return promiseExecArguments(source, run.Name, "build", source.CandidateBuildCommand), nil
+	case "read-wheel":
+		return []string{"container", "cp", run.Name + ":/output/.", "-"}, nil
+	case "find-owned", "verify-absence":
+		return promiseListArguments(run.Name), nil
+	case "inspect-owner":
+		return promiseOwnerArguments(run.ContainerID), nil
+	case "remove":
+		return []string{"container", "rm", "--force", "--volumes", run.ContainerID}, nil
+	}
+	return nil, errors.New("unknown Promise command")
+}
+
+func promiseRecordedWheelhouse(arguments []string, name string) (string, error) {
+	for index, argument := range arguments {
+		if argument != "--mount" || index+1 == len(arguments) {
+			continue
+		}
+		mount := arguments[index+1]
+		mountPath, found := strings.CutPrefix(mount, "type=bind,src=")
+		mountPath, suffix := strings.CutSuffix(mountPath, ",dst=/inputs/wheelhouse,readonly,bind-propagation=rprivate")
+		if !found || !suffix || !path.IsAbs(mountPath) || path.Clean(mountPath) != mountPath ||
+			strings.ContainsAny(mountPath, ",\r\n\\") || path.Base(mountPath) != "wheelhouse" || path.Base(path.Dir(mountPath)) != name {
+			return "", errors.New("invalid private Promise wheelhouse mount path")
+		}
+		return mountPath, nil
+	}
+	return "", errors.New("missing private Promise wheelhouse mount")
+}
+
+func validatePromiseRuntimeEvidence(entries []promiseCommandEvidence, run promiseRunReceipt, procedure promiseProcedure) error {
+	var endpoint string
+	if decodeStrict(entries[0].Stdout, 2, &endpoint) != nil || !strings.HasPrefix(endpoint, "unix:///") {
+		return errors.New("Promise retained endpoint is not local")
+	}
+	imageID, err := parsePromiseRuntime(promiseDockerResult{entries[1].Stdout, entries[1].Stderr}, procedure.Image)
+	if err != nil || imageID != run.ImageID {
+		return errors.New("Promise retained runtime image differs from the run identity")
+	}
+	if strings.TrimSpace(string(entries[9].Stdout)) != run.ContainerID ||
+		strings.TrimSpace(string(entries[11].Stdout)) != run.ContainerID {
+		return errors.New("Promise retained cleanup identities differ")
+	}
+	var owner struct {
+		ID    string `json:"id"`
+		Owner string `json:"owner"`
+	}
+	if decodeStrict(entries[10].Stdout, 3, &owner) != nil || owner.ID != run.ContainerID || owner.Owner != run.Name {
+		return errors.New("Promise retained cleanup ownership differs")
+	}
+	for _, index := range []int{0, 1, 2, 8, 9, 10, 11, 12} {
+		if len(entries[index].Stderr) != 0 {
+			return errors.New("Promise retained inspection or cleanup wrote unexpected stderr")
+		}
+	}
+	return nil
+}

--- a/tooling/internal/clrsfixture/promise_command.go
+++ b/tooling/internal/clrsfixture/promise_command.go
@@ -216,7 +216,7 @@ func expectedPromiseArguments(entry promiseCommandEvidence, run promiseRunReceip
 	case "start":
 		return []string{"container", "start", run.Name}, nil
 	case "copy-source":
-		return []string{"container", "cp", "-a", "-", run.Name + ":/work"}, nil
+		return promiseTransferArguments(source, run.Name, "copy-source"), nil
 	case "bootstrap":
 		return promiseExecArguments(source, run.Name, "bootstrap", source.CandidateBootstrapCommand), nil
 	case "install":
@@ -224,7 +224,7 @@ func expectedPromiseArguments(entry promiseCommandEvidence, run promiseRunReceip
 	case "build":
 		return promiseExecArguments(source, run.Name, "build", source.CandidateBuildCommand), nil
 	case "read-wheel":
-		return []string{"container", "cp", run.Name + ":/output/.", "-"}, nil
+		return promiseTransferArguments(source, run.Name, "read-wheel"), nil
 	case "find-owned", "verify-absence":
 		return promiseListArguments(run.Name), nil
 	case "inspect-owner":

--- a/tooling/internal/clrsfixture/promise_container.go
+++ b/tooling/internal/clrsfixture/promise_container.go
@@ -1,0 +1,359 @@
+package clrsfixture
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"time"
+)
+
+const promiseOwnershipLabel = "org.20watts.promise-reproduction"
+
+func promiseTmpfs() []string {
+	return []string{
+		"/work:rw,nosuid,nodev,noexec,size=16777216,uid=65532,gid=65532,mode=0755",
+		"/opt/build:rw,nosuid,nodev,size=134217728,uid=65532,gid=65532,mode=0755",
+		"/output:rw,nosuid,nodev,noexec,size=1048576,uid=65532,gid=65532,mode=0755",
+		"/tmp:rw,nosuid,nodev,noexec,size=16777216,uid=65532,gid=65532,mode=0700",
+	}
+}
+
+func promiseEnvironment(source GeneratorWheelSourceBuild) []string {
+	environment := []string{"PATH=/opt/build/bin:/usr/local/bin:/usr/bin:/bin", "HOME=/tmp", "TMPDIR=/tmp", "PYTHONNOUSERSITE=1"}
+	return append(environment, source.CandidateEnvironment...)
+}
+
+func promiseContainerArguments(inputs promiseInputs, name, wheels string) []string {
+	arguments := []string{
+		"container", "create", "--name", name, "--label", promiseOwnershipLabel + "=" + name,
+		"--platform", inputs.manifest.Platform, "--pull=never", "--network=none", "--read-only",
+		"--user=65532:65532", "--cpus=1", "--memory=1073741824", "--memory-swap=1073741824",
+		"--pids-limit=64", "--cap-drop=ALL", "--security-opt=no-new-privileges", "--restart=no",
+		"--no-healthcheck", "--log-driver=none", "--ipc=none", "--stop-timeout=1",
+		"--mount", "type=bind,src=" + wheels + ",dst=/inputs/wheelhouse,readonly,bind-propagation=rprivate",
+		"--entrypoint=/usr/bin/env",
+	}
+	for _, mount := range promiseTmpfs() {
+		arguments = append(arguments, "--tmpfs", mount)
+	}
+	arguments = append(arguments, inputs.manifest.SourceBuild.BuilderImage, "-i")
+	arguments = append(arguments, promiseEnvironment(inputs.manifest.SourceBuild)...)
+	return append(arguments, "/bin/sleep", "120")
+}
+
+func promiseExecArguments(source GeneratorWheelSourceBuild, name, operation string, command []string) []string {
+	arguments := []string{"container", "exec", "--user=65532:65532"}
+	if operation == "build" {
+		arguments = append(arguments, "--workdir", source.CandidateWorkingDirectory)
+	} else {
+		arguments = append(arguments, "--workdir", "/work")
+	}
+	arguments = append(arguments, name, "/usr/bin/env", "-i")
+	arguments = append(arguments, promiseEnvironment(source)...)
+	return append(arguments, command...)
+}
+
+func runPromiseReproductions(ctx context.Context, root string, inputs promiseInputs, bundle *os.Root, docker promiseDocker) error {
+	receipt := promiseReceipt{
+		SchemaVersion: 1, Authority: ResultAuthority, State: "two-build-byte-match", GeneratorImageState: "blocked",
+		WheelhouseSHA256: inputs.manifestSHA256, ImageContractSHA256: inputs.imageContractSHA256,
+		Procedure: inputs.procedure, Producer: inputs.producer,
+	}
+	for index := 1; index <= 2; index++ {
+		run, err := runPromiseContainer(ctx, inputs, bundle, docker, index)
+		if err != nil {
+			return fmt.Errorf("Promise reproduction %d: %w", index, err)
+		}
+		receipt.Runs = append(receipt.Runs, run)
+	}
+	if err := validatePromiseReceipt(receipt, inputs, inputs.procedure); err != nil {
+		return err
+	}
+	for _, run := range receipt.Runs {
+		if err := checkPromiseRunFiles(bundle.Name(), run, inputs.procedure); err != nil {
+			return err
+		}
+	}
+	if err := recheckPromiseAuthority(root, inputs); err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	body, err := marshalPromiseJSON(receipt)
+	if err != nil {
+		return err
+	}
+	if int64(len(body)) > promiseMaximumReceiptBytes {
+		return errors.New("Promise reproduction receipt exceeds its byte limit")
+	}
+	return writePromiseFile(bundle, "receipt.json", body)
+}
+
+func recheckPromiseAuthority(root string, before promiseInputs) error {
+	after, err := loadPromiseAuthority(root)
+	if err != nil {
+		return err
+	}
+	procedure, err := currentPromiseProcedure(root, after)
+	if err != nil {
+		return err
+	}
+	if before.manifestSHA256 != after.manifestSHA256 || before.imageContractSHA256 != after.imageContractSHA256 ||
+		!reflect.DeepEqual(before.procedure, procedure) {
+		return errors.New("Promise authority or implementation changed during reproduction; no success receipt written")
+	}
+	return nil
+}
+
+func runPromiseContainer(ctx context.Context, inputs promiseInputs, bundle *os.Root, docker promiseDocker, index int) (receipt promiseRunReceipt, runErr error) {
+	name, err := newPromiseContainerName()
+	if err != nil {
+		return receipt, err
+	}
+	runDirectory := fmt.Sprintf("run-%d", index)
+	if err := bundle.Mkdir(runDirectory, 0o700); err != nil {
+		return receipt, err
+	}
+	receipt = promiseRunReceipt{Index: index, Name: name, SourceTarSHA256: rawSHA256(inputs.sourceTar), SourceTarSizeBytes: int64(len(inputs.sourceTar))}
+	log := newPromiseCommandLog(docker)
+	staging, err := stagePromiseWheels(bundle, name, inputs)
+	if err != nil {
+		return receipt, err
+	}
+	defer func() {
+		cleanupErr := removePromiseStaging(bundle, name, staging)
+		receipt.StagingRemoved = cleanupErr == nil
+		body, encodeErr := marshalPromiseJSON(log.entries)
+		if encodeErr == nil && len(body) > 2<<20 {
+			encodeErr = errors.New("Promise command evidence exceeds its byte limit")
+		}
+		logPath := runDirectory + "/commands.json"
+		if encodeErr == nil {
+			encodeErr = writePromiseFile(bundle, logPath, body)
+		}
+		receipt.Log = promiseIdentity(logPath, body)
+		runErr = errors.Join(runErr, cleanupErr, encodeErr)
+	}()
+	runContext, cancel := context.WithTimeout(ctx, 120*time.Second)
+	defer cancel()
+	imageID, err := inspectPromiseRuntime(runContext, inputs, log)
+	if err != nil {
+		return receipt, err
+	}
+	receipt.ImageID = imageID
+	defer func() {
+		cleanupContext, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cleanupCancel()
+		cleanupErr := cleanupPromiseContainer(cleanupContext, log, name, receipt.ContainerID)
+		receipt.CleanupVerified = cleanupErr == nil
+		runErr = errors.Join(runErr, cleanupErr)
+	}()
+	result, err := log.execute(runContext, "create", promiseContainerArguments(inputs, name, filepath.Join(staging.Name(), "wheelhouse")), nil, false)
+	if err != nil {
+		return receipt, err
+	}
+	containerID := strings.TrimSpace(string(result.stdout))
+	if !lowerHex(containerID, 64) || len(result.stderr) != 0 {
+		return receipt, errors.New("Promise container create returned an invalid identity")
+	}
+	receipt.ContainerID = containerID
+	if _, err := log.execute(runContext, "start", []string{"container", "start", name}, nil, false); err != nil {
+		return receipt, err
+	}
+	if _, err := log.execute(runContext, "copy-source", []string{"container", "cp", "-a", "-", name + ":/work"}, inputs.sourceTar, false); err != nil {
+		return receipt, err
+	}
+	if err := executePromiseBuild(runContext, log, inputs.manifest.SourceBuild, name); err != nil {
+		return receipt, err
+	}
+	result, err = log.execute(runContext, "read-wheel", []string{"container", "cp", name + ":/output/.", "-"}, nil, false)
+	if err != nil {
+		return receipt, err
+	}
+	if len(result.stderr) != 0 {
+		return receipt, errors.New("Promise wheel readback wrote unexpected stderr")
+	}
+	wheel, err := parsePromiseOutput(result.stdout)
+	if err != nil {
+		return receipt, err
+	}
+	if err := runContext.Err(); err != nil {
+		return receipt, err
+	}
+	wheelPath := runDirectory + "/" + promiseWheelFilename
+	if err := writePromiseFile(bundle, wheelPath, wheel); err != nil {
+		return receipt, err
+	}
+	receipt.Wheel = promiseIdentity(wheelPath, wheel)
+	receipt.LicenseSHA256 = promiseLicenseSHA256
+	return receipt, nil
+}
+
+func executePromiseBuild(ctx context.Context, log *promiseCommandLog, source GeneratorWheelSourceBuild, name string) error {
+	steps := []struct {
+		name    string
+		command []string
+	}{
+		{"bootstrap", source.CandidateBootstrapCommand},
+		{"install", source.CandidateInstallCommand},
+		{"build", source.CandidateBuildCommand},
+	}
+	for _, step := range steps {
+		if _, err := log.execute(ctx, step.name, promiseExecArguments(source, name, step.name, step.command), nil, false); err != nil {
+			return fmt.Errorf("Promise %s: %w", step.name, err)
+		}
+	}
+	return nil
+}
+
+func inspectPromiseRuntime(ctx context.Context, inputs promiseInputs, log *promiseCommandLog) (string, error) {
+	result, err := log.execute(ctx, "verify-endpoint", promiseEndpointArguments(), nil, false)
+	if err != nil {
+		return "", err
+	}
+	var endpoint string
+	if decodeStrict(result.stdout, 2, &endpoint) != nil || !strings.HasPrefix(endpoint, "unix:///") || len(result.stderr) != 0 {
+		return "", errors.New("Promise reproduction requires the default local Unix Docker endpoint")
+	}
+	result, err = log.execute(ctx, "verify-image", promiseImageArguments(inputs), nil, false)
+	if err != nil {
+		return "", err
+	}
+	return parsePromiseRuntime(result, inputs.manifest.SourceBuild.BuilderImage)
+}
+
+func promiseEndpointArguments() []string {
+	return []string{"context", "inspect", "default", "--format", "{{json .Endpoints.docker.Host}}"}
+}
+
+func promiseImageArguments(inputs promiseInputs) []string {
+	format := `{"id":{{json .Id}},"os":{{json .Os}},"architecture":{{json .Architecture}},"digests":{{json .RepoDigests}},"volumes":{{json .Config.Volumes}}}`
+	return []string{"image", "inspect", "--platform", inputs.manifest.Platform, "--format", format, inputs.manifest.SourceBuild.BuilderImage}
+}
+
+func parsePromiseRuntime(result promiseDockerResult, image string) (string, error) {
+	var identity struct {
+		ID           string                     `json:"id"`
+		OS           string                     `json:"os"`
+		Architecture string                     `json:"architecture"`
+		Digests      []string                   `json:"digests"`
+		Volumes      map[string]json.RawMessage `json:"volumes"`
+	}
+	if decodeStrict(result.stdout, 4, &identity) != nil || len(result.stderr) != 0 || identity.OS != "linux" ||
+		identity.Architecture != "amd64" || !strings.HasPrefix(identity.ID, "sha256:") ||
+		!lowerHex(strings.TrimPrefix(identity.ID, "sha256:"), 64) || len(identity.Volumes) != 0 || len(identity.Digests) > 32 {
+		return "", errors.New("Promise runtime is not the exact Linux amd64 image without implicit volumes")
+	}
+	_, digest, found := strings.Cut(image, "@")
+	for _, reference := range identity.Digests {
+		if found && strings.HasSuffix(reference, "@"+digest) {
+			return identity.ID, nil
+		}
+	}
+	return "", errors.New("Promise locally available runtime does not report the pinned repository digest")
+}
+
+func cleanupPromiseContainer(ctx context.Context, log *promiseCommandLog, name, expectedID string) error {
+	list := promiseListArguments(name)
+	result, err := log.execute(ctx, "find-owned", list, nil, true)
+	if err != nil || len(result.stderr) != 0 {
+		return errors.Join(err, errors.New("cannot determine owned Promise container before cleanup"))
+	}
+	identity := strings.TrimSpace(string(result.stdout))
+	if identity == "" {
+		return nil
+	}
+	if !lowerHex(identity, 64) || (expectedID != "" && identity != expectedID) {
+		return errors.New("Promise cleanup found an unexpected container identity; no removal attempted")
+	}
+	result, err = log.execute(ctx, "inspect-owner", promiseOwnerArguments(identity), nil, true)
+	var owner struct {
+		ID    string `json:"id"`
+		Owner string `json:"owner"`
+	}
+	if err != nil || len(result.stderr) != 0 || decodeStrict(result.stdout, 3, &owner) != nil || owner.ID != identity || owner.Owner != name {
+		return errors.Join(err, errors.New("Promise cleanup ownership label does not match; no removal attempted"))
+	}
+	if _, err := log.execute(ctx, "remove", []string{"container", "rm", "--force", "--volumes", identity}, nil, true); err != nil {
+		return err
+	}
+	result, err = log.execute(ctx, "verify-absence", list, nil, true)
+	if err != nil || len(bytes.TrimSpace(result.stdout)) != 0 || len(result.stderr) != 0 {
+		return errors.Join(err, errors.New("Promise container absence was not verified"))
+	}
+	return nil
+}
+
+func promiseListArguments(name string) []string {
+	return []string{"container", "ls", "--all", "--no-trunc", "--filter", "name=^/" + name + "$", "--format", "{{.ID}}"}
+}
+
+func promiseOwnerArguments(identity string) []string {
+	format := `{"id":{{json .Id}},"owner":{{json (index .Config.Labels "` + promiseOwnershipLabel + `")}}}`
+	return []string{"container", "inspect", "--format", format, identity}
+}
+
+func newPromiseContainerName() (string, error) {
+	var identifier [16]byte
+	if _, err := rand.Read(identifier[:]); err != nil {
+		return "", err
+	}
+	return "20w-promise-" + hex.EncodeToString(identifier[:]), nil
+}
+
+func validPromiseContainerName(name string) bool {
+	return strings.HasPrefix(name, "20w-promise-") && lowerHex(strings.TrimPrefix(name, "20w-promise-"), 32)
+}
+
+func stagePromiseWheels(bundle *os.Root, name string, inputs promiseInputs) (*os.Root, error) {
+	if !validPromiseContainerName(name) {
+		return nil, errors.New("invalid Promise staging identity")
+	}
+	if err := bundle.Mkdir(name, 0o700); err != nil {
+		return nil, err
+	}
+	staging, err := bundle.OpenRoot(name)
+	if err != nil {
+		return nil, err
+	}
+	if err := staging.Mkdir("wheelhouse", 0o755); err != nil {
+		return nil, errors.Join(err, removePromiseStaging(bundle, name, staging))
+	}
+	if err := staging.Chmod("wheelhouse", 0o755); err != nil {
+		return nil, errors.Join(err, removePromiseStaging(bundle, name, staging))
+	}
+	for index, wheel := range inputs.manifest.SourceBuild.BuildRequirements {
+		if err := writePromiseFile(staging, "wheelhouse/"+wheel.Filename, inputs.wheels[index]); err != nil {
+			return nil, errors.Join(err, removePromiseStaging(bundle, name, staging))
+		}
+	}
+	return staging, nil
+}
+
+func removePromiseStaging(bundle *os.Root, name string, staging *os.Root) error {
+	defer staging.Close()
+	held, err := staging.Stat(".")
+	if err != nil {
+		return err
+	}
+	named, err := bundle.Lstat(name)
+	if err != nil || !named.IsDir() || !os.SameFile(held, named) {
+		return errors.New("Promise staging identity changed; cleanup left it untouched")
+	}
+	if err := bundle.RemoveAll(name); err != nil {
+		return fmt.Errorf("remove owned Promise staging: %w", err)
+	}
+	if _, err := bundle.Lstat(name); !errors.Is(err, os.ErrNotExist) {
+		return errors.New("Promise staging removal was not verified")
+	}
+	return nil
+}

--- a/tooling/internal/clrsfixture/promise_container.go
+++ b/tooling/internal/clrsfixture/promise_container.go
@@ -51,6 +51,9 @@ func promiseContainerArguments(inputs promiseInputs, name, wheels string) []stri
 
 func promiseExecArguments(source GeneratorWheelSourceBuild, name, operation string, command []string) []string {
 	arguments := []string{"container", "exec", "--user=65532:65532"}
+	if operation == "copy-source" {
+		arguments = append(arguments, "--interactive")
+	}
 	if operation == "build" {
 		arguments = append(arguments, "--workdir", source.CandidateWorkingDirectory)
 	} else {
@@ -169,13 +172,13 @@ func runPromiseContainer(ctx context.Context, inputs promiseInputs, bundle *os.R
 	if _, err := log.execute(runContext, "start", []string{"container", "start", name}, nil, false); err != nil {
 		return receipt, err
 	}
-	if _, err := log.execute(runContext, "copy-source", []string{"container", "cp", "-a", "-", name + ":/work"}, inputs.sourceTar, false); err != nil {
+	if _, err := log.execute(runContext, "copy-source", promiseTransferArguments(inputs.manifest.SourceBuild, name, "copy-source"), inputs.sourceTar, false); err != nil {
 		return receipt, err
 	}
 	if err := executePromiseBuild(runContext, log, inputs.manifest.SourceBuild, name); err != nil {
 		return receipt, err
 	}
-	result, err = log.execute(runContext, "read-wheel", []string{"container", "cp", name + ":/output/.", "-"}, nil, false)
+	result, err = log.execute(runContext, "read-wheel", promiseTransferArguments(inputs.manifest.SourceBuild, name, "read-wheel"), nil, false)
 	if err != nil {
 		return receipt, err
 	}

--- a/tooling/internal/clrsfixture/promise_container.go
+++ b/tooling/internal/clrsfixture/promise_container.go
@@ -236,7 +236,7 @@ func promiseEndpointArguments() []string {
 }
 
 func promiseImageArguments(inputs promiseInputs) []string {
-	format := `{"id":{{json .Id}},"os":{{json .Os}},"architecture":{{json .Architecture}},"digests":{{json .RepoDigests}},"volumes":{{json .Config.Volumes}}}`
+	format := `{"id":{{json .Id}},"os":{{json .Os}},"architecture":{{json .Architecture}},"digests":{{json .RepoDigests}},"volumes":{{json (index .Config "Volumes")}}}`
 	return []string{"image", "inspect", "--platform", inputs.manifest.Platform, "--format", format, inputs.manifest.SourceBuild.BuilderImage}
 }
 

--- a/tooling/internal/clrsfixture/promise_process_linux_test.go
+++ b/tooling/internal/clrsfixture/promise_process_linux_test.go
@@ -1,0 +1,68 @@
+package clrsfixture
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestPromiseProcessGroupCancellation(t *testing.T) {
+	role := os.Getenv("PROMISE_PROCESS_TEST_ROLE")
+	if role == "child" {
+		time.Sleep(5 * time.Second)
+		os.Exit(0)
+	}
+	if role == "leader" {
+		child := exec.Command(os.Args[0], "-test.run=^TestPromiseProcessGroupCancellation$")
+		child.Env = append(os.Environ(), "PROMISE_PROCESS_TEST_ROLE=child")
+		if err := child.Start(); err != nil {
+			os.Exit(2)
+		}
+		fmt.Println(child.Process.Pid)
+		time.Sleep(5 * time.Second)
+		os.Exit(0)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+	command := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestPromiseProcessGroupCancellation$")
+	command.Env = append(os.Environ(), "PROMISE_PROCESS_TEST_ROLE=leader")
+	var output bytes.Buffer
+	command.Stdout = &output
+	command.WaitDelay = time.Second
+	cleanup, err := configurePromiseProcess(command)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := command.Run(); err == nil {
+		t.Fatal("process did not cancel")
+	}
+	if err := cleanup(); err != nil {
+		t.Fatal(err)
+	}
+	childPID, err := strconv.Atoi(strings.TrimSpace(output.String()))
+	if err != nil {
+		t.Fatalf("missing descendant identity: %q %v", output.String(), err)
+	}
+	for attempt := 0; attempt < 20; attempt++ {
+		if err := syscall.Kill(childPID, 0); err == syscall.ESRCH {
+			return
+		}
+		body, readErr := os.ReadFile(fmt.Sprintf("/proc/%d/stat", childPID))
+		if os.IsNotExist(readErr) {
+			return
+		}
+		_, state, found := strings.Cut(string(body), ") ")
+		if found && strings.HasPrefix(state, "Z ") {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("descendant still executing after process-group cancellation")
+}

--- a/tooling/internal/clrsfixture/promise_process_unix.go
+++ b/tooling/internal/clrsfixture/promise_process_unix.go
@@ -1,0 +1,26 @@
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+package clrsfixture
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+func configurePromiseProcess(command *exec.Cmd) (func() error, error) {
+	command.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cleanup := func() error {
+		if command.Process == nil {
+			return nil
+		}
+		err := syscall.Kill(-command.Process.Pid, syscall.SIGKILL)
+		if errors.Is(err, syscall.ESRCH) || errors.Is(err, os.ErrProcessDone) {
+			return nil
+		}
+		return err
+	}
+	command.Cancel = cleanup
+	return cleanup, nil
+}

--- a/tooling/internal/clrsfixture/promise_process_unsupported.go
+++ b/tooling/internal/clrsfixture/promise_process_unsupported.go
@@ -1,0 +1,12 @@
+//go:build !aix && !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !solaris
+
+package clrsfixture
+
+import (
+	"errors"
+	"os/exec"
+)
+
+func configurePromiseProcess(_ *exec.Cmd) (func() error, error) {
+	return nil, errors.New("Promise execution needs Unix process-group cleanup; receipt checking remains portable")
+}

--- a/tooling/internal/clrsfixture/promise_receipt.go
+++ b/tooling/internal/clrsfixture/promise_receipt.go
@@ -1,0 +1,297 @@
+package clrsfixture
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/lusoris/20-watts-was-enough/tooling/internal/buildinfo"
+)
+
+type promiseFileIdentity struct {
+	Path      string `json:"path"`
+	SHA256    string `json:"sha256"`
+	SizeBytes int64  `json:"size_bytes"`
+}
+
+type promiseProducer struct {
+	Build               buildinfo.Info `json:"build"`
+	ExecutableSHA256    string         `json:"executable_sha256"`
+	ExecutableSizeBytes int64          `json:"executable_size_bytes"`
+}
+
+type promiseProcedure struct {
+	Version               string                    `json:"version"`
+	Sources               []promiseFileIdentity     `json:"sources"`
+	Platform              string                    `json:"platform"`
+	Image                 string                    `json:"image"`
+	User                  string                    `json:"user"`
+	RunTimeoutSeconds     int                       `json:"run_timeout_seconds"`
+	CleanupTimeoutSeconds int                       `json:"cleanup_timeout_seconds"`
+	CPUs                  int                       `json:"cpus"`
+	MemoryBytes           int64                     `json:"memory_bytes"`
+	PIDs                  int                       `json:"pids"`
+	CapturedOutputBytes   int64                     `json:"captured_output_bytes"`
+	OutputTarBytes        int64                     `json:"output_tar_bytes"`
+	Tmpfs                 []string                  `json:"tmpfs"`
+	Environment           []string                  `json:"environment"`
+	SourceBuild           GeneratorWheelSourceBuild `json:"source_build"`
+}
+
+type promiseRunReceipt struct {
+	Index              int                 `json:"index"`
+	Name               string              `json:"container_name"`
+	ContainerID        string              `json:"container_id"`
+	ImageID            string              `json:"image_id"`
+	SourceTarSHA256    string              `json:"source_tar_sha256"`
+	SourceTarSizeBytes int64               `json:"source_tar_size_bytes"`
+	CleanupVerified    bool                `json:"container_absence_verified"`
+	StagingRemoved     bool                `json:"staging_removed"`
+	Wheel              promiseFileIdentity `json:"wheel"`
+	LicenseSHA256      string              `json:"license_sha256"`
+	Log                promiseFileIdentity `json:"log"`
+}
+
+type promiseReceipt struct {
+	SchemaVersion       int                 `json:"schema_version"`
+	Authority           string              `json:"authority"`
+	State               string              `json:"state"`
+	GeneratorImageState string              `json:"generator_image_state"`
+	WheelhouseSHA256    string              `json:"wheelhouse_sha256"`
+	ImageContractSHA256 string              `json:"image_contract_sha256"`
+	Procedure           promiseProcedure    `json:"procedure"`
+	Producer            promiseProducer     `json:"producer"`
+	Runs                []promiseRunReceipt `json:"runs"`
+}
+
+var promiseProcedurePaths = []string{
+	"tooling/cmd/20w/clrs_promise.go",
+	"tooling/cmd/20w/main.go",
+	"tooling/go.mod",
+	"tooling/go.sum",
+	"tooling/internal/buildinfo/buildinfo.go",
+	"tooling/internal/pdfrenderlock/lock.go",
+	"tooling/internal/strictjson/validate.go",
+}
+
+func currentPromiseProcedure(root string, inputs promiseInputs) (promiseProcedure, error) {
+	procedure := promiseProcedure{
+		Version: promiseProcedureVersion, Platform: inputs.manifest.Platform,
+		Image: inputs.manifest.SourceBuild.BuilderImage, User: "65532:65532",
+		RunTimeoutSeconds: 120, CleanupTimeoutSeconds: 30, CPUs: 1, MemoryBytes: 1 << 30, PIDs: 64,
+		CapturedOutputBytes: promiseMaximumRunOutputBytes, OutputTarBytes: promiseMaximumOutputTarBytes,
+		Tmpfs: promiseTmpfs(), Environment: promiseEnvironment(inputs.manifest.SourceBuild),
+		SourceBuild: inputs.manifest.SourceBuild,
+	}
+	root, err := cleanGeneratorRoot(root)
+	if err != nil {
+		return promiseProcedure{}, err
+	}
+	paths, err := promiseSourcePaths(root)
+	if err != nil {
+		return promiseProcedure{}, err
+	}
+	for _, path := range paths {
+		body, err := readGeneratorFile(root, path, 128<<10)
+		if err != nil {
+			return promiseProcedure{}, err
+		}
+		procedure.Sources = append(procedure.Sources, promiseIdentity(path, body))
+	}
+	return procedure, nil
+}
+
+func promiseSourcePaths(root string) ([]string, error) {
+	directory := filepath.Join(root, "tooling/internal/clrsfixture")
+	if err := rejectGeneratorSymlink(root, directory); err != nil {
+		return nil, err
+	}
+	file, err := os.Open(directory)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	entries, err := file.ReadDir(129)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return nil, err
+	}
+	if len(entries) > 128 {
+		return nil, errors.New("Promise procedure source directory exceeds its entry limit")
+	}
+	paths := append([]string(nil), promiseProcedurePaths...)
+	for _, entry := range entries {
+		if !strings.HasSuffix(entry.Name(), ".go") || strings.HasSuffix(entry.Name(), "_test.go") {
+			continue
+		}
+		paths = append(paths, "tooling/internal/clrsfixture/"+entry.Name())
+	}
+	sort.Strings(paths)
+	return paths, nil
+}
+
+func currentPromiseProducer() (promiseProducer, error) {
+	path, err := os.Executable()
+	if err != nil {
+		return promiseProducer{}, err
+	}
+	path, err = filepath.EvalSymlinks(path)
+	if err != nil {
+		return promiseProducer{}, err
+	}
+	body, err := readGeneratorFile(filepath.Dir(path), filepath.Base(path), 128<<20)
+	if err != nil {
+		return promiseProducer{}, fmt.Errorf("read Promise producer executable: %w", err)
+	}
+	return promiseProducer{buildinfo.Current(), rawSHA256(body), int64(len(body))}, nil
+}
+
+func promiseIdentity(path string, body []byte) promiseFileIdentity {
+	return promiseFileIdentity{path, rawSHA256(body), int64(len(body))}
+}
+
+func marshalPromiseJSON(value any) ([]byte, error) {
+	var output bytes.Buffer
+	encoder := json.NewEncoder(&output)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(value); err != nil {
+		return nil, err
+	}
+	return output.Bytes(), nil
+}
+
+// CheckPromiseWheelReproduction consumes the actual two-wheel evidence bundle
+// without subprocesses or writes. This is not an image-admission check.
+func CheckPromiseWheelReproduction(repositoryRoot, directory string) error {
+	inputs, err := loadPromiseAuthority(repositoryRoot)
+	if err != nil {
+		return err
+	}
+	procedure, err := currentPromiseProcedure(repositoryRoot, inputs)
+	if err != nil {
+		return err
+	}
+	directory, err = cleanGeneratorRoot(directory)
+	if err != nil {
+		return err
+	}
+	body, err := readGeneratorFile(directory, "receipt.json", promiseMaximumReceiptBytes)
+	if err != nil {
+		return err
+	}
+	var receipt promiseReceipt
+	if err := decodeCanonicalGeneratorJSON(body, 12, &receipt); err != nil {
+		return fmt.Errorf("parse Promise reproduction receipt: %w", err)
+	}
+	if err := validatePromiseReceipt(receipt, inputs, procedure); err != nil {
+		return err
+	}
+	if err := checkPromiseBundleEntries(directory); err != nil {
+		return err
+	}
+	for _, run := range receipt.Runs {
+		if err := checkPromiseRunFiles(directory, run, procedure); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func checkPromiseBundleEntries(directory string) error {
+	for _, scope := range []struct {
+		path  string
+		names []string
+	}{
+		{".", []string{"receipt.json", "run-1", "run-2"}},
+		{"run-1", []string{"commands.json", promiseWheelFilename}},
+		{"run-2", []string{"commands.json", promiseWheelFilename}},
+	} {
+		path := filepath.Join(directory, scope.path)
+		if err := rejectGeneratorSymlink(directory, path); err != nil {
+			return err
+		}
+		file, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		entries, readErr := file.ReadDir(len(scope.names) + 1)
+		closeErr := file.Close()
+		if (readErr != nil && !errors.Is(readErr, io.EOF)) || closeErr != nil || len(entries) != len(scope.names) {
+			return errors.New("Promise evidence bundle contains missing or unexpected entries")
+		}
+		names := make([]string, 0, len(entries))
+		for _, entry := range entries {
+			names = append(names, entry.Name())
+		}
+		sort.Strings(names)
+		sort.Strings(scope.names)
+		if !reflect.DeepEqual(names, scope.names) {
+			return errors.New("Promise evidence bundle entry set differs from its contract")
+		}
+	}
+	return nil
+}
+
+func validatePromiseReceipt(receipt promiseReceipt, inputs promiseInputs, procedure promiseProcedure) error {
+	if receipt.SchemaVersion != 1 || receipt.Authority != ResultAuthority ||
+		receipt.State != "two-build-byte-match" || receipt.GeneratorImageState != "blocked" ||
+		receipt.WheelhouseSHA256 != inputs.manifestSHA256 ||
+		receipt.ImageContractSHA256 != inputs.imageContractSHA256 ||
+		!reflect.DeepEqual(receipt.Procedure, procedure) || len(receipt.Runs) != 2 {
+		return errors.New("Promise receipt authority, procedure sources, or two-run coverage is stale or invalid")
+	}
+	producer := receipt.Producer
+	if !lowerHex(producer.ExecutableSHA256, 64) || producer.ExecutableSizeBytes < 1 ||
+		producer.ExecutableSizeBytes > 128<<20 || producer.Build.GoVersion == "" ||
+		producer.Build.OperatingSys == "" || producer.Build.Architecture == "" ||
+		producer.Build.Version == "" || producer.Build.Revision == "" || producer.Build.BuiltAt == "" {
+		return errors.New("Promise receipt producer build identity is invalid")
+	}
+	for index, run := range receipt.Runs {
+		if err := validatePromiseRunReceipt(index+1, run); err != nil {
+			return err
+		}
+	}
+	first, second := receipt.Runs[0], receipt.Runs[1]
+	if first.Name == second.Name || first.ContainerID == second.ContainerID || first.ImageID != second.ImageID ||
+		first.SourceTarSHA256 != second.SourceTarSHA256 || first.SourceTarSizeBytes != second.SourceTarSizeBytes {
+		return errors.New("Promise receipt does not identify two separate clean runs of the same inputs")
+	}
+	return nil
+}
+
+func validatePromiseRunReceipt(index int, run promiseRunReceipt) error {
+	prefix := fmt.Sprintf("run-%d/", index)
+	if run.Index != index || !validPromiseContainerName(run.Name) || !lowerHex(run.ContainerID, 64) ||
+		!strings.HasPrefix(run.ImageID, "sha256:") || !lowerHex(strings.TrimPrefix(run.ImageID, "sha256:"), 64) ||
+		run.SourceTarSHA256 != promiseCanonicalTarSHA256 || run.SourceTarSizeBytes != promiseCanonicalTarSize ||
+		!run.CleanupVerified || !run.StagingRemoved ||
+		run.Wheel != (promiseFileIdentity{prefix + promiseWheelFilename, promiseWheelSHA256, promiseWheelSize}) ||
+		run.LicenseSHA256 != promiseLicenseSHA256 || run.Log.Path != prefix+"commands.json" ||
+		!lowerHex(run.Log.SHA256, 64) || run.Log.SizeBytes < 1 || run.Log.SizeBytes > 2<<20 {
+		return fmt.Errorf("Promise run %d receipt is invalid or incomplete", index)
+	}
+	return nil
+}
+
+func checkPromiseRunFiles(directory string, run promiseRunReceipt, procedure promiseProcedure) error {
+	wheel, err := readPromisePinnedFile(directory, run.Wheel.Path, run.Wheel.SHA256, run.Wheel.SizeBytes)
+	if err != nil {
+		return err
+	}
+	if err := verifyPromiseWheel(wheel); err != nil {
+		return err
+	}
+	body, err := readPromisePinnedFile(directory, run.Log.Path, run.Log.SHA256, run.Log.SizeBytes)
+	if err != nil {
+		return err
+	}
+	return validatePromiseCommandLog(body, run, procedure)
+}

--- a/tooling/internal/clrsfixture/promise_receipt_test.go
+++ b/tooling/internal/clrsfixture/promise_receipt_test.go
@@ -3,11 +3,13 @@ package clrsfixture
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
+	"text/template"
 
 	"github.com/lusoris/20-watts-was-enough/tooling/internal/buildinfo"
 )
@@ -265,6 +267,39 @@ func TestPromiseRetainedFourInputsFailBeforeEffectsWhenTampered(t *testing.T) {
 			}
 			if _, err := os.Stat(output); !os.IsNotExist(err) {
 				t.Fatalf("output created before preflight: %v", err)
+			}
+		})
+	}
+}
+
+func TestPromiseRuntimeTemplateHandlesOmittedEmptyVolumes(t *testing.T) {
+	inputs := promiseLifecycleInputs(t)
+	arguments := promiseImageArguments(inputs)
+	format := arguments[slices.Index(arguments, "--format")+1]
+	formatter, err := template.New("inspect").Option("missingkey=error").Funcs(template.FuncMap{
+		"json": func(value any) (string, error) {
+			body, err := json.Marshal(value)
+			return string(body), err
+		},
+	}).Parse(format)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, digest, _ := strings.Cut(inputs.manifest.SourceBuild.BuilderImage, "@")
+	for name, config := range map[string]map[string]any{
+		"omitted":  {},
+		"empty":    {"Volumes": map[string]any{}},
+		"nonempty": {"Volumes": map[string]any{"/data": map[string]any{}}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			identity := map[string]any{"Id": "sha256:" + strings.Repeat("a", 64), "Os": "linux", "Architecture": "amd64", "RepoDigests": []string{"python@" + digest}, "Config": config}
+			var output bytes.Buffer
+			if err := formatter.Execute(&output, identity); err != nil {
+				t.Fatal(err)
+			}
+			_, err := parsePromiseRuntime(promiseDockerResult{stdout: output.Bytes()}, inputs.manifest.SourceBuild.BuilderImage)
+			if (err != nil) != (name == "nonempty") {
+				t.Fatalf("runtime volumes %s: %v", name, err)
 			}
 		})
 	}

--- a/tooling/internal/clrsfixture/promise_receipt_test.go
+++ b/tooling/internal/clrsfixture/promise_receipt_test.go
@@ -1,0 +1,271 @@
+package clrsfixture
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/lusoris/20-watts-was-enough/tooling/internal/buildinfo"
+)
+
+func promiseReceiptFixture(t *testing.T) (promiseInputs, promiseReceipt) {
+	t.Helper()
+	inputs := promiseLifecycleInputs(t)
+	procedure, err := currentPromiseProcedure(trackedRepositoryRoot(t), inputs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	inputs.procedure = procedure
+	receipt := promiseReceipt{
+		SchemaVersion: 1, Authority: ResultAuthority, State: "two-build-byte-match", GeneratorImageState: "blocked",
+		WheelhouseSHA256: inputs.manifestSHA256, ImageContractSHA256: inputs.imageContractSHA256, Procedure: procedure,
+		Producer: promiseProducer{buildinfo.Current(), strings.Repeat("a", 64), 1024},
+	}
+	for index, digit := range []string{"1", "2"} {
+		prefix := "run-" + digit + "/"
+		receipt.Runs = append(receipt.Runs, promiseRunReceipt{
+			Index: index + 1, Name: "20w-promise-" + strings.Repeat(digit, 32), ContainerID: strings.Repeat(digit, 64),
+			ImageID: "sha256:" + strings.Repeat("a", 64), SourceTarSHA256: promiseCanonicalTarSHA256, SourceTarSizeBytes: promiseCanonicalTarSize,
+			CleanupVerified: true, StagingRemoved: true, Wheel: promiseFileIdentity{prefix + promiseWheelFilename, promiseWheelSHA256, promiseWheelSize},
+			LicenseSHA256: promiseLicenseSHA256, Log: promiseFileIdentity{prefix + "commands.json", strings.Repeat("a", 64), 100},
+		})
+	}
+	return inputs, receipt
+}
+
+func TestPromiseReceiptRejectsAuthorityAndCoverageChanges(t *testing.T) {
+	inputs, valid := promiseReceiptFixture(t)
+	if err := validatePromiseReceipt(valid, inputs, inputs.procedure); err != nil {
+		t.Fatal(err)
+	}
+	for name, mutate := range map[string]func(*promiseReceipt){
+		"version":         func(r *promiseReceipt) { r.SchemaVersion++ },
+		"authority":       func(r *promiseReceipt) { r.Authority = "RESULT" },
+		"admission":       func(r *promiseReceipt) { r.GeneratorImageState = "admitted" },
+		"wheelhouse":      func(r *promiseReceipt) { r.WheelhouseSHA256 = strings.Repeat("0", 64) },
+		"procedure":       func(r *promiseReceipt) { r.Procedure.Version = "other" },
+		"missing run":     func(r *promiseReceipt) { r.Runs = r.Runs[:1] },
+		"same container":  func(r *promiseReceipt) { r.Runs[1].ContainerID = r.Runs[0].ContainerID },
+		"same name":       func(r *promiseReceipt) { r.Runs[1].Name = r.Runs[0].Name },
+		"cleanup":         func(r *promiseReceipt) { r.Runs[0].CleanupVerified = false },
+		"staging":         func(r *promiseReceipt) { r.Runs[0].StagingRemoved = false },
+		"source transfer": func(r *promiseReceipt) { r.Runs[0].SourceTarSHA256 = strings.Repeat("0", 64) },
+		"license":         func(r *promiseReceipt) { r.Runs[0].LicenseSHA256 = strings.Repeat("0", 64) },
+		"wheel":           func(r *promiseReceipt) { r.Runs[0].Wheel.SizeBytes++ },
+		"producer":        func(r *promiseReceipt) { r.Producer.ExecutableSHA256 = "" },
+	} {
+		t.Run(name, func(t *testing.T) {
+			candidate := valid
+			candidate.Runs = slices.Clone(valid.Runs)
+			mutate(&candidate)
+			if err := validatePromiseReceipt(candidate, inputs, inputs.procedure); err == nil {
+				t.Fatal("accepted changed receipt")
+			}
+		})
+	}
+}
+
+func TestPromiseReceiptRejectsMalformedJSONBeforeFiles(t *testing.T) {
+	_, receipt := promiseReceiptFixture(t)
+	valid, err := marshalPromiseJSON(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, body := range map[string][]byte{
+		"duplicate":    bytes.Replace(valid, []byte("  \"schema_version\": 1,"), []byte("  \"schema_version\": 1,\n  \"schema_version\": 1,"), 1),
+		"unknown":      bytes.Replace(valid, []byte("{\n"), []byte("{\n  \"unknown\": true,\n"), 1),
+		"trailing":     append(bytes.Clone(valid), []byte("{}")...),
+		"noncanonical": bytes.Replace(valid, []byte("  \"schema_version\""), []byte(" \"schema_version\""), 1),
+	} {
+		t.Run(name, func(t *testing.T) {
+			bundle := t.TempDir()
+			if err := os.WriteFile(filepath.Join(bundle, "receipt.json"), body, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if err := CheckPromiseWheelReproduction(trackedRepositoryRoot(t), bundle); err == nil || !strings.Contains(err.Error(), "parse Promise") {
+				t.Fatalf("malformed receipt: %v", err)
+			}
+		})
+	}
+}
+
+func TestPromiseReceiptDetectsInvokedHelperSourceDrift(t *testing.T) {
+	inputs, receipt := promiseReceiptFixture(t)
+	root := copyGeneratorFoundation(t)
+	for _, identity := range receipt.Procedure.Sources {
+		body, err := os.ReadFile(filepath.Join(trackedRepositoryRoot(t), identity.Path))
+		if err != nil {
+			t.Fatal(err)
+		}
+		target := filepath.Join(root, identity.Path)
+		if err := os.MkdirAll(filepath.Dir(target), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(target, body, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := recheckPromiseAuthority(root, inputs); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(root, "tooling/internal/clrsfixture/image_files.go")
+	file, err := os.OpenFile(target, os.O_APPEND|os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, writeErr := file.WriteString("\n// test source drift\n")
+	closeErr := file.Close()
+	if writeErr != nil || closeErr != nil {
+		t.Fatal(writeErr, closeErr)
+	}
+	if err := recheckPromiseAuthority(root, inputs); err == nil {
+		t.Fatal("accepted helper changed during reproduction")
+	}
+}
+
+func promiseLogFixture(t *testing.T, inputs promiseInputs, run promiseRunReceipt) []promiseCommandEvidence {
+	t.Helper()
+	wheels := "/retained/evidence/" + run.Name + "/wheelhouse"
+	names := []string{"verify-endpoint", "verify-image", "create", "start", "copy-source", "bootstrap", "install", "build", "read-wheel", "find-owned", "inspect-owner", "remove", "verify-absence"}
+	entries := make([]promiseCommandEvidence, 0, len(names))
+	for _, name := range names {
+		entry := promiseCommandEvidence{Operation: name, StdinSHA256: rawSHA256(nil)}
+		if name == "create" {
+			entry.Arguments = promiseContainerArguments(inputs, run.Name, wheels)
+		}
+		arguments, err := expectedPromiseArguments(entry, run, inputs.procedure)
+		if err != nil {
+			t.Fatal(err)
+		}
+		entry.Arguments = arguments
+		if name == "copy-source" {
+			entry.StdinSHA256 = run.SourceTarSHA256
+			entry.StdinSizeBytes = run.SourceTarSizeBytes
+		}
+		entries = append(entries, entry)
+	}
+	return entries
+}
+
+func TestPromiseReceiptRejectsChangedRequestedArguments(t *testing.T) {
+	inputs, receipt := promiseReceiptFixture(t)
+	for _, operation := range []string{"verify-endpoint", "verify-image", "create", "start", "copy-source", "bootstrap", "install", "build", "read-wheel", "find-owned", "inspect-owner", "remove", "verify-absence"} {
+		t.Run(operation, func(t *testing.T) {
+			entries := promiseLogFixture(t, inputs, receipt.Runs[0])
+			for index := range entries {
+				if entries[index].Operation == operation {
+					entries[index].Arguments = append(slices.Clone(entries[index].Arguments), "--network=host")
+				}
+			}
+			body, err := marshalPromiseJSON(entries)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := validatePromiseCommandLog(body, receipt.Runs[0], inputs.procedure); err == nil || !strings.Contains(err.Error(), "argv differs") {
+				t.Fatalf("changed %s accepted or wrong error: %v", operation, err)
+			}
+		})
+	}
+}
+
+func TestPromiseRetainedInputsExerciseCompleteFakeConsumer(t *testing.T) {
+	directory := os.Getenv("CLRS_PROMISE_TEST_INPUTS")
+	wheelPath := os.Getenv("CLRS_PROMISE_TEST_WHEEL")
+	if directory == "" || wheelPath == "" {
+		t.Skip("explicit retained artifact paths not supplied")
+	}
+	inputs, err := readPromiseInputs(trackedRepositoryRoot(t), directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wheel, err := os.ReadFile(wheelPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := verifyPromiseWheel(wheel); err != nil {
+		t.Fatal(err)
+	}
+	output := promiseTestTar(t, []promiseTestTarMember{promiseTestFile(promiseWheelFilename, wheel)})
+	fake := &promiseFakeDocker{inputs: inputs, output: output}
+	bundle := filepath.Join(t.TempDir(), "new-evidence")
+	if err := reproducePromiseWheel(context.Background(), trackedRepositoryRoot(t), directory, bundle, fake); err != nil {
+		t.Fatal(err)
+	}
+	if err := CheckPromiseWheelReproduction(trackedRepositoryRoot(t), bundle); err != nil {
+		t.Fatal(err)
+	}
+	if fake.created != 2 || fake.present {
+		t.Fatalf("runs=%d present=%v", fake.created, fake.present)
+	}
+	target := filepath.Join(bundle, "run-2", promiseWheelFilename)
+	if err := os.Chmod(target, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	wheel[0] ^= 1
+	if err := os.WriteFile(target, wheel, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := CheckPromiseWheelReproduction(trackedRepositoryRoot(t), bundle); err == nil {
+		t.Fatal("accepted tampered reproduced wheel")
+	}
+}
+
+func TestPromiseRetainedFourInputsFailBeforeEffectsWhenTampered(t *testing.T) {
+	directory := os.Getenv("CLRS_PROMISE_TEST_INPUTS")
+	if directory == "" {
+		t.Skip("explicit retained artifact path not supplied")
+	}
+	inputs := promiseLifecycleInputs(t)
+	paths := []string{"source-build-inputs/promise-2.3.tar.gz"}
+	for _, wheel := range inputs.manifest.SourceBuild.BuildRequirements {
+		paths = append(paths, "build-tools/"+wheel.Filename)
+	}
+	copyRoot := t.TempDir()
+	for _, path := range paths {
+		body, err := readGeneratorFile(directory, path, 1<<20)
+		if err != nil {
+			t.Fatal(err)
+		}
+		target := filepath.Join(copyRoot, path)
+		if err := os.MkdirAll(filepath.Dir(target), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(target, body, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, path := range paths {
+		t.Run(path, func(t *testing.T) {
+			target := filepath.Join(copyRoot, path)
+			original, err := os.ReadFile(target)
+			if err != nil {
+				t.Fatal(err)
+			}
+			tampered := bytes.Clone(original)
+			tampered[0] ^= 1
+			if err := os.WriteFile(target, tampered, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() {
+				if err := os.WriteFile(target, original, 0o600); err != nil {
+					t.Error(err)
+				}
+			})
+			fake := &promiseFakeDocker{}
+			output := filepath.Join(t.TempDir(), "new")
+			if err := reproducePromiseWheel(context.Background(), trackedRepositoryRoot(t), copyRoot, output, fake); err == nil {
+				t.Fatal("accepted tampered input")
+			}
+			if len(fake.calls) != 0 {
+				t.Fatal("Docker called before complete input verification")
+			}
+			if _, err := os.Stat(output); !os.IsNotExist(err) {
+				t.Fatalf("output created before preflight: %v", err)
+			}
+		})
+	}
+}

--- a/tooling/internal/clrsfixture/promise_reproduce.go
+++ b/tooling/internal/clrsfixture/promise_reproduce.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	promiseProcedureVersion      = "promise-wheel-reproduction-v1"
+	promiseProcedureVersion      = "promise-wheel-reproduction-v2"
 	promiseMaximumReceiptBytes   = int64(64 << 10)
 	promiseMaximumRunOutputBytes = int64(1 << 20)
 	promiseMaximumOutputTarBytes = int64(128 << 10)

--- a/tooling/internal/clrsfixture/promise_reproduce.go
+++ b/tooling/internal/clrsfixture/promise_reproduce.go
@@ -1,0 +1,224 @@
+package clrsfixture
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	promiseProcedureVersion      = "promise-wheel-reproduction-v1"
+	promiseMaximumReceiptBytes   = int64(64 << 10)
+	promiseMaximumRunOutputBytes = int64(1 << 20)
+	promiseMaximumOutputTarBytes = int64(128 << 10)
+	promiseCanonicalTarSHA256    = "460b0ce320c4da18784e97b99839a0ba74fa19e26e11320fc44037c791e38fe4"
+	promiseCanonicalTarSize      = int64(108032)
+)
+
+type promiseInputs struct {
+	manifest            GeneratorWheelhouseManifest
+	manifestSHA256      string
+	imageContractSHA256 string
+	sourceTar           []byte
+	wheels              [][]byte
+	procedure           promiseProcedure
+	producer            promiseProducer
+}
+
+// ReproducePromiseWheel builds the one locked source-built dependency twice.
+// It never acquires inputs, publishes an image, or changes admission authority.
+// A failure leaves its bounded diagnostic bundle without a success receipt.
+func ReproducePromiseWheel(ctx context.Context, repositoryRoot, inputsDirectory, outputDirectory string) error {
+	return reproducePromiseWheel(ctx, repositoryRoot, inputsDirectory, outputDirectory, localPromiseDocker{})
+}
+
+func reproducePromiseWheel(ctx context.Context, root, inputDirectory, output string, docker promiseDocker) error {
+	inputs, err := readPromiseInputs(root, inputDirectory)
+	if err != nil {
+		return err
+	}
+	inputs.procedure, err = currentPromiseProcedure(root, inputs)
+	if err != nil {
+		return err
+	}
+	inputs.producer, err = currentPromiseProducer()
+	if err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	bundle, err := newPromiseBundle(output, inputDirectory)
+	if err != nil {
+		return err
+	}
+	defer bundle.Close()
+	err = runPromiseReproductions(ctx, root, inputs, bundle, docker)
+	if err != nil {
+		failure := struct {
+			SchemaVersion int    `json:"schema_version"`
+			Authority     string `json:"authority"`
+			State         string `json:"state"`
+			Error         string `json:"error"`
+		}{1, ResultAuthority, "incomplete", boundedPromiseError(err)}
+		body, encodeErr := marshalPromiseJSON(failure)
+		if encodeErr == nil {
+			encodeErr = writePromiseFile(bundle, "failure.json", body)
+		}
+		return errors.Join(err, encodeErr)
+	}
+	return nil
+}
+
+func loadPromiseAuthority(root string) (promiseInputs, error) {
+	foundation, err := CheckGeneratorImageFoundation(root)
+	if err != nil {
+		return promiseInputs{}, err
+	}
+	input, contract, lock, err := loadGeneratorWheelhouseInputs(root)
+	if err != nil {
+		return promiseInputs{}, err
+	}
+	root, err = cleanGeneratorRoot(root)
+	if err != nil {
+		return promiseInputs{}, err
+	}
+	body, err := readGeneratorFile(root, trackedGeneratorWheelhousePath, contract.Limits.WheelhouseManifestBytes)
+	if err != nil {
+		return promiseInputs{}, err
+	}
+	manifest, err := ParseGeneratorWheelhouseManifest(body, lock, input, contract)
+	if err != nil {
+		return promiseInputs{}, err
+	}
+	return promiseInputs{
+		manifest: manifest, manifestSHA256: rawSHA256(body),
+		imageContractSHA256: foundation.ImageContractSHA256,
+	}, nil
+}
+
+func readPromiseInputs(root, directory string) (promiseInputs, error) {
+	inputs, err := loadPromiseAuthority(root)
+	if err != nil {
+		return promiseInputs{}, err
+	}
+	directory, err = cleanGeneratorRoot(directory)
+	if err != nil {
+		return promiseInputs{}, fmt.Errorf("Promise input directory: %w", err)
+	}
+	source := inputs.manifest.SourceBuild
+	body, err := readPromisePinnedFile(directory, "source-build-inputs/promise-2.3.tar.gz", source.SourceSHA256, source.SourceSizeBytes)
+	if err != nil {
+		return promiseInputs{}, err
+	}
+	for _, wheel := range source.BuildRequirements {
+		wheelBody, err := readPromisePinnedFile(directory, "build-tools/"+wheel.Filename, wheel.SHA256, wheel.SizeBytes)
+		if err != nil {
+			return promiseInputs{}, err
+		}
+		inputs.wheels = append(inputs.wheels, wheelBody)
+	}
+	inputs.sourceTar, err = preparePromiseSource(body, source)
+	if err != nil {
+		return promiseInputs{}, fmt.Errorf("prepare Promise source: %w", err)
+	}
+	if rawSHA256(inputs.sourceTar) != promiseCanonicalTarSHA256 || int64(len(inputs.sourceTar)) != promiseCanonicalTarSize {
+		return promiseInputs{}, errors.New("Promise canonical source transfer differs from the frozen preparation identity")
+	}
+	return inputs, nil
+}
+
+func readPromisePinnedFile(root, relative, digest string, size int64) ([]byte, error) {
+	body, err := readGeneratorFile(root, relative, size)
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(body)) != size || rawSHA256(body) != digest {
+		return nil, fmt.Errorf("Promise input %s differs from its locked size or SHA-256", relative)
+	}
+	return body, nil
+}
+
+func newPromiseBundle(output, inputDirectory string) (*os.Root, error) {
+	if output == "" {
+		return nil, errors.New("Promise output directory is required")
+	}
+	absolute, err := filepath.Abs(output)
+	if err != nil {
+		return nil, err
+	}
+	parent, err := cleanGeneratorRoot(filepath.Dir(absolute))
+	if err != nil || strings.ContainsAny(parent, ",\r\n") {
+		return nil, errors.New("Promise output parent must be an existing real directory without mount separators")
+	}
+	input, err := cleanGeneratorRoot(inputDirectory)
+	if err != nil {
+		return nil, err
+	}
+	if relative, err := filepath.Rel(input, absolute); err == nil && (relative == "." ||
+		(relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator)))) {
+		return nil, errors.New("Promise output must be outside the retained input directory")
+	}
+	parentRoot, err := os.OpenRoot(parent)
+	if err != nil {
+		return nil, err
+	}
+	defer parentRoot.Close()
+	name := filepath.Base(absolute)
+	if err := parentRoot.Mkdir(name, 0o700); err != nil {
+		return nil, fmt.Errorf("create new Promise output directory: %w", err)
+	}
+	return parentRoot.OpenRoot(name)
+}
+
+func writePromiseFile(root *os.Root, name string, body []byte) error {
+	if err := checkPromiseRootName(root); err != nil {
+		return err
+	}
+	file, err := root.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return fmt.Errorf("create Promise evidence %s: %w", name, err)
+	}
+	defer file.Close()
+	if _, err := file.Write(body); err != nil {
+		return err
+	}
+	if err := file.Sync(); err != nil {
+		return err
+	}
+	if err := file.Chmod(0o444); err != nil {
+		return err
+	}
+	if err := file.Close(); err != nil {
+		return err
+	}
+	written, err := readGeneratorFile(root.Name(), name, int64(len(body)))
+	if err != nil || !bytes.Equal(body, written) {
+		return fmt.Errorf("Promise evidence %s readback differs", name)
+	}
+	return checkPromiseRootName(root)
+}
+
+func checkPromiseRootName(root *os.Root) error {
+	held, err := root.Stat(".")
+	if err != nil {
+		return err
+	}
+	named, err := os.Lstat(root.Name())
+	if err != nil || !named.IsDir() || named.Mode()&os.ModeSymlink != 0 || !os.SameFile(held, named) {
+		return errors.New("Promise directory name no longer identifies the held root")
+	}
+	return nil
+}
+
+func boundedPromiseError(err error) string {
+	message := err.Error()
+	if len(message) > 4096 {
+		return message[:4096] + " [diagnostic limit]"
+	}
+	return message
+}

--- a/tooling/internal/clrsfixture/promise_reproduce_test.go
+++ b/tooling/internal/clrsfixture/promise_reproduce_test.go
@@ -1,0 +1,287 @@
+package clrsfixture
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+type promiseFakeDocker struct {
+	inputs          promiseInputs
+	calls           []promiseDockerRequest
+	name            string
+	id              string
+	created         int
+	present         bool
+	fail            string
+	malformedCreate bool
+	createStderr    bool
+	wrongOwner      bool
+	remains         bool
+	output          []byte
+	cancel          context.CancelFunc
+	cleanupCanceled bool
+	deadlines       []time.Time
+}
+
+func (fake *promiseFakeDocker) run(ctx context.Context, request promiseDockerRequest) (promiseDockerResult, error) {
+	fake.calls = append(fake.calls, request)
+	if deadline, ok := ctx.Deadline(); ok && request.operation != "find-owned" && request.operation != "inspect-owner" &&
+		request.operation != "remove" && request.operation != "verify-absence" {
+		fake.deadlines = append(fake.deadlines, deadline)
+	}
+	if slices.Contains([]string{"find-owned", "inspect-owner", "remove", "verify-absence"}, request.operation) && ctx.Err() != nil {
+		fake.cleanupCanceled = true
+	}
+	if request.operation == "create" {
+		fake.name = request.arguments[slices.Index(request.arguments, "--name")+1]
+		fake.created++
+		fake.id = fmt.Sprintf("%064x", fake.created)
+		fake.present = true
+	}
+	if request.operation == fake.fail {
+		if fake.cancel != nil {
+			fake.cancel()
+		}
+		return promiseDockerResult{stderr: []byte("retained injected failure")}, errors.New("injected " + fake.fail)
+	}
+	textResult := func(value string) (promiseDockerResult, error) {
+		return promiseDockerResult{stdout: []byte(value)}, nil
+	}
+	switch request.operation {
+	case "verify-endpoint":
+		return textResult("\"unix:///var/run/docker.sock\"\n")
+	case "verify-image":
+		image := fake.inputs.manifest.SourceBuild.BuilderImage
+		_, digest, _ := strings.Cut(image, "@")
+		return textResult(fmt.Sprintf(`{"id":"sha256:%s","os":"linux","architecture":"amd64","digests":["python@%s"],"volumes":null}`, strings.Repeat("a", 64), digest))
+	case "create":
+		if fake.malformedCreate {
+			return textResult(fake.id + "\nunexpected\n")
+		}
+		if fake.createStderr {
+			return promiseDockerResult{stdout: []byte(fake.id + "\n"), stderr: []byte("unexpected")}, nil
+		}
+		return textResult(fake.id + "\n")
+	case "start":
+		return textResult(fake.name + "\n")
+	case "read-wheel":
+		return promiseDockerResult{stdout: fake.output}, nil
+	case "find-owned", "verify-absence":
+		if fake.present {
+			return textResult(fake.id + "\n")
+		}
+		return textResult("")
+	case "inspect-owner":
+		owner := fake.name
+		if fake.wrongOwner {
+			owner = "another-workload"
+		}
+		return textResult(fmt.Sprintf(`{"id":%q,"owner":%q}`, fake.id, owner))
+	case "remove":
+		fake.present = fake.remains
+		return textResult(fake.id + "\n")
+	default:
+		return promiseDockerResult{}, nil
+	}
+}
+
+func promiseLifecycleInputs(t *testing.T) promiseInputs {
+	t.Helper()
+	inputs, err := loadPromiseAuthority(trackedRepositoryRoot(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	inputs.sourceTar = []byte("bounded source fixture")
+	for range inputs.manifest.SourceBuild.BuildRequirements {
+		inputs.wheels = append(inputs.wheels, []byte("bounded wheel fixture"))
+	}
+	return inputs
+}
+
+func promiseTestBundle(t *testing.T) *os.Root {
+	t.Helper()
+	root, err := os.OpenRoot(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = root.Close() })
+	return root
+}
+
+func TestPromiseFailedRunsRemoveOwnedResources(t *testing.T) {
+	for _, operation := range []string{"create", "start", "copy-source", "bootstrap", "install", "build", "read-wheel"} {
+		t.Run(operation, func(t *testing.T) {
+			inputs := promiseLifecycleInputs(t)
+			fake := &promiseFakeDocker{inputs: inputs, fail: operation}
+			bundle := promiseTestBundle(t)
+			run, err := runPromiseContainer(context.Background(), inputs, bundle, fake, 1)
+			if err == nil || fake.present || !run.CleanupVerified || !run.StagingRemoved {
+				t.Fatalf("failure cleanup: err=%v present=%v run=%+v", err, fake.present, run)
+			}
+			if _, err := bundle.Stat("receipt.json"); !errors.Is(err, os.ErrNotExist) {
+				t.Fatal("failed run wrote success receipt")
+			}
+			body, err := readGeneratorFile(bundle.Name(), "run-1/commands.json", 2<<20)
+			if err != nil || !bytes.Contains(body, []byte("injected "+operation)) {
+				t.Fatalf("failure evidence not retained: %v", err)
+			}
+			assertPromiseStagingAbsent(t, bundle, run.Name)
+			for _, deadline := range fake.deadlines {
+				if !deadline.Equal(fake.deadlines[0]) {
+					t.Fatal("run deadline was reset per step")
+				}
+			}
+		})
+	}
+}
+
+func TestPromiseAmbiguousCreateStillCleansOwnedContainer(t *testing.T) {
+	for _, stderr := range []bool{false, true} {
+		t.Run(fmt.Sprint(stderr), func(t *testing.T) {
+			inputs := promiseLifecycleInputs(t)
+			fake := &promiseFakeDocker{inputs: inputs, malformedCreate: !stderr, createStderr: stderr}
+			bundle := promiseTestBundle(t)
+			run, err := runPromiseContainer(context.Background(), inputs, bundle, fake, 1)
+			if err == nil || fake.present || !run.CleanupVerified || run.ContainerID != "" {
+				t.Fatalf("ambiguous create: %v %+v present=%v", err, run, fake.present)
+			}
+		})
+	}
+}
+
+func TestPromiseCleanupHasIndependentDeadline(t *testing.T) {
+	inputs := promiseLifecycleInputs(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	fake := &promiseFakeDocker{inputs: inputs, fail: "build", cancel: cancel}
+	run, err := runPromiseContainer(ctx, inputs, promiseTestBundle(t), fake, 1)
+	if err == nil || fake.cleanupCanceled || fake.present || !run.CleanupVerified {
+		t.Fatalf("cancellation cleanup: %v %+v", err, run)
+	}
+}
+
+func TestPromiseCleanupDoesNotRemoveOtherOwnership(t *testing.T) {
+	inputs := promiseLifecycleInputs(t)
+	fake := &promiseFakeDocker{inputs: inputs, fail: "build", wrongOwner: true}
+	run, err := runPromiseContainer(context.Background(), inputs, promiseTestBundle(t), fake, 1)
+	if err == nil || !fake.present || run.CleanupVerified {
+		t.Fatalf("ownership guard: %v %+v", err, run)
+	}
+	for _, request := range fake.calls {
+		if request.operation == "remove" {
+			t.Fatal("removed a container with another owner label")
+		}
+	}
+}
+
+func TestPromiseCleanupFailureNeverReportsSuccess(t *testing.T) {
+	for _, operation := range []string{"find-owned", "inspect-owner", "remove", "verify-absence"} {
+		t.Run(operation, func(t *testing.T) {
+			inputs := promiseLifecycleInputs(t)
+			fake := &promiseFakeDocker{inputs: inputs, fail: operation}
+			run, err := runPromiseContainer(context.Background(), inputs, promiseTestBundle(t), fake, 1)
+			if err == nil || run.CleanupVerified || !run.StagingRemoved {
+				t.Fatalf("cleanup failure: %v %+v", err, run)
+			}
+		})
+	}
+}
+
+func TestPromiseStagingUsesPrivateParentAndReadonlyWheels(t *testing.T) {
+	inputs := promiseLifecycleInputs(t)
+	bundle := promiseTestBundle(t)
+	name := "20w-promise-" + strings.Repeat("1", 32)
+	staging, err := stagePromiseWheels(bundle, name, inputs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for path, want := range map[string]os.FileMode{".": 0o700, "wheelhouse": 0o755, "wheelhouse/" + inputs.manifest.SourceBuild.BuildRequirements[0].Filename: 0o444} {
+		info, err := staging.Stat(path)
+		if err != nil || info.Mode().Perm() != want {
+			t.Fatalf("mode %s: %v %v", path, info, err)
+		}
+	}
+	if err := removePromiseStaging(bundle, name, staging); err != nil {
+		t.Fatal(err)
+	}
+	assertPromiseStagingAbsent(t, bundle, name)
+}
+
+func assertPromiseStagingAbsent(t *testing.T, bundle *os.Root, name string) {
+	t.Helper()
+	if _, err := bundle.Stat(name); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("staging remains: %v", err)
+	}
+}
+
+func TestPromisePreflightRejectsInputBeforeEffects(t *testing.T) {
+	inputs := t.TempDir()
+	if err := os.Mkdir(filepath.Join(inputs, "source-build-inputs"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(inputs, "source-build-inputs/promise-2.3.tar.gz"), []byte("tampered"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fake := &promiseFakeDocker{}
+	output := filepath.Join(t.TempDir(), "evidence")
+	err := reproducePromiseWheel(context.Background(), trackedRepositoryRoot(t), inputs, output, fake)
+	if err == nil || len(fake.calls) != 0 {
+		t.Fatalf("preflight: %v calls=%d", err, len(fake.calls))
+	}
+	if _, err := os.Lstat(output); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("preflight created output: %v", err)
+	}
+}
+
+func TestPromiseBundleRejectsExistingAndInputChild(t *testing.T) {
+	inputs := t.TempDir()
+	for _, output := range []string{inputs, filepath.Join(inputs, "new"), t.TempDir()} {
+		if root, err := newPromiseBundle(output, inputs); err == nil {
+			root.Close()
+			t.Fatalf("accepted %s", output)
+		}
+	}
+}
+
+func TestPromiseReceiptSourceClosureCoversExistingHelpers(t *testing.T) {
+	inputs := promiseLifecycleInputs(t)
+	procedure, err := currentPromiseProcedure(trackedRepositoryRoot(t), inputs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	paths := make([]string, 0, len(procedure.Sources))
+	for _, source := range procedure.Sources {
+		paths = append(paths, source.Path)
+	}
+	for _, path := range []string{"tooling/cmd/20w/main.go", "tooling/internal/clrsfixture/image_files.go", "tooling/internal/clrsfixture/image_wheelhouse.go", "tooling/internal/strictjson/validate.go", "tooling/internal/pdfrenderlock/lock.go", "tooling/internal/buildinfo/buildinfo.go"} {
+		if !slices.Contains(paths, path) {
+			t.Fatalf("missing procedure dependency %s", path)
+		}
+	}
+	second, err := currentPromiseProcedure(trackedRepositoryRoot(t), inputs)
+	if err != nil || !reflect.DeepEqual(procedure, second) {
+		t.Fatalf("procedure identity not stable: %v", err)
+	}
+}
+
+func TestPromiseCaptureSharesAndEnforcesOutputLimit(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	capture := &promiseCapture{remaining: 8, cancel: cancel}
+	stdout := promiseCaptureWriter{capture: capture}
+	stderr := promiseCaptureWriter{capture: capture, stderr: true}
+	_, _ = stdout.Write([]byte("12345"))
+	_, _ = stderr.Write([]byte("abcdef"))
+	if !capture.exceeded || ctx.Err() == nil || capture.stdout.Len()+capture.stderr.Len() != 8 {
+		t.Fatalf("combined output cap not enforced: %+v", capture)
+	}
+}

--- a/tooling/internal/clrsfixture/promise_transfer.go
+++ b/tooling/internal/clrsfixture/promise_transfer.go
@@ -1,0 +1,69 @@
+package clrsfixture
+
+import "fmt"
+
+// These fixed Python snippets access the running container's tmpfs. Docker's
+// archive API uses a separate filesystem view. Go owns archive validation,
+// canonicalization, command limits, exact output checks, and orchestration.
+func promiseMaterializer() string {
+	return fmt.Sprintf(`import hashlib, io, os, sys, tarfile
+body = sys.stdin.buffer.read(%d)
+if len(body) != %d or hashlib.sha256(body).hexdigest() != %q:
+    raise ValueError("Promise canonical source transfer identity mismatch")
+os.umask(0o022)
+with tarfile.open(fileobj=io.BytesIO(body), mode="r:", errorlevel=2) as archive:
+    members = archive.getmembers()
+    archive.extractall("/work", members=members, filter="data")
+    for member in members:
+        info = os.stat("/work/" + member.name, follow_symlinks=False)
+        if (info.st_mode & 0o777) != member.mode or info.st_mtime != member.mtime:
+            raise ValueError("Promise materialized source metadata differs")
+        if info.st_uid != 65532 or info.st_gid != 65532:
+            raise ValueError("Promise materialized source ownership differs")
+`, promiseCanonicalTarSize+1, promiseCanonicalTarSize, promiseCanonicalTarSHA256)
+}
+
+func promiseOutputReader() string {
+	return fmt.Sprintf(`import io, os, stat, sys, tarfile
+name = %q
+maximum = %d
+def identity(info):
+    return (info.st_dev, info.st_ino, info.st_mode, info.st_uid, info.st_gid, info.st_size, info.st_mtime_ns, info.st_ctime_ns)
+with os.scandir("/output") as entries:
+    entry = next(entries, None)
+    extra = next(entries, None)
+    if entry is None or extra is not None or entry.name != name or not entry.is_file(follow_symlinks=False):
+        raise ValueError("Promise output must contain only the named regular wheel")
+path = "/output/" + name
+descriptor = os.open(path, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK)
+with os.fdopen(descriptor, "rb") as wheel:
+    before = os.fstat(wheel.fileno())
+    if not stat.S_ISREG(before.st_mode) or before.st_size < 1 or before.st_size > maximum:
+        raise ValueError("Promise wheel exceeds regular-file size bounds")
+    body = wheel.read(maximum + 1)
+    after = os.fstat(wheel.fileno())
+named = os.stat(path, follow_symlinks=False)
+if len(body) != before.st_size or identity(before) != identity(after) or identity(after) != identity(named):
+    raise ValueError("Promise wheel changed during bounded readback")
+output = io.BytesIO()
+with tarfile.open(fileobj=output, mode="w", format=tarfile.USTAR_FORMAT) as archive:
+    member = tarfile.TarInfo(name)
+    member.size = len(body)
+    member.mode = 0o644
+    member.uid = member.gid = 65532
+    member.mtime = %d
+    archive.addfile(member, io.BytesIO(body))
+body = output.getvalue()
+if len(body) > %d:
+    raise ValueError("Promise output tar exceeds its byte limit")
+sys.stdout.buffer.write(body)
+`, promiseWheelFilename, promiseArchiveFileBytes, generatorSourceDateEpoch, promiseMaximumOutputTarBytes)
+}
+
+func promiseTransferArguments(source GeneratorWheelSourceBuild, name, operation string) []string {
+	program := promiseOutputReader()
+	if operation == "copy-source" {
+		program = promiseMaterializer()
+	}
+	return promiseExecArguments(source, name, operation, []string{"python", "-c", program})
+}

--- a/tooling/internal/clrsfixture/promise_transfer_test.go
+++ b/tooling/internal/clrsfixture/promise_transfer_test.go
@@ -1,0 +1,76 @@
+package clrsfixture
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestPromiseTransfersUseFixedRuntimeExec(t *testing.T) {
+	inputs := promiseLifecycleInputs(t)
+	name := "20w-promise-" + strings.Repeat("1", 32)
+	for _, operation := range []string{"copy-source", "read-wheel"} {
+		arguments := promiseTransferArguments(inputs.manifest.SourceBuild, name, operation)
+		if arguments[0] != "container" || arguments[1] != "exec" || slices.Contains(arguments, "cp") ||
+			!slices.Contains(arguments, "--user=65532:65532") || !slices.Contains(arguments, "/usr/bin/env") ||
+			!slices.Contains(arguments, "-i") || arguments[len(arguments)-3] != "python" || arguments[len(arguments)-2] != "-c" {
+			t.Fatalf("transfer is not fixed direct runtime execution: %v", arguments)
+		}
+		if slices.Contains(arguments, "--interactive") != (operation == "copy-source") {
+			t.Fatalf("unexpected stdin configuration: %v", arguments)
+		}
+	}
+}
+
+func TestPromiseMaterializerChecksExactBytesBeforeExtraction(t *testing.T) {
+	program := promiseMaterializer()
+	read := strings.Index(program, fmt.Sprintf("sys.stdin.buffer.read(%d)", promiseCanonicalTarSize+1))
+	hash := strings.Index(program, promiseCanonicalTarSHA256)
+	extract := strings.Index(program, `archive.extractall("/work", members=members, filter="data")`)
+	if read < 0 || hash <= read || extract <= hash || !strings.Contains(program, fmt.Sprintf("len(body) != %d", promiseCanonicalTarSize)) {
+		t.Fatal("materializer no longer verifies the bounded canonical transfer before extraction")
+	}
+	for _, boundary := range []string{"os.umask(0o022)", "errorlevel=2", "info.st_mode & 0o777", "info.st_mtime != member.mtime", "info.st_uid != 65532", "info.st_gid != 65532"} {
+		if !strings.Contains(program, boundary) {
+			t.Fatalf("missing materialization boundary %q", boundary)
+		}
+	}
+}
+
+func TestPromiseOutputReaderHasBoundedRegularFileEnvelope(t *testing.T) {
+	program := promiseOutputReader()
+	for _, boundary := range []string{"next(entries, None)", "extra is not None", "entry.name != name", "entry.is_file(follow_symlinks=False)",
+		"os.O_NOFOLLOW", "os.O_NONBLOCK", "stat.S_ISREG(before.st_mode)", "before.st_size > maximum", "wheel.read(maximum + 1)",
+		"info.st_mtime_ns", "info.st_ctime_ns", "tarfile.USTAR_FORMAT", "archive.addfile(member, io.BytesIO(body))"} {
+		if !strings.Contains(program, boundary) {
+			t.Fatalf("missing readback boundary %q", boundary)
+		}
+	}
+	if strings.Contains(program, "st_atime") {
+		t.Fatal("normal read access time must not appear in stable-file identity")
+	}
+}
+
+func TestPromiseReceiptRejectsModifiedTransferPrograms(t *testing.T) {
+	inputs, receipt := promiseReceiptFixture(t)
+	for _, operation := range []string{"copy-source", "read-wheel"} {
+		t.Run(operation, func(t *testing.T) {
+			entries := promiseLogFixture(t, inputs, receipt.Runs[0])
+			for index := range entries {
+				if entries[index].Operation == operation {
+					arguments := slices.Clone(entries[index].Arguments)
+					arguments[len(arguments)-1] += "\nprint('modified transfer')\n"
+					entries[index].Arguments = arguments
+				}
+			}
+			body, err := marshalPromiseJSON(entries)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := validatePromiseCommandLog(body, receipt.Runs[0], inputs.procedure); err == nil || !strings.Contains(err.Error(), "argv differs") {
+				t.Fatalf("changed transfer was not rejected at argv boundary: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Scope

Tracks #12

Add `20w experiment reproduce-clrs-promise-wheel` for the one source-built
dependency in the locked CLRS wheel selection. This is candidate engineering
machinery: all output remains `NO_RESULT`; the generator image, procedure
admission and accepted receipt remain blocked. No registry publication,
release, claim promotion or issue closure is part of this change.

Go owns input verification, source canonicalisation, orchestration, bounded
logs, cleanup and receipt validation. Two clean containers use the already
present digest-pinned Python image, no network, a read-only root, UID/GID 65532,
one CPU, 1 GiB memory, 64 PIDs and bounded temporary filesystems. Each run has
one 120-second deadline and a separate 30-second owner-checked cleanup budget.
No new dependency or host-specific wrapper is added.

The runtime transfer uses two fixed Python snippets inside the existing
container. Docker's archive API cannot access the running container's tmpfs
through its separate filesystem view. Go streams an exact source archive to
the first snippet and validates the bounded single-wheel archive returned by
the second. The read-only `--check` consumer needs no Docker and reconstructs
the exact requested commands, including both fixed snippets; it rejects stale
authority, procedure source, command records and output bytes.

## Retained local execution

Two actual builds from source freeze
`ab6316e2109b0efa5b2a4f5d6dd89ec37a244d28` each produced the locked
21,582-byte wheel, SHA-256
`bef8aedf1f65bca04bed59a7dd784f94075ceeb61c13ea9aaf86c91f569f861b`.
Both embedded MIT licence streams separately match
`5d328768394abffaa84512c90783941dd899a62bcc8009a4181e28b2743228ec`.
Both distinct containers were removed and independently observed absent.
The retained receipt consumer passed in the implementing and coordinating
agents' checks. Producer executable identity and source identity are separate
observations, not a claim that their hashes prove compilation provenance.

Receipt SHA-256:
`6bf3b32a2c17644d27b097b1c3249cb36253d9cde75d1123e995d877cdce7518`.
Local, ignored evidence lives under
`.workingdir2/evidence/experiments/2026-09-05-clrs-promise-reproduction/`.
The earlier image-template and archive-copy failures remain there with their
original executables and diagnostics. They have not been erased or relabelled
as successful runs. These local artifacts are not an admitted public bundle.

The tracked book PDF is byte-identical at
`387bca765e0ae4a675f5274a0f511a0644f1d26fd4f9b665fdeb9b64236ad454`.
The CLI dispatch change requires a refreshed 344-file source binding; only
the manifest and semantic-baseline identity fields change. All six existing
PDF semantic debts remain failing known debt, not accessibility conformance.

## Validation and integration

The complete Go module passed a fresh race-detector run in 34.695 seconds:
`GOMAXPROCS=2 go -C tooling test -race -count=1 -p 2 -parallel 2 -timeout 5m ./...`.
Focused CLRS/CLI tests also cover success, input tampering before effects,
archive limits, exact command reconstruction, cancellation, ownership,
cleanup, stale source and corrupt receipts.

The canonical `npm run check` sequence is covered by retained prefix and
suffix runs on the unchanged tree. The original invocation passed through
`validate:workstation`, including 112 static site tests and five browser tests,
then disappeared without a terminal status after starting the workstation
suite. Its incomplete log is retained; it is not reported as a passing full
invocation. The exact missing suffix was restarted once and exited 0 in
7m4.352s: all 20 workstation jobs, coverage, six readiness tests, PDF freshness,
Pages build and its 433-file/49-document validation passed.

Final head `fb06a6990ad5dfcb42ca83fa0ee6d953b74dcf3c` replaces only the temporary
Pages candidate parent with merged main
`ee84ea7eff7df1de396effaf4e2a5a4e756112ee`. All four commits have equal
`range-diff` patches; the complete tested tree is unchanged at
`b2898670ee509e70e3fb9156069d21c439e77411`. The retained two-run consumer,
344-file PDF freshness and clean-tree checks passed after reparenting.
Dependency metadata identities remained unchanged. No wheel build, PDF render
or aggregate replay was performed for that ancestry-only operation.

The committed impact planner selects `full` and `renderer`: the CLI dispatch
file is loadable selector authority. That required fail-closed gate has not
been weakened. Detailed commands, interruption qualification and hashes are
in the local `integration-continuation.md` evidence record.

## Review boundary

Codex implemented and reviewed the candidate, including a separate bounded
agent review of archive, cleanup and receipt boundaries. Go standard-library,
installed Docker and primary Moby/Python sources informed the implementation.
An actual local Qwen3.8-27B review through Ollama read 12 complete files from
the frozen commit and returned advisory `PASS` with no concrete blocking
findings. Its scope excluded lock/strict-JSON internals, test coverage, daemon
and kernel security, runtime performance and provenance authentication.
The local selector was `hf.co/unsloth/Qwen3.8-27B-GGUF:UD-Q4_K_M`; this was not
the separate AGY Gemini/120B reviewer. Its bounded request and response remain
in `.workingdir2/evidence/experiments/2026-09-05-clrs-promise-local-qwen-review/`.
These are AI-assisted engineering checks, not independent human scientific
review. Human acceptance of source/licensing and public image admission gates
is not inferred from a successful local reproduction or advisory review.
